### PR TITLE
Implement initial Queue protobufs

### DIFF
--- a/.github/doc-updates/23bb8284-1a70-46cc-9f22-eb5044cd9fbd.json
+++ b/.github/doc-updates/23bb8284-1a70-46cc-9f22-eb5044cd9fbd.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented initial Queue protobufs (QueueMessage, DeliveryOptions, SendMessageRequest, SendMessageResponse, MessageState)",
+  "guid": "23bb8284-1a70-46cc-9f22-eb5044cd9fbd",
+  "created_at": "2025-07-21T02:15:25Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/28da8e47-f914-48af-aba4-664796357567.json
+++ b/.github/doc-updates/28da8e47-f914-48af-aba4-664796357567.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Continue implementing remaining queue module protobuf files",
+  "guid": "28da8e47-f914-48af-aba4-664796357567",
+  "created_at": "2025-07-21T02:15:29Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b78f8ab0-c3e3-4903-a95f-83d661e30d43.json
+++ b/.github/doc-updates/b78f8ab0-c3e3-4903-a95f-83d661e30d43.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "### July 21, 2025\\n- Implemented QueueMessage, DeliveryOptions, SendMessageRequest and Response, MessageState.\\n- Queue module completion: 7/177 files (~4%).",
+  "guid": "b78f8ab0-c3e3-4903-a95f-83d661e30d43",
+  "created_at": "2025-07-21T02:15:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e5945277-060e-4d24-bee1-e29403eb8b14.json
+++ b/.github/doc-updates/e5945277-060e-4d24-bee1-e29403eb8b14.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### July 21, 2025: Queue module progress\\n\\nImplemented core protobuf files for queue messages and delivery options. Module completion now 7/177 files (~4%).",
+  "guid": "e5945277-060e-4d24-bee1-e29403eb8b14",
+  "created_at": "2025-07-21T02:15:34Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/32626e06-4991-4eef-bb7a-a30971eede35.json
+++ b/.github/issue-updates/32626e06-4991-4eef-bb7a-a30971eede35.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 89,
+  "body": "Implemented core queue protobufs: QueueMessage, DeliveryOptions, SendMessageRequest/Response, MessageState",
+  "guid": "32626e06-4991-4eef-bb7a-a30971eede35",
+  "legacy_guid": "comment-issue-89-2025-07-21"
+}

--- a/.github/issue-updates/3490ff66-071b-4c8f-b9f0-01511968d4a5.json
+++ b/.github/issue-updates/3490ff66-071b-4c8f-b9f0-01511968d4a5.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 90,
+  "body": "Implemented core queue protobufs: QueueMessage, DeliveryOptions, SendMessageRequest/Response, MessageState",
+  "guid": "3490ff66-071b-4c8f-b9f0-01511968d4a5",
+  "legacy_guid": "comment-issue-90-2025-07-21"
+}

--- a/.github/issue-updates/6d4019f9-c614-423f-92f2-b06f140b05a6.json
+++ b/.github/issue-updates/6d4019f9-c614-423f-92f2-b06f140b05a6.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 87,
+  "body": "Implemented core queue protobufs: QueueMessage, DeliveryOptions, SendMessageRequest/Response, MessageState",
+  "guid": "6d4019f9-c614-423f-92f2-b06f140b05a6",
+  "legacy_guid": "comment-issue-87-2025-07-21"
+}

--- a/.github/issue-updates/d9ab20ff-f9c8-408f-9c25-ae434875de4d.json
+++ b/.github/issue-updates/d9ab20ff-f9c8-408f-9c25-ae434875de4d.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 91,
+  "body": "Implemented core queue protobufs: QueueMessage, DeliveryOptions, SendMessageRequest/Response, MessageState",
+  "guid": "d9ab20ff-f9c8-408f-9c25-ae434875de4d",
+  "legacy_guid": "comment-issue-91-2025-07-21"
+}

--- a/.github/issue-updates/dfbc8c79-7fd4-4afa-a515-3c8b90d87bae.json
+++ b/.github/issue-updates/dfbc8c79-7fd4-4afa-a515-3c8b90d87bae.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 88,
+  "body": "Implemented core queue protobufs: QueueMessage, DeliveryOptions, SendMessageRequest/Response, MessageState",
+  "guid": "dfbc8c79-7fd4-4afa-a515-3c8b90d87bae",
+  "legacy_guid": "comment-issue-88-2025-07-21"
+}

--- a/pkg/queue/proto/enums/message_state.proto
+++ b/pkg/queue/proto/enums/message_state.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/enums/message_state.proto
 // file: queue/proto/enums/message_state.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// version: 1.0.0
+// guid: 4eba7921-816c-420b-8880-172c0631fa22
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,26 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// MessageState represents the lifecycle state of a queue message.
+enum MessageState {
+  // Default unspecified state.
+  MESSAGE_STATE_UNSPECIFIED = 0;
+
+  // Message is queued and awaiting delivery.
+  MESSAGE_STATE_PENDING = 1;
+
+  // Message has been delivered to a consumer.
+  MESSAGE_STATE_DELIVERED = 2;
+
+  // Consumer acknowledged successful processing.
+  MESSAGE_STATE_ACKNOWLEDGED = 3;
+
+  // Delivery failed and will be retried.
+  MESSAGE_STATE_FAILED = 4;
+
+  // Message moved to dead letter queue.
+  MESSAGE_STATE_DEAD_LETTER = 5;
+
+  // Message expired before processing.
+  MESSAGE_STATE_EXPIRED = 6;
+}

--- a/pkg/queue/proto/messages/delivery_options.proto
+++ b/pkg/queue/proto/messages/delivery_options.proto
@@ -1,18 +1,40 @@
-// filepath: pkg/queue/proto/messages/delivery_options.proto
 // file: queue/proto/messages/delivery_options.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// version: 1.0.0
+// guid: 226d4794-23ca-4b54-9a0d-7c6671093c04
+
 edition = "2023";
 
 package gcommon.v1.queue;
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/go_features.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// DeliveryOptions control message routing and retries.
+message DeliveryOptions {
+  // Optional delivery delay.
+  google.protobuf.Duration delay = 1;
+
+  // Maximum retry attempts before sending to dead letter queue.
+  int32 max_retries = 2;
+
+  // Delay between retry attempts.
+  google.protobuf.Duration retry_delay = 3;
+
+  // Multiplier for exponential backoff.
+  double backoff_multiplier = 4;
+
+  // Maximum delay allowed between retries.
+  google.protobuf.Duration max_retry_delay = 5;
+
+  // Name of the dead letter queue.
+  string dead_letter_queue = 6;
+
+  // Whether acknowledgment is required for delivery.
+  bool require_ack = 7;
+
+  // Timeout waiting for acknowledgment.
+  google.protobuf.Duration ack_timeout = 8;
+}

--- a/pkg/queue/proto/messages/queue_message.proto
+++ b/pkg/queue/proto/messages/queue_message.proto
@@ -1,18 +1,50 @@
-// filepath: pkg/queue/proto/messages/queue_message.proto
 // file: queue/proto/messages/queue_message.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// version: 1.0.0
+// guid: a2597962-4731-4f47-b6dd-4da9a937c834
+
 edition = "2023";
 
 package gcommon.v1.queue;
 
+import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "google/protobuf/go_features.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// QueueMessage represents a single item in a queue.
+message QueueMessage {
+  // Message ID (auto-generated if not provided).
+  string id = 1;
+
+  // Arbitrary payload for the message.
+  google.protobuf.Any body = 2;
+
+  // Custom key/value attributes for routing or metadata.
+  map<string, string> attributes = 3;
+
+  // Additional headers attached to the message.
+  map<string, string> headers = 4;
+
+  // Priority value (0-255, higher values processed first).
+  int32 priority = 5;
+
+  // Expiration time for the message.
+  google.protobuf.Timestamp expires_at = 6;
+
+  // Optional correlation identifier.
+  string correlation_id = 7;
+
+  // Queue name for replies.
+  string reply_to = 8;
+
+  // MIME type of the message body.
+  string content_type = 9;
+
+  // Encoding used for the message body.
+  string content_encoding = 10;
+
+  // Creation timestamp of the message.
+  google.protobuf.Timestamp created_at = 11;
+}

--- a/pkg/queue/proto/requests/send_message_request.proto
+++ b/pkg/queue/proto/requests/send_message_request.proto
@@ -1,0 +1,30 @@
+// file: queue/proto/requests/send_message_request.proto
+// version: 1.0.0
+// guid: 0acd1eb1-8464-4f9c-8fd2-0562acde190f
+
+edition = "2023";
+
+package gcommon.v1.queue;
+
+import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+import "pkg/queue/proto/messages/queue_message.proto";
+import "pkg/queue/proto/messages/delivery_options.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// SendMessageRequest sends a single message to a queue.
+message SendMessageRequest {
+  // Name of the target queue.
+  string queue_name = 1;
+
+  // Message to be enqueued.
+  QueueMessage message = 2;
+
+  // Optional delivery parameters.
+  DeliveryOptions delivery_options = 3;
+
+  // Standard request metadata.
+  gcommon.v1.common.RequestMetadata metadata = 4;
+}

--- a/pkg/queue/proto/responses/send_message_response.proto
+++ b/pkg/queue/proto/responses/send_message_response.proto
@@ -1,0 +1,28 @@
+// file: queue/proto/responses/send_message_response.proto
+// version: 1.0.0
+// guid: 2bbac133-fc81-4653-a03a-e5227ae81d4e
+
+edition = "2023";
+
+package gcommon.v1.queue;
+
+import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// SendMessageResponse contains the result of a send operation.
+message SendMessageResponse {
+  // Identifier of the queued message.
+  string message_id = 1;
+
+  // Whether the send operation succeeded.
+  bool success = 2;
+
+  // Position in the queue if known.
+  int64 queue_position = 3;
+
+  // Error information when `success` is false.
+  gcommon.v1.common.Error error = 4;
+}


### PR DESCRIPTION
## Summary
Implemented core queue module protobuf files following 1-1-1 pattern and created associated documentation and issue updates.

## Issues Addressed

### feat(queue): add core protobuf messages
- `pkg/queue/proto/messages/queue_message.proto` - defined QueueMessage
- `pkg/queue/proto/messages/delivery_options.proto` - defined DeliveryOptions
- `pkg/queue/proto/enums/message_state.proto` - defined MessageState enum
- `pkg/queue/proto/requests/send_message_request.proto` - added SendMessageRequest
- `pkg/queue/proto/responses/send_message_response.proto` - added SendMessageResponse
- `.github/doc-updates/*.json` - queued documentation updates
- `.github/issue-updates/*.json` - progress comments for issues #87-#91

## Testing
- `make compile` *(fails: buf not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687da180fe948321961c198508a7fdcb