### PR TITLE
Add gRPC metrics middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auth Module**: Partial implementation (16/48 types) with core authentication services functional
 - **Documentation**: Comprehensive technical design documents and implementation guides
 - **Automated Issue Management**: GitHub Actions workflow for programmatic issue updates via JSON files
+- **gRPC Metrics Middleware**: Unary and streaming interceptors for metrics collection
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ func main() {
 }
 ```
 
+### gRPC Metrics Interceptor Example
+
+```go
+server := grpc.NewServer(
+    grpc.UnaryInterceptor(
+        middleware.UnaryServerMetrics(middleware.GRPCMetricsOptions{Provider: metricsProvider}),
+    ),
+)
+```
+
 ### Multi-Module Example
 
 ```go
@@ -77,7 +87,7 @@ func main() {
     // Initialize health checking
     healthProvider := health.NewProvider()
 
-    // Initialize metrics (70% complete)
+    // Initialize metrics (75% complete)
     metricsProvider := metrics.NewPrometheusProvider()
 
     // Initialize logging (50% complete)
@@ -238,7 +248,7 @@ The GitHub Actions workflow automatically processes these updates on every push 
 
 ### Module-Specific Guides
 
-- [Metrics Collection](docs/user/metrics.md) (70% complete)
+- [Metrics Collection](docs/user/metrics.md) (75% complete)
 - [Logging](docs/user/logging.md) (50% complete)
 - [Database Operations](docs/user/database.md) (30% complete)
 - [Caching](docs/user/cache.md) (20% complete)
@@ -267,7 +277,7 @@ The GitHub Actions workflow automatically processes these updates on every push 
 
 We welcome contributions! Current priority areas:
 
-1. **Completing Metrics Module** (70% → 100%)
+1. **Completing Metrics Module** (75% → 100%)
 2. **Finishing Logging Module** (50% → 100%)
 3. **Documentation improvements**
 4. **Example applications**

--- a/TODO.md
+++ b/TODO.md
@@ -913,7 +913,7 @@ This roadmap represents our commitment to building the most comprehensive and we
   - [x] Histogram implementation
   - [x] Timer implementation
   - [x] Provider implementation
-- [ ] Add gRPC middleware for request metrics
+ - [x] Add gRPC middleware for request metrics
 - [x] Add integration with Health module
 - [ ] Add runtime metrics collection
 - [ ] Implement metrics export functionality
@@ -1057,7 +1057,7 @@ Based on the current state, here are the implementation priorities for rapid com
 1. **Complete Metrics Module Implementation** (3 days)
    - Finish Prometheus provider (Gauge implementation (this week), Histogram implementation (this week), Summary and Timer implementations (next week))
    - Implement OpenTelemetry provider
-   - Add gRPC middleware
+   - Add gRPC middleware ✅
    - Complete comprehensive tests
 
 2. **Enhance Logging Module** (2 days)

--- a/pkg/metrics/middleware/grpc.go
+++ b/pkg/metrics/middleware/grpc.go
@@ -1,0 +1,119 @@
+// Package middleware provides gRPC interceptors for metrics collection.
+package middleware
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/metrics"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// GRPCMetricsOptions configures the gRPC metrics interceptors.
+type GRPCMetricsOptions struct {
+	// Provider is the metrics provider.
+	Provider metrics.Provider
+
+	// Buckets are the histogram buckets for request duration.
+	Buckets []float64
+
+	// AdditionalTags are additional tags to include with all metrics.
+	AdditionalTags []metrics.Tag
+
+	// RequestCounterName is the name of the request counter.
+	// Default: "grpc_server_requests_total".
+	RequestCounterName string
+
+	// DurationHistogramName is the name of the request duration histogram.
+	// Default: "grpc_server_request_duration_seconds".
+	DurationHistogramName string
+}
+
+// UnaryServerMetrics returns a unary server interceptor that records metrics.
+func UnaryServerMetrics(opts GRPCMetricsOptions) grpc.UnaryServerInterceptor {
+	if opts.RequestCounterName == "" {
+		opts.RequestCounterName = "grpc_server_requests_total"
+	}
+	if opts.DurationHistogramName == "" {
+		opts.DurationHistogramName = "grpc_server_request_duration_seconds"
+	}
+	if opts.Buckets == nil {
+		opts.Buckets = metrics.DefaultBuckets
+	}
+
+	counter := opts.Provider.Counter(
+		opts.RequestCounterName,
+		metrics.WithDescription("Total number of gRPC requests"),
+	)
+	histogram := opts.Provider.Histogram(
+		opts.DurationHistogramName,
+		metrics.WithDescription("gRPC request duration in seconds"),
+		metrics.WithBuckets(opts.Buckets),
+	)
+
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		svc, method := splitFullMethod(info.FullMethod)
+		code := status.Code(err).String()
+		tags := append(opts.AdditionalTags, []metrics.Tag{
+			{Key: "service", Value: svc},
+			{Key: "method", Value: method},
+			{Key: "status", Value: code},
+		}...)
+		counter.WithTags(tags...).Inc()
+		histogram.WithTags(tags...).Observe(time.Since(start).Seconds())
+		return resp, err
+	}
+}
+
+// StreamServerMetrics returns a stream server interceptor that records metrics.
+func StreamServerMetrics(opts GRPCMetricsOptions) grpc.StreamServerInterceptor {
+	if opts.RequestCounterName == "" {
+		opts.RequestCounterName = "grpc_server_requests_total"
+	}
+	if opts.DurationHistogramName == "" {
+		opts.DurationHistogramName = "grpc_server_request_duration_seconds"
+	}
+	if opts.Buckets == nil {
+		opts.Buckets = metrics.DefaultBuckets
+	}
+
+	counter := opts.Provider.Counter(
+		opts.RequestCounterName,
+		metrics.WithDescription("Total number of gRPC requests"),
+	)
+	histogram := opts.Provider.Histogram(
+		opts.DurationHistogramName,
+		metrics.WithDescription("gRPC request duration in seconds"),
+		metrics.WithBuckets(opts.Buckets),
+	)
+
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		start := time.Now()
+		err := handler(srv, stream)
+		svc, method := splitFullMethod(info.FullMethod)
+		code := status.Code(err).String()
+		tags := append(opts.AdditionalTags, []metrics.Tag{
+			{Key: "service", Value: svc},
+			{Key: "method", Value: method},
+			{Key: "status", Value: code},
+		}...)
+		counter.WithTags(tags...).Inc()
+		histogram.WithTags(tags...).Observe(time.Since(start).Seconds())
+		return err
+	}
+}
+
+// splitFullMethod splits a gRPC full method name into service and method.
+// The input is expected in the form "/package.Service/Method".
+func splitFullMethod(fullMethod string) (string, string) {
+	fullMethod = strings.TrimPrefix(fullMethod, "/")
+	parts := strings.SplitN(fullMethod, "/", 2)
+	if len(parts) != 2 {
+		return fullMethod, ""
+	}
+	return parts[0], parts[1]
+}

--- a/pkg/metrics/middleware/grpc_test.go
+++ b/pkg/metrics/middleware/grpc_test.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/metrics"
+	"google.golang.org/grpc"
+)
+
+// mockCounter implements metrics.Counter for testing.
+type mockCounter struct {
+	value float64
+	tags  []metrics.Tag
+}
+
+func (c *mockCounter) Inc()          { c.value++ }
+func (c *mockCounter) Add(v float64) { c.value += v }
+func (c *mockCounter) WithTags(tags ...metrics.Tag) metrics.Counter {
+	return &mockCounter{tags: append(c.tags, tags...)}
+}
+func (c *mockCounter) Value() float64 { return c.value }
+
+// mockHistogram implements metrics.Histogram for testing.
+type mockHistogram struct {
+	observations []float64
+	tags         []metrics.Tag
+}
+
+func (h *mockHistogram) Observe(v float64) { h.observations = append(h.observations, v) }
+func (h *mockHistogram) WithTags(tags ...metrics.Tag) metrics.Histogram {
+	return &mockHistogram{observations: h.observations, tags: append(h.tags, tags...)}
+}
+func (h *mockHistogram) Snapshot() metrics.HistogramSnapshot { return nil }
+
+// mockProvider implements metrics.Provider for testing.
+type mockProvider struct {
+	counter   *mockCounter
+	histogram *mockHistogram
+}
+
+func newMockProvider() *mockProvider {
+	return &mockProvider{
+		counter:   &mockCounter{},
+		histogram: &mockHistogram{},
+	}
+}
+
+func (p *mockProvider) Counter(name string, options ...metrics.Option) metrics.Counter {
+	return p.counter
+}
+func (p *mockProvider) Gauge(name string, options ...metrics.Option) metrics.Gauge { return nil }
+func (p *mockProvider) Histogram(name string, options ...metrics.Option) metrics.Histogram {
+	return p.histogram
+}
+func (p *mockProvider) Summary(name string, options ...metrics.Option) metrics.Summary { return nil }
+func (p *mockProvider) Timer(name string, options ...metrics.Option) metrics.Timer     { return nil }
+func (p *mockProvider) Registry() metrics.Registry                                     { return nil }
+func (p *mockProvider) Handler() http.Handler                                          { return nil }
+func (p *mockProvider) Start(ctx context.Context) error                                { return nil }
+func (p *mockProvider) Stop(ctx context.Context) error                                 { return nil }
+func (p *mockProvider) WithTags(tags ...metrics.Tag) metrics.Provider                  { return p }
+
+// dummy unary handler
+func dummyUnary(ctx context.Context, req interface{}) (interface{}, error) {
+	return "ok", nil
+}
+
+func TestUnaryServerMetrics(t *testing.T) {
+	p := newMockProvider()
+	interceptor := UnaryServerMetrics(GRPCMetricsOptions{Provider: p})
+
+	_, err := interceptor(context.Background(), struct{}{}, &grpc.UnaryServerInfo{FullMethod: "/pkg.Service/Method"}, dummyUnary)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if p.counter.value != 1 {
+		t.Errorf("expected counter to be 1, got %f", p.counter.value)
+	}
+	if len(p.histogram.observations) != 1 {
+		t.Errorf("expected one observation, got %d", len(p.histogram.observations))
+	}
+}
+
+// dummy stream handler
+func dummyStream(srv interface{}, stream grpc.ServerStream) error { return nil }
+
+type dummyServerStream struct{ grpc.ServerStream }
+
+func TestStreamServerMetrics(t *testing.T) {
+	p := newMockProvider()
+	interceptor := StreamServerMetrics(GRPCMetricsOptions{Provider: p})
+
+	ds := &dummyServerStream{}
+	err := interceptor(nil, ds, &grpc.StreamServerInfo{FullMethod: "/pkg.Service/Stream"}, dummyStream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.counter.value != 1 {
+		t.Errorf("expected counter to be 1, got %f", p.counter.value)
+	}
+	if len(p.histogram.observations) != 1 {
+		t.Errorf("expected one observation, got %d", len(p.histogram.observations))
+	}
+}


### PR DESCRIPTION
## Description
Adds unary and streaming interceptors for the metrics package and updates project docs.

## Motivation
Metrics module lacked gRPC interceptors for collecting call metrics. This feature completes a TODO item and improves observability.

## Changes
- Implement `UnaryServerMetrics` and `StreamServerMetrics` interceptors
- Provide unit tests for interceptors
- Mark TODO item as complete and update roadmap
- Document new feature in CHANGELOG and README

## Testing
- `go test ./...` *(fails: missing proto packages)*


------
https://chatgpt.com/codex/tasks/task_e_685db4eb27448321b369be2e4d5d136e