### PR TITLE
Add protobuf validation pipeline

### DIFF
--- a/.github/doc-updates/3fcbcc4c-4ac1-4a1e-bd0b-abc4e6d7530f.json
+++ b/.github/doc-updates/3fcbcc4c-4ac1-4a1e-bd0b-abc4e6d7530f.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added protobuf validation workflow",
+  "guid": "3fcbcc4c-4ac1-4a1e-bd0b-abc4e6d7530f",
+  "created_at": "2025-07-21T02:13:16Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/4e8f2007-32c8-429f-afa9-1875ab0ab18f.json
+++ b/.github/doc-updates/4e8f2007-32c8-429f-afa9-1875ab0ab18f.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### Protobuf Validation Pipeline\\n\\nRun 'make proto-compile' to validate all protobuf files using protoc and buf lint.",
+  "guid": "4e8f2007-32c8-429f-afa9-1875ab0ab18f",
+  "created_at": "2025-07-21T02:13:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/604daaac-ee05-49cc-8184-5e02d763b68f.json
+++ b/.github/doc-updates/604daaac-ee05-49cc-8184-5e02d763b68f.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Setup protobuf validation workflow (#67)",
+  "guid": "604daaac-ee05-49cc-8184-5e02d763b68f",
+  "created_at": "2025-07-21T02:13:23Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7438f982-dfaf-4446-885f-b5dcf1b5bb30.json
+++ b/.github/doc-updates/7438f982-dfaf-4446-885f-b5dcf1b5bb30.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "- [x] Set up Protobuf Validation Pipeline (Issue #67)",
+  "guid": "7438f982-dfaf-4446-885f-b5dcf1b5bb30",
+  "created_at": "2025-07-21T02:13:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/91c1f39c-7bf8-4adf-aa6f-71e0da3af605.json
+++ b/.github/issue-updates/91c1f39c-7bf8-4adf-aa6f-71e0da3af605.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 67,
+  "body": "Set up validation pipeline",
+  "labels": ["completed"],
+  "guid": "91c1f39c-7bf8-4adf-aa6f-71e0da3af605",
+  "legacy_guid": "update-issue-67-2025-07-21"
+}

--- a/.github/workflows/protobuf-validation.yml
+++ b/.github/workflows/protobuf-validation.yml
@@ -1,0 +1,41 @@
+# file: .github/workflows/protobuf-validation.yml
+# version: 1.0.0
+# guid: d9715abb-f269-4b59-9b39-8d45af3a7c9b
+
+name: Protobuf Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/**/*.proto'
+      - '.github/workflows/protobuf-validation.yml'
+      - 'scripts/validate-protos.sh'
+      - 'buf.yaml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/**/*.proto'
+      - 'scripts/validate-protos.sh'
+      - '.github/workflows/protobuf-validation.yml'
+      - 'buf.yaml'
+
+jobs:
+  validate-protos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run protobuf validation
+        run: make proto-compile

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ config/*.json
 
 # Documentation update stats (disabled to prevent merge conflicts)
 .doc-update-stats*.json
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,12 @@ validate: ## Validate protobuf compilation
 	@./test_protoc.sh
 
 compile: ## Compile all protobuf files
-	@echo "🔨 Compiling protobuf files..."
-	@./generate.sh
+        @echo "🔨 Compiling protobuf files..."
+        @./generate.sh
+
+proto-compile: ## Validate protobuf compilation and linting
+        @echo "🔍 Validating protobuf files..."
+        @./scripts/validate-protos.sh
 
 test: ## Run all tests
 	@echo "🧪 Running tests..."

--- a/scripts/validate-protos.sh
+++ b/scripts/validate-protos.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# file: scripts/validate-protos.sh
+# version: 1.0.0
+# guid: b56b0b7e-9c4c-4d1f-942f-3a77c3c8f6ab
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+source .github/scripts/ci-status.sh || true
+
+print_status "Running protobuf compilation test"
+
+# Compile all proto files with protoc to verify they compile
+proto_failures=()
+for proto in $(find pkg -name "*.proto" -type f); do
+    if ! protoc --proto_path=. --go_out=/tmp --go-grpc_out=/tmp "$proto" 2> /dev/null; then
+        proto_failures+=("$proto")
+    fi
+done
+
+if [ ${#proto_failures[@]} -ne 0 ]; then
+    print_error "Compilation failed for ${#proto_failures[@]} files"
+    for file in "${proto_failures[@]}"; do
+        echo " - $file"
+    done
+    exit 1
+fi
+
+print_success "All protobuf files compiled successfully"
+
+print_status "Running buf lint"
+buf lint
+
+print_success "Protobuf validation complete"


### PR DESCRIPTION
## Summary
- add protobuf validation script and Makefile target
- validate protobuf files in CI workflow
- document protobuf validation process and TODO
- mark issue #67 completed

## Testing
- `go test ./...` *(fails: github.com/jdfalk/gcommon/pkg/db/mock missing)*

------
https://chatgpt.com/codex/tasks/task_e_687da1510f9083219adae0779884cf50