### PR TITLE
Populate cache protobuf definitions

### DIFF
--- a/pkg/cache/proto/requests/append_request.proto
+++ b/pkg/cache/proto/requests/append_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/append_request.proto
-// file: cache/proto/requests/append_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/append_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/any.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to append data to an existing cache entry.
+ */
+message AppendRequest {
+  // Cache key to modify
+  string key = 1;
+
+  // Value to append
+  google.protobuf.Any value = 2 [lazy = true];
+
+  // Optional namespace for cache isolation
+  string namespace = 3;
+
+  // Request metadata for tracing
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/backup_request.proto
+++ b/pkg/cache/proto/requests/backup_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/backup_request.proto
-// file: cache/proto/requests/backup_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/backup_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to create a backup of the cache contents.
+ */
+message BackupRequest {
+  // Destination path or identifier for the backup
+  string destination = 1;
+
+  // Optional namespace to back up
+  string namespace = 2;
+
+  // Request metadata for auditing
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/config_request.proto
+++ b/pkg/cache/proto/requests/config_request.proto
@@ -1,18 +1,20 @@
-// filepath: pkg/cache/proto/requests/config_request.proto
-// file: cache/proto/requests/config_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/config_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/cache/proto/cache.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to configure cache policies for a namespace.
+ */
+message ConfigurePolicyRequest {
+  string namespace = 1;
+  gcommon.v1.common.CachePolicy policy = 2;
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/decrement_request.proto
+++ b/pkg/cache/proto/requests/decrement_request.proto
@@ -1,18 +1,34 @@
-// filepath: pkg/cache/proto/requests/decrement_request.proto
-// file: cache/proto/requests/decrement_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/decrement_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to decrement a cached counter atomically.
+ */
+message DecrementRequest {
+  // Counter key
+  string key = 1;
+
+  // Decrement delta (can be negative)
+  int64 delta = 2;
+
+  // Initial value if key doesn't exist
+  int64 initial_value = 3;
+
+  // TTL for the counter
+  google.protobuf.Duration ttl = 4 [lazy = true];
+
+  // Optional namespace
+  string namespace = 5;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 6 [lazy = true];
+}

--- a/pkg/cache/proto/requests/defrag_request.proto
+++ b/pkg/cache/proto/requests/defrag_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/defrag_request.proto
-// file: cache/proto/requests/defrag_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/defrag_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to defragment the cache storage.
+ */
+message DefragRequest {
+  // Optional namespace to defragment
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/exists_request.proto
+++ b/pkg/cache/proto/requests/exists_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/exists_request.proto
-// file: cache/proto/requests/exists_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/exists_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to check for the existence of a cache key.
+ */
+message ExistsRequest {
+  // Cache key to check
+  string key = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/expire_request.proto
+++ b/pkg/cache/proto/requests/expire_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/expire_request.proto
-// file: cache/proto/requests/expire_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/expire_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to expire a cache key after a specified duration.
+ */
+message ExpireRequest {
+  // Key to expire
+  string key = 1;
+
+  // New TTL duration
+  google.protobuf.Duration ttl = 2 [lazy = true];
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/export_request.proto
+++ b/pkg/cache/proto/requests/export_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/export_request.proto
-// file: cache/proto/requests/export_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/export_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to export cache contents to an external system.
+ */
+message ExportRequest {
+  // Destination identifier for export
+  string destination = 1;
+
+  // Optional namespace filter
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/flush_request.proto
+++ b/pkg/cache/proto/requests/flush_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/flush_request.proto
-// file: cache/proto/requests/flush_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/flush_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to flush the cache to persistent storage.
+ */
+message FlushRequest {
+  // Optional namespace to flush
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/gc_request.proto
+++ b/pkg/cache/proto/requests/gc_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/gc_request.proto
-// file: cache/proto/requests/gc_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/gc_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to trigger cache garbage collection.
+ */
+message GcRequest {
+  // Optional namespace to clean
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/get_memory_usage_request.proto
+++ b/pkg/cache/proto/requests/get_memory_usage_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/get_memory_usage_request.proto
-// file: cache/proto/requests/get_memory_usage_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/get_memory_usage_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to retrieve cache memory usage statistics.
+ */
+message GetMemoryUsageRequest {
+  // Optional namespace filter
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/health_check_request.proto
+++ b/pkg/cache/proto/requests/health_check_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/health_check_request.proto
-// file: cache/proto/requests/health_check_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/health_check_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to perform a cache health check.
+ */
+message HealthCheckRequest {
+  // Optional namespace to check
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/import_request.proto
+++ b/pkg/cache/proto/requests/import_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/import_request.proto
-// file: cache/proto/requests/import_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/import_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to import cache contents from an external source.
+ */
+message ImportRequest {
+  // Source location of the data
+  string source = 1;
+
+  // Optional namespace to import into
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/increment_request.proto
+++ b/pkg/cache/proto/requests/increment_request.proto
@@ -1,18 +1,34 @@
-// filepath: pkg/cache/proto/requests/increment_request.proto
-// file: cache/proto/requests/increment_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/increment_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to increment a cached counter atomically.
+ */
+message IncrementRequest {
+  // Counter key
+  string key = 1;
+
+  // Increment delta (can be negative)
+  int64 delta = 2;
+
+  // Initial value if key doesn't exist
+  int64 initial_value = 3;
+
+  // TTL for the counter
+  google.protobuf.Duration ttl = 4 [lazy = true];
+
+  // Optional namespace
+  string namespace = 5;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 6 [lazy = true];
+}

--- a/pkg/cache/proto/requests/info_request.proto
+++ b/pkg/cache/proto/requests/info_request.proto
@@ -1,18 +1,18 @@
-// filepath: pkg/cache/proto/requests/info_request.proto
-// file: cache/proto/requests/info_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/info_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to retrieve cache server information.
+ */
+message InfoRequest {
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1 [lazy = true];
+}

--- a/pkg/cache/proto/requests/keys_request.proto
+++ b/pkg/cache/proto/requests/keys_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/keys_request.proto
-// file: cache/proto/requests/keys_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/keys_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/common/proto/messages/pagination.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to list cache keys matching a pattern.
+ */
+message KeysRequest {
+  // Key pattern to match (supports wildcards)
+  string pattern = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Pagination options
+  gcommon.v1.common.Pagination pagination = 3 [lazy = true];
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/list_subscriptions_request.proto
+++ b/pkg/cache/proto/requests/list_subscriptions_request.proto
@@ -1,18 +1,18 @@
-// filepath: pkg/cache/proto/requests/list_subscriptions_request.proto
-// file: cache/proto/requests/list_subscriptions_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/list_subscriptions_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to list active cache subscriptions.
+ */
+message ListSubscriptionsRequest {
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1 [lazy = true];
+}

--- a/pkg/cache/proto/requests/lock_request.proto
+++ b/pkg/cache/proto/requests/lock_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/lock_request.proto
-// file: cache/proto/requests/lock_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/lock_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to acquire a cache lock.
+ */
+message LockRequest {
+  // Lock key
+  string key = 1;
+
+  // Lock expiration
+  google.protobuf.Duration ttl = 2 [lazy = true];
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/mdelete_request.proto
+++ b/pkg/cache/proto/requests/mdelete_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/mdelete_request.proto
-// file: cache/proto/requests/mdelete_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/mdelete_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to delete multiple cache keys.
+ */
+message DeleteMultipleRequest {
+  // Keys to delete
+  repeated string keys = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/mset_request.proto
+++ b/pkg/cache/proto/requests/mset_request.proto
@@ -1,18 +1,35 @@
-// filepath: pkg/cache/proto/requests/mset_request.proto
-// file: cache/proto/requests/mset_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/mset_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to set multiple cache values atomically.
+ */
+message SetMultipleRequest {
+  // Key-value pairs to store
+  map<string, google.protobuf.Any> items = 1;
+
+  // Common TTL for all items
+  google.protobuf.Duration ttl = 2 [lazy = true];
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Common metadata for all items
+  map<string, string> metadata = 4 [lazy = true];
+
+  // Common tags for all items
+  repeated string tags = 5;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata request_metadata = 6 [lazy = true];
+}

--- a/pkg/cache/proto/requests/optimize_request.proto
+++ b/pkg/cache/proto/requests/optimize_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/optimize_request.proto
-// file: cache/proto/requests/optimize_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/optimize_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to optimize cache storage layout.
+ */
+message OptimizeRequest {
+  // Optional namespace to optimize
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/pipeline_request.proto
+++ b/pkg/cache/proto/requests/pipeline_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/pipeline_request.proto
-// file: cache/proto/requests/pipeline_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/pipeline_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to execute a batch of cache operations atomically.
+ */
+message PipelineRequest {
+  // Encoded operations in execution order
+  bytes operations = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/prepend_request.proto
+++ b/pkg/cache/proto/requests/prepend_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/prepend_request.proto
-// file: cache/proto/requests/prepend_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/prepend_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/any.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to prepend data to an existing cache entry.
+ */
+message PrependRequest {
+  // Cache key to modify
+  string key = 1;
+
+  // Value to prepend
+  google.protobuf.Any value = 2 [lazy = true];
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/publish_request.proto
+++ b/pkg/cache/proto/requests/publish_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/cache/proto/requests/publish_request.proto
-// file: cache/proto/requests/publish_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/publish_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/any.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to publish a value to cache subscribers.
+ */
+message PublishRequest {
+  // Topic or channel name
+  string topic = 1;
+
+  // Payload to publish
+  google.protobuf.Any payload = 2 [lazy = true];
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/restore_request.proto
+++ b/pkg/cache/proto/requests/restore_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/restore_request.proto
-// file: cache/proto/requests/restore_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/restore_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to restore cache contents from a backup.
+ */
+message RestoreRequest {
+  // Source backup identifier
+  string source = 1;
+
+  // Optional namespace to restore
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/scan_request.proto
+++ b/pkg/cache/proto/requests/scan_request.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/cache/proto/requests/scan_request.proto
-// file: cache/proto/requests/scan_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/scan_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to scan cache keys with a cursor.
+ */
+message ScanRequest {
+  // Scan cursor position
+  string cursor = 1;
+
+  // Match pattern for keys
+  string pattern = 2;
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/stats_request.proto
+++ b/pkg/cache/proto/requests/stats_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/stats_request.proto
-// file: cache/proto/requests/stats_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/stats_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to retrieve cache statistics.
+ */
+message GetStatsRequest {
+  // Optional namespace filter
+  string namespace = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/subscribe_request.proto
+++ b/pkg/cache/proto/requests/subscribe_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/subscribe_request.proto
-// file: cache/proto/requests/subscribe_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/subscribe_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to subscribe to cache events.
+ */
+message SubscribeRequest {
+  // Topic or channel name
+  string topic = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/transaction_request.proto
+++ b/pkg/cache/proto/requests/transaction_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/transaction_request.proto
-// file: cache/proto/requests/transaction_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/transaction_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to execute multiple cache operations in a transaction.
+ */
+message TransactionRequest {
+  // Encoded operations in transaction
+  bytes operations = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/ttl_request.proto
+++ b/pkg/cache/proto/requests/ttl_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/cache/proto/requests/ttl_request.proto
-// file: cache/proto/requests/ttl_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/ttl_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to update the TTL of an existing cache key.
+ */
+message TouchExpirationRequest {
+  // Key to update
+  string key = 1;
+
+  // New TTL duration
+  google.protobuf.Duration ttl = 2 [lazy = true];
+
+  // Optional namespace
+  string namespace = 3;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 4 [lazy = true];
+}

--- a/pkg/cache/proto/requests/unlock_request.proto
+++ b/pkg/cache/proto/requests/unlock_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/cache/proto/requests/unlock_request.proto
-// file: cache/proto/requests/unlock_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/unlock_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to release a previously acquired cache lock.
+ */
+message UnlockRequest {
+  // Lock key
+  string key = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/cache/proto/requests/unsubscribe_request.proto
+++ b/pkg/cache/proto/requests/unsubscribe_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/unsubscribe_request.proto
-// file: cache/proto/requests/unsubscribe_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/unsubscribe_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to unsubscribe from cache events.
+ */
+message UnsubscribeRequest {
+  // Topic or channel name
+  string topic = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/unwatch_request.proto
+++ b/pkg/cache/proto/requests/unwatch_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/unwatch_request.proto
-// file: cache/proto/requests/unwatch_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/unwatch_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to stop watching a cache key for changes.
+ */
+message UnwatchRequest {
+  // Key being watched
+  string key = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/requests/watch_request.proto
+++ b/pkg/cache/proto/requests/watch_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/cache/proto/requests/watch_request.proto
-// file: cache/proto/requests/watch_request.proto
-//
-// Request definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/requests/watch_request.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Request to watch a cache key for changes.
+ */
+message WatchRequest {
+  // Key to watch
+  string key = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/cache/proto/services/cache_admin_service.proto
+++ b/pkg/cache/proto/services/cache_admin_service.proto
@@ -1,18 +1,31 @@
-// filepath: pkg/cache/proto/services/cache_admin_service.proto
-// file: cache/proto/services/cache_admin_service.proto
-//
-// Service definitions for cache module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/cache/proto/services/cache_admin_service.proto
 edition = "2023";
 
 package gcommon.v1.cache;
 
+import "google/protobuf/empty.proto";
 import "google/protobuf/go_features.proto";
+import "pkg/cache/proto/cache.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/cache/proto;cachepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add service definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the cache module requirements
+/**
+ * Administrative cache management operations.
+ */
+service CacheAdminService {
+  // CreateNamespace creates a new cache namespace
+  rpc CreateNamespace(CreateNamespaceRequest) returns (CreateNamespaceResponse);
+
+  // DeleteNamespace removes a cache namespace
+  rpc DeleteNamespace(DeleteNamespaceRequest) returns (google.protobuf.Empty);
+
+  // ListNamespaces returns all available namespaces
+  rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
+
+  // GetNamespaceStats returns statistics for a namespace
+  rpc GetNamespaceStats(GetNamespaceStatsRequest) returns (GetNamespaceStatsResponse);
+
+  // ConfigurePolicy sets cache policies for a namespace
+  rpc ConfigurePolicy(ConfigurePolicyRequest) returns (ConfigurePolicyResponse);
+}


### PR DESCRIPTION
## Summary
- flesh out cache protobuf request stubs with message definitions
- add CacheAdminService implementation

## Testing
- `make quick-wins`
- `make status`
- `make validate` *(fails: several metrics protos missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845db5d3bc48321bcaf0a66fef7b9f4