### PR TITLE
Add logging provider factory and std provider

### DIFF
--- a/pkg/log/factory.go
+++ b/pkg/log/factory.go
@@ -1,0 +1,67 @@
+// file: pkg/log/factory.go
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ProviderConstructor creates a Provider from a Config.
+type ProviderConstructor func(config Config) (Provider, error)
+
+// providerRegistry stores provider constructors keyed by name.
+var providerRegistry = struct {
+	sync.RWMutex
+	constructors map[string]ProviderConstructor
+}{constructors: make(map[string]ProviderConstructor)}
+
+// RegisterProvider registers a provider constructor.
+func RegisterProvider(name string, constructor ProviderConstructor) {
+	providerRegistry.Lock()
+	defer providerRegistry.Unlock()
+	providerRegistry.constructors[name] = constructor
+}
+
+// NewProvider creates a new provider from the given config.
+func NewProvider(config Config) (Provider, error) {
+	providerRegistry.RLock()
+	constructor, ok := providerRegistry.constructors[config.Provider]
+	providerRegistry.RUnlock()
+	if !ok {
+		if config.Provider == "" || config.Provider == "noop" {
+			return newNoopProvider(), nil
+		}
+		return nil, fmt.Errorf("unknown log provider: %s", config.Provider)
+	}
+	return constructor(config)
+}
+
+// noopProvider is a provider that discards all logs.
+type noopProvider struct{}
+
+func newNoopProvider() Provider { return &noopProvider{} }
+
+func (p *noopProvider) Name() string          { return "noop" }
+func (p *noopProvider) Close() error          { return nil }
+func (p *noopProvider) Sync() error           { return nil }
+func (p *noopProvider) SetOutput(w io.Writer) {}
+func (p *noopProvider) AddHook(h Hook) error  { return nil }
+
+// Logger methods for noopProvider
+func (p *noopProvider) Debug(msg string, fields ...Field)                             {}
+func (p *noopProvider) DebugContext(ctx context.Context, msg string, fields ...Field) {}
+func (p *noopProvider) Info(msg string, fields ...Field)                              {}
+func (p *noopProvider) InfoContext(ctx context.Context, msg string, fields ...Field)  {}
+func (p *noopProvider) Warn(msg string, fields ...Field)                              {}
+func (p *noopProvider) WarnContext(ctx context.Context, msg string, fields ...Field)  {}
+func (p *noopProvider) Error(msg string, fields ...Field)                             {}
+func (p *noopProvider) ErrorContext(ctx context.Context, msg string, fields ...Field) {}
+func (p *noopProvider) Fatal(msg string, fields ...Field)                             {}
+func (p *noopProvider) FatalContext(ctx context.Context, msg string, fields ...Field) {}
+func (p *noopProvider) With(fields ...Field) Logger                                   { return p }
+func (p *noopProvider) WithContext(ctx context.Context) Logger                        { return p }
+func (p *noopProvider) SetLevel(level Level)                                          {}
+func (p *noopProvider) GetLevel() Level                                               { return InfoLevel }

--- a/pkg/log/factory_test.go
+++ b/pkg/log/factory_test.go
@@ -1,0 +1,48 @@
+package log
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestRegisterProvider verifies provider registration.
+func TestRegisterProvider(t *testing.T) {
+	defer func() { providerRegistry.constructors = make(map[string]ProviderConstructor) }()
+
+	RegisterProvider("test", func(config Config) (Provider, error) { return &noopProvider{}, nil })
+	if _, ok := providerRegistry.constructors["test"]; !ok {
+		t.Error("expected provider to be registered")
+	}
+}
+
+// TestNewProvider verifies provider creation.
+func TestNewProvider(t *testing.T) {
+	defer func() { providerRegistry.constructors = make(map[string]ProviderConstructor) }()
+
+	if _, err := NewProvider(Config{Provider: "missing"}); err == nil {
+		t.Error("expected error for unknown provider")
+	}
+
+	RegisterProvider("err", func(c Config) (Provider, error) { return nil, errors.New("bad") })
+	if _, err := NewProvider(Config{Provider: "err"}); err == nil {
+		t.Error("expected error from provider")
+	}
+
+	mock := &noopProvider{}
+	RegisterProvider("ok", func(c Config) (Provider, error) { return mock, nil })
+	p, err := NewProvider(Config{Provider: "ok"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p != mock {
+		t.Error("expected returned provider")
+	}
+
+	p, err = NewProvider(Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := p.(*noopProvider); !ok {
+		t.Error("expected noop provider when provider name empty")
+	}
+}

--- a/pkg/log/interfaces.go
+++ b/pkg/log/interfaces.go
@@ -123,3 +123,100 @@ func (l Level) String() string {
 		return "unknown"
 	}
 }
+
+// Config represents the logging configuration.
+type Config struct {
+	// Provider specifies the logging provider to use.
+	// Supported values: "std", "zap", "logrus", "multi", "noop"
+	Provider string
+
+	// Level is the minimum log level.
+	Level string
+
+	// Format is the log format. Supported values: "json", "text", "console"
+	Format string
+
+	// TimeFormat is the time format for log timestamps.
+	TimeFormat string
+
+	// CallerReportingEnabled enables caller reporting.
+	CallerReportingEnabled bool
+
+	// CallerSkipFrames is the number of frames to skip when reporting callers.
+	CallerSkipFrames int
+
+	// StackTraceEnabled enables stack trace reporting.
+	StackTraceEnabled bool
+
+	// StackTraceLevel is the minimum level for stack traces.
+	StackTraceLevel string
+
+	// Fields are the default fields for all logs.
+	Fields map[string]interface{}
+
+	// OutputPaths are the output paths.
+	OutputPaths []string
+
+	// ErrorOutputPaths are the error output paths.
+	ErrorOutputPaths []string
+
+	// FileConfig contains file-specific configuration.
+	FileConfig *FileConfig
+
+	// ZapConfig contains Zap-specific configuration.
+	ZapConfig *ZapConfig
+
+	// LogrusConfig contains Logrus-specific configuration.
+	LogrusConfig *LogrusConfig
+}
+
+// FileConfig represents file-specific configuration.
+type FileConfig struct {
+	// Path is the file path.
+	Path string
+
+	// RotationMaxSize is the maximum file size in megabytes.
+	RotationMaxSize int
+
+	// RotationMaxAge is the maximum file age in days.
+	RotationMaxAge int
+
+	// RotationMaxBackups is the maximum number of backups.
+	RotationMaxBackups int
+
+	// RotationCompress enables compression of rotated files.
+	RotationCompress bool
+
+	// RotationLocalTime uses local time for rotation.
+	RotationLocalTime bool
+}
+
+// ZapConfig represents Zap-specific configuration.
+type ZapConfig struct {
+	// Development enables development mode.
+	Development bool
+
+	// Sampling enables sampling.
+	Sampling bool
+
+	// SamplingInitial is the initial sampling rate.
+	SamplingInitial int
+
+	// SamplingThereafter is the sampling rate thereafter.
+	SamplingThereafter int
+
+	// EncoderConfig is the encoder configuration.
+	EncoderConfig interface{}
+}
+
+// LogrusConfig represents Logrus-specific configuration.
+type LogrusConfig struct {
+	// ReportCaller enables caller reporting.
+	ReportCaller bool
+
+	// ExitFunc is the exit function for Fatal logs.
+	ExitFunc func(int)
+
+	// Hooks are the logrus hooks.
+	Hooks []interface{}
+}

--- a/pkg/log/std.go
+++ b/pkg/log/std.go
@@ -2,5 +2,103 @@
 
 package log
 
-// TODO: Implement standard library logger provider
-// This file is a placeholder for the standard library logging provider implementation
+import (
+	"context"
+	"fmt"
+	"io"
+	stdlog "log"
+	"os"
+	"strings"
+)
+
+// stdProvider implements the Provider interface using the standard library logger.
+type stdProvider struct {
+	logger *stdlog.Logger
+	level  Level
+}
+
+// NewStdProvider creates a new standard library logging provider.
+func NewStdProvider(config Config) (Provider, error) {
+	p := &stdProvider{
+		logger: stdlog.New(os.Stdout, "", stdlog.LstdFlags),
+		level:  parseLevel(config.Level),
+	}
+	return p, nil
+}
+
+func (p *stdProvider) Name() string          { return "std" }
+func (p *stdProvider) Close() error          { return nil }
+func (p *stdProvider) Sync() error           { return nil }
+func (p *stdProvider) SetOutput(w io.Writer) { p.logger.SetOutput(w) }
+func (p *stdProvider) AddHook(h Hook) error  { return nil }
+
+func (p *stdProvider) logf(level Level, msg string, fields []Field) {
+	if p.level > level {
+		return
+	}
+	if len(fields) > 0 {
+		msg = fmt.Sprintf("%s %s", msg, formatFields(fields))
+	}
+	p.logger.Printf("[%s] %s", level.String(), msg)
+}
+
+func (p *stdProvider) Debug(msg string, fields ...Field) { p.logf(DebugLevel, msg, fields) }
+func (p *stdProvider) DebugContext(ctx context.Context, msg string, fields ...Field) {
+	p.Debug(msg, fields...)
+}
+func (p *stdProvider) Info(msg string, fields ...Field) { p.logf(InfoLevel, msg, fields) }
+func (p *stdProvider) InfoContext(ctx context.Context, msg string, fields ...Field) {
+	p.Info(msg, fields...)
+}
+func (p *stdProvider) Warn(msg string, fields ...Field) { p.logf(WarnLevel, msg, fields) }
+func (p *stdProvider) WarnContext(ctx context.Context, msg string, fields ...Field) {
+	p.Warn(msg, fields...)
+}
+func (p *stdProvider) Error(msg string, fields ...Field) { p.logf(ErrorLevel, msg, fields) }
+func (p *stdProvider) ErrorContext(ctx context.Context, msg string, fields ...Field) {
+	p.Error(msg, fields...)
+}
+func (p *stdProvider) Fatal(msg string, fields ...Field) { p.logf(FatalLevel, msg, fields); os.Exit(1) }
+func (p *stdProvider) FatalContext(ctx context.Context, msg string, fields ...Field) {
+	p.Fatal(msg, fields...)
+}
+func (p *stdProvider) With(fields ...Field) Logger {
+	return &stdProvider{logger: p.logger, level: p.level}
+}
+func (p *stdProvider) WithContext(ctx context.Context) Logger { return p }
+func (p *stdProvider) SetLevel(level Level)                   { p.level = level }
+func (p *stdProvider) GetLevel() Level                        { return p.level }
+
+func formatFields(fields []Field) string {
+	var b strings.Builder
+	for i, f := range fields {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(f.Key)
+		b.WriteByte('=')
+		fmt.Fprint(&b, f.Value)
+	}
+	return b.String()
+}
+
+func parseLevel(l string) Level {
+	switch strings.ToLower(l) {
+	case "debug":
+		return DebugLevel
+	case "info":
+		return InfoLevel
+	case "warn", "warning":
+		return WarnLevel
+	case "error":
+		return ErrorLevel
+	case "fatal":
+		return FatalLevel
+	default:
+		return InfoLevel
+	}
+}
+
+func init() {
+	RegisterProvider("std", NewStdProvider)
+}


### PR DESCRIPTION
## Description
Implemented basic logging provider factory with a noop implementation and a simple standard library provider.

## Motivation
README and TODO indicated missing logging provider implementations. This change begins filling that gap with a factory pattern and a functional `std` provider.

## Changes
- Added configuration structs and provider registry
- Created new `std` provider implementation
- Added noop provider and factory
- Introduced unit tests for provider registration and creation

## Testing
- `go test ./pkg/log`
- `go test ./...` *(fails: missing packages)*


------
https://chatgpt.com/codex/tasks/task_e_685db281ab1c8321964dcd93baf0aedc