### PR TITLE
Add issue files for new tasks

### DIFF
--- a/.github/issue-updates/18c5101e-df63-4bb9-9d84-ddf9939dbf76.json
+++ b/.github/issue-updates/18c5101e-df63-4bb9-9d84-ddf9939dbf76.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement environment variable config provider",
+  "body": "Create a configuration provider that reads settings from environment variables with prefix support. Register provider in factory and add tests.",
+  "labels": ["enhancement", "module:config"],
+  "guid": "84c67e08-7d7a-4c49-b408-55432c457f02",
+  "legacy_guid": "create-implement-environment-variable-config-provider-2025-06-28"
+}

--- a/.github/issue-updates/84e803b2-a91b-4b3f-be11-ce6b2c4c8711.json
+++ b/.github/issue-updates/84e803b2-a91b-4b3f-be11-ce6b2c4c8711.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add context-aware logging",
+  "body": "Enhance logging interfaces to accept context.Context and propagate fields. Update existing providers (std, logrus, zap) and add tests.",
+  "labels": ["enhancement", "module:log"],
+  "guid": "0b087c36-65ba-4341-ad6d-65f524861ec6",
+  "legacy_guid": "create-add-context-aware-logging-2025-06-28"
+}

--- a/.github/issue-updates/94af4400-8425-4d67-8857-ca9e7f268040.json
+++ b/.github/issue-updates/94af4400-8425-4d67-8857-ca9e7f268040.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add runtime metrics collection",
+  "body": "Implement Go runtime metrics in the Prometheus provider. Expose gauges for memory, goroutines, and GC. Add enable flag in Config and unit tests.",
+  "labels": ["enhancement", "module:metrics"],
+  "guid": "4d6da6cc-927d-4fcc-82c0-3c8c4c494fc6",
+  "legacy_guid": "create-add-runtime-metrics-collection-2025-06-28"
+}


### PR DESCRIPTION
## Description
Add issue tracker entries for upcoming tasks using the provided script.

## Motivation
No open issues exist; these new issues track planned work for logging, metrics, and configuration modules.

## Changes
- Create issue file for context-aware logging
- Create issue file for runtime metrics collection
- Create issue file for environment variable config provider

## Testing
- `./scripts/create-issue-update.sh create` (verified files created)


------
https://chatgpt.com/codex/tasks/task_e_686022dcb5e08321a00ea5f9b23ece5b