### PR TITLE
Add script for GitHub project boards

### DIFF
--- a/.github/doc-updates/8208a5bd-e794-4be0-bd3f-9ebbc3704ece.json
+++ b/.github/doc-updates/8208a5bd-e794-4be0-bd3f-9ebbc3704ece.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "The updated setup script automatically authenticates using `gh auth token` and links open issues by module labels.",
+  "guid": "8208a5bd-e794-4be0-bd3f-9ebbc3704ece",
+  "created_at": "2025-07-09T23:21:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ba580e0f-73f1-4673-a6ba-4f6be7872bd6.json
+++ b/.github/doc-updates/ba580e0f-73f1-4673-a6ba-4f6be7872bd6.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Automate issue linking for project boards",
+  "guid": "ba580e0f-73f1-4673-a6ba-4f6be7872bd6",
+  "created_at": "2025-07-09T23:21:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c4dec300-49d9-4d19-a6a4-7dca3923b5c7.json
+++ b/.github/doc-updates/c4dec300-49d9-4d19-a6a4-7dca3923b5c7.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### GitHub Projects\\nThis repository now uses a dedicated GitHub Project board for each major module (Metrics, Queue, Web, Auth, Cache, Config). Run `scripts/setup-github-projects.sh` to create these boards and automatically add issues by label.",
+  "guid": "c4dec300-49d9-4d19-a6a4-7dca3923b5c7",
+  "created_at": "2025-07-09T19:09:24Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e4c1134e-03ce-41b7-9031-5d96f425667d.json
+++ b/.github/doc-updates/e4c1134e-03ce-41b7-9031-5d96f425667d.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added improved GitHub project setup script with automatic authentication and issue linking",
+  "guid": "e4c1134e-03ce-41b7-9031-5d96f425667d",
+  "created_at": "2025-07-09T23:21:23Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/scripts/setup-github-projects.sh
+++ b/scripts/setup-github-projects.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# file: scripts/setup-github-projects.sh
+# version: 2.0.0
+# guid: 9255d459-ae8e-428e-943b-7529ac0e8196
+
+set -euo pipefail
+
+ORG="${ORG:-jdfalk}"
+REPO="${REPO:-gcommon}"
+
+PROJECTS=("Metrics" "Queue" "Web" "Auth" "Cache" "Config")
+
+#------------------------------
+# Authentication Helpers
+#------------------------------
+setup_auth() {
+    echo "Checking GitHub CLI authentication..."
+    if ! gh auth token >/dev/null 2>&1; then
+        echo "❌ GitHub CLI is not authenticated. Please run: gh auth login" >&2
+        exit 1
+    fi
+
+    if ! gh project list --owner "$ORG" >/dev/null 2>&1; then
+        echo "⚠️  Missing project scopes, attempting refresh..." >&2
+        if ! gh auth refresh -s project,read:project >/dev/null 2>&1; then
+            echo "❌ Failed to refresh authentication" >&2
+            exit 1
+        fi
+    fi
+
+    export GH_TOKEN=$(gh auth token)
+    echo "✅ Authentication configured"
+}
+
+#------------------------------
+# Project Helpers
+#------------------------------
+create_project() {
+    local title="$1"
+    local description="$2"
+    local data
+    echo "Creating project: $title"
+    data=$(gh project create --owner "$ORG" --title "$title" --format json)
+    local number
+    number=$(echo "$data" | jq -r '.number')
+    if [[ -n "$number" && "$number" != "null" ]]; then
+        gh project edit "$number" --owner "$ORG" --description "$description"
+        echo "$number"
+    fi
+}
+
+get_project_number() {
+    local title="$1"
+    gh project list --owner "$ORG" --format json | jq -r --arg t "$title" '.projects[] | select(.title==$t) | .number'
+}
+
+link_repository() {
+    local number="$1"
+    gh project link --owner "$ORG" --repo "$REPO" "$number" >/dev/null 2>&1 || true
+}
+
+link_issues() {
+    local number="$1"
+    local label="$2"
+    gh issue list --repo "$ORG/$REPO" --label "$label" --state open --json number \
+        | jq -r '.[].number' | while read -r num; do
+            gh project item-add "$number" --owner "$ORG" --url "https://github.com/$ORG/$REPO/issues/$num" >/dev/null 2>&1 || true
+        done
+}
+
+#------------------------------
+# Main
+#------------------------------
+main() {
+    setup_auth
+
+    for module in "${PROJECTS[@]}"; do
+        local title="$module Module"
+        local description="Development tasks for the $module module"
+        local number
+        number=$(get_project_number "$title")
+        if [[ -z "$number" || "$number" == "null" ]]; then
+            number=$(create_project "$title" "$description")
+        fi
+        if [[ -n "$number" && "$number" != "null" ]]; then
+            link_repository "$number"
+            link_issues "$number" "module:${module,,}"
+            echo "✅ Project $title ready (#$number)"
+        else
+            echo "❌ Failed to create or locate project for $module" >&2
+        fi
+    done
+
+    echo "🎉 Project setup completed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- create `setup-github-projects.sh` to create module boards and populate them
- document new project board workflow using doc updates

## Testing
- `make test` *(fails: found packages mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686ebca67e448321a34cf457725ed6ca