### PR TITLE
Fix proto package conflicts

### DIFF
--- a/pkg/auth/mock/AuthServiceClient_mock.go
+++ b/pkg/auth/mock/AuthServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/auth/proto"
+	proto "github.com/jdfalk/gcommon/pkg/auth/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/auth/mock/AuthServiceServer_mock.go
+++ b/pkg/auth/mock/AuthServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/auth/proto"
+	proto "github.com/jdfalk/gcommon/pkg/auth/proto"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/pkg/auth/proto/proto.go
+++ b/pkg/auth/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/auth/proto/proto.go
 
-// Package proto provides consolidated exports for auth protobuf types
-package proto
+// Package authpb provides consolidated exports for auth protobuf types
+package authpb
 
 // Re-export types from various auth protobuf packages for backwards compatibility
 import (

--- a/pkg/cache/mock/CacheServiceClient_mock.go
+++ b/pkg/cache/mock/CacheServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/cache/proto"
+	proto "github.com/jdfalk/gcommon/pkg/cache/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/cache/mock/CacheServiceServer_mock.go
+++ b/pkg/cache/mock/CacheServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/cache/proto"
+	proto "github.com/jdfalk/gcommon/pkg/cache/proto"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/pkg/cache/proto/proto.go
+++ b/pkg/cache/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/cache/proto/proto.go
 
-// Package proto provides consolidated exports for cache protobuf types
-package proto
+// Package cachepb provides consolidated exports for cache protobuf types
+package cachepb
 
 // Re-export types from various cache protobuf packages for backwards compatibility
 import (

--- a/pkg/common/proto/proto.go
+++ b/pkg/common/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/common/proto/proto.go
 
-// Package proto provides consolidated exports for common protobuf types
-package proto
+// Package commonpb provides consolidated exports for common protobuf types
+package commonpb
 
 // Re-export types from various common protobuf packages for backwards compatibility
 import (

--- a/pkg/config/mock/ConfigServiceClient_mock.go
+++ b/pkg/config/mock/ConfigServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/config/proto"
+	proto "github.com/jdfalk/gcommon/pkg/config/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/config/mock/ConfigServiceServer_mock.go
+++ b/pkg/config/mock/ConfigServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/config/proto"
+	proto "github.com/jdfalk/gcommon/pkg/config/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/config/proto/proto.go
+++ b/pkg/config/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/config/proto/proto.go
 
-// Package proto provides consolidated exports for config protobuf types
-package proto
+// Package configpb provides consolidated exports for config protobuf types
+package configpb
 
 // Re-export types from various config protobuf packages for backwards compatibility
 import (

--- a/pkg/db/mock/DatabaseServiceClient_mock.go
+++ b/pkg/db/mock/DatabaseServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/db/proto"
+	proto "github.com/jdfalk/gcommon/pkg/db/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/db/mock/DatabaseServiceServer_mock.go
+++ b/pkg/db/mock/DatabaseServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/db/proto"
+	proto "github.com/jdfalk/gcommon/pkg/db/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/db/proto/proto.go
+++ b/pkg/db/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/db/proto/proto.go
 
-// Package proto provides consolidated exports for database protobuf types
-package proto
+// Package dbpb provides consolidated exports for database protobuf types
+package dbpb
 
 // Re-export types from various database protobuf packages for backwards compatibility
 import (

--- a/pkg/health/mock/HealthServiceClient_mock.go
+++ b/pkg/health/mock/HealthServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/health/proto"
+	proto "github.com/jdfalk/gcommon/pkg/health/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/health/mock/HealthServiceServer_mock.go
+++ b/pkg/health/mock/HealthServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/health/proto"
+	proto "github.com/jdfalk/gcommon/pkg/health/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/health/proto/health.pb.go
+++ b/pkg/health/proto/health.pb.go
@@ -6,7 +6,7 @@
 
 //go:build !protoopaque
 
-package proto
+package healthpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"

--- a/pkg/health/proto/health_protoopaque.pb.go
+++ b/pkg/health/proto/health_protoopaque.pb.go
@@ -6,7 +6,7 @@
 
 //go:build protoopaque
 
-package proto
+package healthpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"

--- a/pkg/health/proto/proto.go
+++ b/pkg/health/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/health/proto/proto.go
 
-// Package proto provides consolidated exports for health protobuf types
-package proto
+// Package healthpb provides consolidated exports for health protobuf types
+package healthpb
 
 // Since there are no generated .pb.go files in health proto subdirectories yet,
 // this package serves as a placeholder for future health service definitions.

--- a/pkg/log/mock/LogServiceClient_mock.go
+++ b/pkg/log/mock/LogServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/log/proto"
+	proto "github.com/jdfalk/gcommon/pkg/log/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/log/mock/LogServiceServer_mock.go
+++ b/pkg/log/mock/LogServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/log/proto"
+	proto "github.com/jdfalk/gcommon/pkg/log/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/log/proto/proto.go
+++ b/pkg/log/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/log/proto/proto.go
 
-// Package proto provides consolidated exports for log protobuf types
-package proto
+// Package logpb provides consolidated exports for log protobuf types
+package logpb
 
 // Since there are no generated .pb.go files in log proto subdirectories yet,
 // this package serves as a placeholder for future log service definitions.

--- a/pkg/metrics/mock/MetricsServiceClient_mock.go
+++ b/pkg/metrics/mock/MetricsServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/metrics/proto"
+	proto "github.com/jdfalk/gcommon/pkg/metrics/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/metrics/mock/MetricsServiceServer_mock.go
+++ b/pkg/metrics/mock/MetricsServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/metrics/proto"
+	proto "github.com/jdfalk/gcommon/pkg/metrics/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/metrics/proto/proto.go
+++ b/pkg/metrics/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/metrics/proto/proto.go
 
-// Package proto provides consolidated exports for metrics protobuf types
-package proto
+// Package metricspb provides consolidated exports for metrics protobuf types
+package metricspb
 
 // Since there are no generated .pb.go files in metrics proto subdirectories yet,
 // this package serves as a placeholder for future metrics service definitions.

--- a/pkg/notification/proto/proto.go
+++ b/pkg/notification/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/notification/proto/proto.go
 
-// Package proto provides consolidated exports for notification protobuf types
-package proto
+// Package notificationpb provides consolidated exports for notification protobuf types
+package notificationpb
 
 // Re-export types from notification protobuf packages for backwards compatibility
 import (

--- a/pkg/queue/mock/QueueServiceClient_mock.go
+++ b/pkg/queue/mock/QueueServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/queue/proto"
+	proto "github.com/jdfalk/gcommon/pkg/queue/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/queue/mock/QueueServiceServer_mock.go
+++ b/pkg/queue/mock/QueueServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/queue/proto"
+	proto "github.com/jdfalk/gcommon/pkg/queue/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/queue/proto/proto.go
+++ b/pkg/queue/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/queue/proto/proto.go
 
-// Package proto provides consolidated exports for queue protobuf types
-package proto
+// Package queuepb provides consolidated exports for queue protobuf types
+package queuepb
 
 // Since there are no generated .pb.go files in queue proto subdirectories yet,
 // this package serves as a placeholder for future queue service definitions.

--- a/pkg/web/mock/WebServiceClient_mock.go
+++ b/pkg/web/mock/WebServiceClient_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/web/proto"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/web/mock/WebServiceServer_mock.go
+++ b/pkg/web/mock/WebServiceServer_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	"context"
 
-	"github.com/jdfalk/gcommon/pkg/web/proto"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )

--- a/pkg/web/proto/proto.go
+++ b/pkg/web/proto/proto.go
@@ -1,7 +1,7 @@
 // file: pkg/web/proto/proto.go
 
-// Package proto provides consolidated exports for web protobuf types
-package proto
+// Package webpb provides consolidated exports for web protobuf types
+package webpb
 
 // Since there are no generated .pb.go files in web proto subdirectories yet,
 // this package serves as a placeholder for future web service definitions.


### PR DESCRIPTION
## Description
Align protobuf alias packages with generated package names and update mocks accordingly. Health protobuf files were corrected to use `healthpb`.

## Motivation
`go vet` failed due to mixed package declarations in protobuf directories. Matching the alias files with generated package names avoids these conflicts.

## Changes
- Set package names in `proto.go` files to generated `*pb` names
- Alias protobuf imports in mocks to `proto`
- Adjust health protobuf files to package `healthpb`

## Testing
- `go test ./...` *(fails: undefined symbols in generated protobuf files)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1b450c883218e918c2a36b8ead5