### PR TITLE
Add DebugInfo message

### DIFF
--- a/.github/doc-updates/25695ed0-3614-44df-ad55-de77f9970d60.json
+++ b/.github/doc-updates/25695ed0-3614-44df-ad55-de77f9970d60.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "- Added DebugInfo message for advanced debugging",
+  "guid": "25695ed0-3614-44df-ad55-de77f9970d60",
+  "created_at": "2025-07-21T03:59:57Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/35701ded-341f-408d-aebd-1cff08dcd0c6.json
+++ b/.github/doc-updates/35701ded-341f-408d-aebd-1cff08dcd0c6.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add DebugInfo message to common module",
+  "guid": "35701ded-341f-408d-aebd-1cff08dcd0c6",
+  "created_at": "2025-07-21T04:00:02Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/472d7df9-5656-4353-9202-af1e68f2c1be.json
+++ b/.github/doc-updates/472d7df9-5656-4353-9202-af1e68f2c1be.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-feature",
+  "content": "Added DebugInfo message for enhanced debugging metadata",
+  "guid": "472d7df9-5656-4353-9202-af1e68f2c1be",
+  "created_at": "2025-07-21T03:59:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/4bd3d182-f64a-46d8-8028-e23f6f030137.json
+++ b/.github/doc-updates/4bd3d182-f64a-46d8-8028-e23f6f030137.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "### July 24, 2025 - Implemented DebugInfo message in Common module",
+  "guid": "4bd3d182-f64a-46d8-8028-e23f6f030137",
+  "created_at": "2025-07-21T04:00:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/common/proto/common.proto
+++ b/pkg/common/proto/common.proto
@@ -26,42 +26,40 @@ edition = "2023";
 package gcommon.v1.common;
 
 import "google/protobuf/go_features.proto";
-
-option go_package = "github.com/jdfalk/gcommon/pkg/common/proto;commonpb";
-option features.(pb.go).api_level = API_HYBRID;
-
+import public "pkg/common/proto/enums/ack_mode.proto";
+import public "pkg/common/proto/enums/audit_result.proto";
+import public "pkg/common/proto/enums/circuit_breaker_state.proto";
 // Import all 1-1-1 protobuf files with public visibility for backward compatibility
 
 // Enums (12 total)
 import public "pkg/common/proto/enums/error_code.proto";
-import public "pkg/common/proto/types/sort.proto";
+import public "pkg/common/proto/enums/eviction_policy.proto";
+import public "pkg/common/proto/enums/expiration_policy.proto";
 import public "pkg/common/proto/enums/filter_operation.proto";
 import public "pkg/common/proto/enums/health_status.proto";
 import public "pkg/common/proto/enums/resource_status.proto";
-import public "pkg/common/proto/enums/value_type.proto";
-import public "pkg/common/proto/enums/audit_result.proto";
 import public "pkg/common/proto/enums/subscription_status.proto";
-import public "pkg/common/proto/enums/ack_mode.proto";
-import public "pkg/common/proto/enums/eviction_policy.proto";
-import public "pkg/common/proto/enums/expiration_policy.proto";
-import public "pkg/common/proto/enums/circuit_breaker_state.proto";
-
-// Messages (9 total)
-import public "pkg/common/proto/messages/error.proto";
-import public "pkg/common/proto/messages/pagination.proto";
-import public "pkg/common/proto/messages/paginated_response.proto";
-import public "pkg/common/proto/messages/rate_limit.proto";
-import public "pkg/common/proto/messages/service_version.proto";
+import public "pkg/common/proto/enums/value_type.proto";
 import public "pkg/common/proto/messages/batch_options.proto";
+import public "pkg/common/proto/messages/cache_policy.proto";
+import public "pkg/common/proto/messages/debug_info.proto";
+// Messages (10 total)
+import public "pkg/common/proto/messages/error.proto";
+import public "pkg/common/proto/messages/paginated_response.proto";
+import public "pkg/common/proto/messages/pagination.proto";
+import public "pkg/common/proto/messages/rate_limit.proto";
 import public "pkg/common/proto/messages/request_metadata.proto";
 import public "pkg/common/proto/messages/response_metadata.proto";
-import public "pkg/common/proto/messages/cache_policy.proto";
-
-// Types (7 total)
-import public "pkg/common/proto/types/time_range.proto";
+import public "pkg/common/proto/messages/service_version.proto";
 import public "pkg/common/proto/types/client_info.proto";
-import public "pkg/common/proto/types/string_array.proto";
 import public "pkg/common/proto/types/int64_array.proto";
 import public "pkg/common/proto/types/key_value.proto";
-import public "pkg/common/proto/types/resource_reference.proto";
 import public "pkg/common/proto/types/metric_point.proto";
+import public "pkg/common/proto/types/resource_reference.proto";
+import public "pkg/common/proto/types/sort.proto";
+import public "pkg/common/proto/types/string_array.proto";
+// Types (7 total)
+import public "pkg/common/proto/types/time_range.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/common/proto;commonpb";

--- a/pkg/common/proto/messages/debug_info.proto
+++ b/pkg/common/proto/messages/debug_info.proto
@@ -1,0 +1,37 @@
+// file: pkg/common/proto/messages/debug_info.proto
+// version: 1.0.0
+// guid: 5cfc62b5-b458-4d97-bf91-b5a1c3eccadf
+
+syntax = "proto3";
+edition = "2023";
+
+package gcommon.v1.common;
+
+import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/common/proto;commonpb";
+
+/**
+ * DebugInfo provides supplemental debugging information
+ * that can be included in request or response messages.
+ * It captures contextual details useful for tracing and
+ * troubleshooting complex issues.
+ */
+message DebugInfo {
+  // Service or component name emitting this debug info
+  string service = 1;
+
+  // Optional method or operation identifier
+  string method = 2;
+
+  // Time when this debug info was generated
+  google.protobuf.Timestamp timestamp = 3;
+
+  // Arbitrary key/value details for debugging
+  map<string, string> details = 4;
+
+  // Additional tags to categorize or filter debug entries
+  repeated string tags = 5;
+}


### PR DESCRIPTION
## Summary
- add DebugInfo message for better debugging
- import DebugInfo in common.proto
- create doc updates for changelog, readme, todo, and plan

## Testing
- `protoc --proto_path=. --go_out=/tmp --go-grpc_out=/tmp pkg/common/proto/messages/debug_info.proto` *(fails: Expected top-level statement)*


------
https://chatgpt.com/codex/tasks/task_e_687db9804a948321b87ebcc817c11660