### PR TITLE
Implement initial Metrics protobufs

### DIFF
--- a/.github/doc-updates/21e9616e-8bda-40c1-b040-40ce089560d3.json
+++ b/.github/doc-updates/21e9616e-8bda-40c1-b040-40ce089560d3.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented initial metrics protobufs",
+  "guid": "21e9616e-8bda-40c1-b040-40ce089560d3",
+  "created_at": "2025-07-21T03:59:48Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/35d16be7-6007-494a-b726-4aa32d5b33e3.json
+++ b/.github/doc-updates/35d16be7-6007-494a-b726-4aa32d5b33e3.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Implemented initial metrics protobuf files",
+  "guid": "35d16be7-6007-494a-b726-4aa32d5b33e3",
+  "created_at": "2025-07-21T03:59:57Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7b864ce2-bd33-4aec-a066-5090571ed09b.json
+++ b/.github/doc-updates/7b864ce2-bd33-4aec-a066-5090571ed09b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Implemented initial metrics protobufs",
+  "guid": "7b864ce2-bd33-4aec-a066-5090571ed09b",
+  "created_at": "2025-07-21T03:59:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8d0630c7-71bc-4d37-8404-e6a65497cc30.json
+++ b/.github/doc-updates/8d0630c7-71bc-4d37-8404-e6a65497cc30.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Implemented initial metrics protobuf files",
+  "guid": "8d0630c7-71bc-4d37-8404-e6a65497cc30",
+  "created_at": "2025-07-21T04:00:02Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/0bc04fa5-fc83-45a7-ab89-105afbb49679.json
+++ b/.github/issue-updates/0bc04fa5-fc83-45a7-ab89-105afbb49679.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 68,
+  "body": "Implemented initial metrics protobuf files",
+  "guid": "0bc04fa5-fc83-45a7-ab89-105afbb49679",
+  "legacy_guid": "comment-issue-68-2025-07-21"
+}

--- a/empty_protos.txt
+++ b/empty_protos.txt
@@ -1,6 +1,5 @@
 pkg/metrics/proto/messages/scrape_job.proto
 pkg/metrics/proto/messages/histogram_metric.proto
-pkg/metrics/proto/messages/metric_health.proto
 pkg/metrics/proto/messages/metric_family.proto
 pkg/metrics/proto/messages/retention_policy.proto
 pkg/metrics/proto/messages/import_config.proto
@@ -14,15 +13,12 @@ pkg/metrics/proto/messages/summary_metric.proto
 pkg/metrics/proto/messages/metric_config.proto
 pkg/metrics/proto/messages/alerting_rule.proto
 pkg/metrics/proto/messages/metric_query.proto
-pkg/metrics/proto/messages/metric_label.proto
 pkg/metrics/proto/messages/export_config.proto
 pkg/metrics/proto/messages/metric_aggregation.proto
 pkg/metrics/proto/messages/metric_filter.proto
-pkg/metrics/proto/messages/scrape_target.proto
 pkg/metrics/proto/messages/gauge_metric.proto
 pkg/metrics/proto/messages/metric_quantile.proto
 pkg/metrics/proto/messages/metric_metadata.proto
-pkg/metrics/proto/messages/scrape_config.proto
 pkg/metrics/proto/messages/counter_metric.proto
 pkg/metrics/proto/messages/alert_notification.proto
 pkg/metrics/proto/types/timestamp_range.proto
@@ -46,7 +42,6 @@ pkg/metrics/proto/responses/get_stats_response.proto
 pkg/metrics/proto/responses/set_alerting_rules_response.proto
 pkg/metrics/proto/responses/record_gauge_response.proto
 pkg/metrics/proto/responses/record_summary_response.proto
-pkg/metrics/proto/responses/get_metric_config_response.proto
 pkg/metrics/proto/responses/query_metrics_response.proto
 pkg/metrics/proto/responses/reset_metrics_response.proto
 pkg/metrics/proto/responses/get_metric_metadata_response.proto
@@ -59,7 +54,6 @@ pkg/metrics/proto/responses/set_scrape_config_response.proto
 pkg/metrics/proto/responses/list_metrics_response.proto
 pkg/metrics/proto/responses/record_histogram_response.proto
 pkg/metrics/proto/responses/get_alerting_rules_response.proto
-pkg/metrics/proto/responses/set_metric_config_response.proto
 pkg/metrics/proto/responses/start_scraping_response.proto
 pkg/metrics/proto/responses/create_metric_response.proto
 pkg/metrics/proto/responses/export_metrics_response.proto
@@ -82,14 +76,12 @@ pkg/metrics/proto/requests/reset_metrics_request.proto
 pkg/metrics/proto/requests/record_summary_request.proto
 pkg/metrics/proto/requests/stop_scraping_request.proto
 pkg/metrics/proto/requests/get_scrape_config_request.proto
-pkg/metrics/proto/requests/set_metric_config_request.proto
 pkg/metrics/proto/requests/set_scrape_config_request.proto
 pkg/metrics/proto/requests/get_metric_config_request.proto
 pkg/metrics/proto/requests/health_check_request.proto
 pkg/metrics/proto/requests/get_alerting_rules_request.proto
 pkg/metrics/proto/requests/start_scraping_request.proto
 pkg/metrics/proto/requests/get_metric_metadata_request.proto
-pkg/metrics/proto/requests/list_metrics_request.proto
 pkg/metrics/proto/requests/import_metrics_request.proto
 pkg/metrics/proto/requests/query_metrics_request.proto
 pkg/metrics/proto/services/metrics_admin_service.proto

--- a/non_empty_protos.txt
+++ b/non_empty_protos.txt
@@ -263,3 +263,11 @@ pkg/organization/proto/services/hierarchy_service.proto
 pkg/organization/proto/services/organization_service.proto
 pkg/organization/proto/services/tenant_service.proto
 pkg/organization/proto/types/tenant_isolation.proto
+pkg/metrics/proto/messages/metric_label.proto
+pkg/metrics/proto/messages/metric_health.proto
+pkg/metrics/proto/messages/scrape_config.proto
+pkg/metrics/proto/messages/scrape_target.proto
+pkg/metrics/proto/requests/list_metrics_request.proto
+pkg/metrics/proto/requests/set_metric_config_request.proto
+pkg/metrics/proto/responses/get_metric_config_response.proto
+pkg/metrics/proto/responses/set_metric_config_response.proto

--- a/pkg/metrics/proto/messages/metric_health.proto
+++ b/pkg/metrics/proto/messages/metric_health.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/metrics/proto/messages/metric_health.proto
-// file: metrics/proto/messages/metric_health.proto
-//
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/messages/metric_health.proto
+// version: 1.0.0
+// guid: eaa94765-18f8-4a94-9530-b8182f2b5092
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/enums/health_status.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * MetricHealth provides health information about a metric.
+ */
+message MetricHealth {
+  // Name of the metric
+  string metric_name = 1;
+
+  // Current health status
+  HealthStatus status = 2;
+
+  // Optional descriptive message
+  string message = 3;
+}

--- a/pkg/metrics/proto/messages/metric_label.proto
+++ b/pkg/metrics/proto/messages/metric_label.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/metrics/proto/messages/metric_label.proto
-// file: metrics/proto/messages/metric_label.proto
-//
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/messages/metric_label.proto
+// version: 1.0.0
+// guid: 7c0ce179-e17c-43b0-8f57-cc7585f6cb85
+
 edition = "2023";
 
 package gcommon.v1.metrics;
@@ -13,6 +11,13 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * MetricLabel represents a key/value label attached to a metric.
+ */
+message MetricLabel {
+  // Label key
+  string key = 1;
+
+  // Label value
+  string value = 2;
+}

--- a/pkg/metrics/proto/messages/scrape_config.proto
+++ b/pkg/metrics/proto/messages/scrape_config.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/metrics/proto/messages/scrape_config.proto
-// file: metrics/proto/messages/scrape_config.proto
-//
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/messages/scrape_config.proto
+// version: 1.0.0
+// guid: a754fb7e-a819-4731-82fd-6a587b928a9e
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/messages/scrape_target.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ScrapeConfig defines how metrics should be scraped from targets.
+ */
+message ScrapeConfig {
+  // Job name for the scrape configuration
+  string job_name = 1;
+
+  // Targets to scrape
+  repeated ScrapeTarget targets = 2;
+
+  // Interval between scrapes in seconds
+  int32 scrape_interval_seconds = 3;
+}

--- a/pkg/metrics/proto/messages/scrape_target.proto
+++ b/pkg/metrics/proto/messages/scrape_target.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/metrics/proto/messages/scrape_target.proto
-// file: metrics/proto/messages/scrape_target.proto
-//
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/messages/scrape_target.proto
+// version: 1.0.0
+// guid: bc47b323-f2ec-45a1-9eb1-a02cee44f29d
+
 edition = "2023";
 
 package gcommon.v1.metrics;
@@ -13,6 +11,13 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ScrapeTarget describes a target endpoint to scrape metrics from.
+ */
+message ScrapeTarget {
+  // Target URL
+  string url = 1;
+
+  // Optional labels to associate with this target
+  map<string, string> labels = 2;
+}

--- a/pkg/metrics/proto/requests/list_metrics_request.proto
+++ b/pkg/metrics/proto/requests/list_metrics_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/metrics/proto/requests/list_metrics_request.proto
-// file: metrics/proto/requests/list_metrics_request.proto
-//
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/requests/list_metrics_request.proto
+// version: 1.0.0
+// guid: a5ae698c-a783-4005-b054-167c31d44c8b
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/pagination.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ListMetricsRequest requests a paginated list of metrics.
+ */
+message ListMetricsRequest {
+  // Pagination information
+  PaginationRequest pagination = 1;
+
+  // Optional name filter
+  string name_filter = 2;
+}

--- a/pkg/metrics/proto/requests/set_metric_config_request.proto
+++ b/pkg/metrics/proto/requests/set_metric_config_request.proto
@@ -1,18 +1,21 @@
-// filepath: pkg/metrics/proto/requests/set_metric_config_request.proto
-// file: metrics/proto/requests/set_metric_config_request.proto
-//
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/requests/set_metric_config_request.proto
+// version: 1.0.0
+// guid: d1b98b0c-98f7-47fc-9bb5-f18ebfbbe1d3
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/messages/metric_config.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetMetricConfigRequest updates configuration for a metric.
+ */
+message SetMetricConfigRequest {
+  // Updated configuration
+  MetricConfig config = 1;
+}

--- a/pkg/metrics/proto/responses/get_metric_config_response.proto
+++ b/pkg/metrics/proto/responses/get_metric_config_response.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/metrics/proto/responses/get_metric_config_response.proto
-// file: metrics/proto/responses/get_metric_config_response.proto
-//
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/responses/get_metric_config_response.proto
+// version: 1.0.0
+// guid: 1d1401a7-7986-407f-9b51-d77ceae3b42b
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/messages/metric_config.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetMetricConfigResponse contains metric configuration information.
+ */
+message GetMetricConfigResponse {
+  // Operation success flag
+  bool success = 1;
+
+  // Error details if any
+  gcommon.v1.common.Error error = 2;
+
+  // Retrieved configuration
+  MetricConfig config = 3;
+}

--- a/pkg/metrics/proto/responses/set_metric_config_response.proto
+++ b/pkg/metrics/proto/responses/set_metric_config_response.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/metrics/proto/responses/set_metric_config_response.proto
-// file: metrics/proto/responses/set_metric_config_response.proto
-//
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/responses/set_metric_config_response.proto
+// version: 1.0.0
+// guid: 5faba194-b6ab-42ba-99c3-62eb07df9265
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetMetricConfigResponse is returned after updating metric config.
+ */
+message SetMetricConfigResponse {
+  // Operation success flag
+  bool success = 1;
+
+  // Error details if any
+  gcommon.v1.common.Error error = 2;
+}


### PR DESCRIPTION
## Summary
Implemented several placeholder protobuf definitions within the Metrics module and updated tracking lists and documentation via the automated doc update system.

## Issues Addressed
### feat(metrics): implement initial protobufs
- Created message definitions for `MetricLabel`, `MetricHealth`, `ScrapeConfig`, and `ScrapeTarget`.
- Added request `ListMetricsRequest` and `SetMetricConfigRequest`.
- Added response messages `GetMetricConfigResponse` and `SetMetricConfigResponse`.
- Updated `empty_protos.txt` and `non_empty_protos.txt` accordingly.
- Added doc updates for README, CHANGELOG, TODO, and implementation plan.
- Commented on issue #68 via issue update file.

## Testing
- Ran `scripts/validate-protos.sh` which failed because many protobuf files remain unimplemented across the repo.


------
https://chatgpt.com/codex/tasks/task_e_687db94f0ed08321978954ea3b724fa5