### PR TITLE
Implement initial auth proto messages

### DIFF
--- a/.github/doc-updates/57921007-dc36-4e69-8cee-df05c36a91c9.json
+++ b/.github/doc-updates/57921007-dc36-4e69-8cee-df05c36a91c9.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented initial auth configuration and API key messages",
+  "guid": "57921007-dc36-4e69-8cee-df05c36a91c9",
+  "created_at": "2025-07-21T02:17:12Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/686d1501-52b8-4eca-8b30-2e88e2ec34c4.json
+++ b/.github/doc-updates/686d1501-52b8-4eca-8b30-2e88e2ec34c4.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Implemented initial auth configuration and API key messages",
+  "guid": "686d1501-52b8-4eca-8b30-2e88e2ec34c4",
+  "created_at": "2025-07-21T02:17:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/af215432-5210-4277-8828-185cb52b9127.json
+++ b/.github/doc-updates/af215432-5210-4277-8828-185cb52b9127.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement core Auth configuration messages",
+  "guid": "af215432-5210-4277-8828-185cb52b9127",
+  "created_at": "2025-07-21T02:17:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d598715d-73d9-4a54-b437-e3d5e2f87f0e.json
+++ b/.github/doc-updates/d598715d-73d9-4a54-b437-e3d5e2f87f0e.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Implemented core auth config and API key messages",
+  "guid": "d598715d-73d9-4a54-b437-e3d5e2f87f0e",
+  "created_at": "2025-07-21T02:17:56Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/8ac7a561-140d-4825-8ac9-fc27384a78d9.json
+++ b/.github/issue-updates/8ac7a561-140d-4825-8ac9-fc27384a78d9.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Protobuf: Implement core Auth messages",
+  "body": "Implement APIKey, AuthConfig, and JWTConfig messages plus ProviderType enum",
+  "labels": ["module:auth", "protobuf"],
+  "guid": "8ac7a561-140d-4825-8ac9-fc27384a78d9",
+  "legacy_guid": "create-protobuf-implement-core-auth-messages-2025-07-21"
+}

--- a/pkg/auth/proto/enums/provider_type.proto
+++ b/pkg/auth/proto/enums/provider_type.proto
@@ -1,18 +1,29 @@
-// filepath: pkg/auth/proto/enums/provider_type.proto
-// file: auth/proto/enums/provider_type.proto
-//
-// Enum definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/enums/provider_type.proto
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
-
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * ProviderType enumerates the supported authentication provider backends.
+ */
+enum ProviderType {
+  // Default unspecified provider type
+  PROVIDER_TYPE_UNSPECIFIED = 0;
+
+  // Built-in local provider
+  PROVIDER_TYPE_LOCAL = 1;
+
+  // LDAP directory provider
+  PROVIDER_TYPE_LDAP = 2;
+
+  // SAML identity provider
+  PROVIDER_TYPE_SAML = 3;
+
+  // OAuth2 or OpenID Connect provider
+  PROVIDER_TYPE_OAUTH2 = 4;
+}

--- a/pkg/auth/proto/messages/api_key.proto
+++ b/pkg/auth/proto/messages/api_key.proto
@@ -1,18 +1,39 @@
-// filepath: pkg/auth/proto/messages/api_key.proto
-// file: auth/proto/messages/api_key.proto
-//
-// Message definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/messages/api_key.proto
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-789a-b0c1-d2e3f4a5b6c7
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * APIKey represents a user-issued API key used for authenticating
+ * programmatic access. The key value itself should be stored securely
+ * and only the hashed form transmitted.
+ */
+message APIKey {
+  // Unique identifier for the API key
+  string id = 1;
+
+  // ID of the user this key belongs to
+  string user_id = 2;
+
+  // Human readable description for the key
+  string description = 3;
+
+  // Hash of the API key value
+  string key_hash = 4;
+
+  // Creation timestamp
+  google.protobuf.Timestamp created_at = 5 [lazy = true];
+
+  // Optional expiration timestamp
+  google.protobuf.Timestamp expires_at = 6 [lazy = true];
+
+  // Whether the key is currently active
+  bool active = 7;
+}

--- a/pkg/auth/proto/messages/auth_config.proto
+++ b/pkg/auth/proto/messages/auth_config.proto
@@ -1,18 +1,26 @@
-// filepath: pkg/auth/proto/messages/auth_config.proto
-// file: auth/proto/messages/auth_config.proto
-//
-// Message definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/messages/auth_config.proto
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-890b-c1d2-e3f4a5b6c7d8
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * AuthConfig defines authentication configuration for the application
+ * including token lifetimes and password requirements.
+ */
+message AuthConfig {
+  // How long issued access tokens remain valid
+  google.protobuf.Timestamp access_token_ttl = 1;
+
+  // How long refresh tokens remain valid
+  google.protobuf.Timestamp refresh_token_ttl = 2;
+
+  // Whether multi-factor authentication is required
+  bool require_mfa = 3;
+}

--- a/pkg/auth/proto/messages/jwt_config.proto
+++ b/pkg/auth/proto/messages/jwt_config.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/messages/jwt_config.proto
-// file: auth/proto/messages/jwt_config.proto
-//
-// Message definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/messages/jwt_config.proto
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-90c1-d2e3-f4a5b6c7d8e9
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * JWTConfig defines parameters for JWT token generation and validation.
+ */
+message JWTConfig {
+  // Signing algorithm used for tokens (e.g., HS256, RS256)
+  string signing_algorithm = 1;
+
+  // Duration access tokens remain valid
+  google.protobuf.Duration access_token_ttl = 2;
+
+  // Duration refresh tokens remain valid
+  google.protobuf.Duration refresh_token_ttl = 3;
+}


### PR DESCRIPTION
## Summary
Implemented basic protobuf definitions for core authentication configuration.

## Issues Addressed

### feat(auth): implement core config messages
**Description:** Added APIKey, AuthConfig, JWTConfig messages, and ProviderType enum. Created documentation update entries and an issue for tracking.

**Files Modified:**
- `pkg/auth/proto/enums/provider_type.proto` - defined provider type enum
- `pkg/auth/proto/messages/api_key.proto` - added APIKey message definition
- `pkg/auth/proto/messages/auth_config.proto` - added AuthConfig message
- `pkg/auth/proto/messages/jwt_config.proto` - added JWTConfig message
- `.github/doc-updates/`* - generated doc update JSON files
- `.github/issue-updates/8ac7a561-140d-4825-8ac9-fc27384a78d9.json` - new issue to track work

## Testing
- `./test_protoc.sh` *(failed: missing other module protos)*

------
https://chatgpt.com/codex/tasks/task_e_687da1a14b94832192dc8b85ff7b3419