### PR TITLE
Add database migration and transaction protobuf services

### DIFF
--- a/.github/doc-updates/5b874daa-490c-478a-9e96-43e8425ccb5a.json
+++ b/.github/doc-updates/5b874daa-490c-478a-9e96-43e8425ccb5a.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Implemented new database migration and transaction services",
+  "guid": "5b874daa-490c-478a-9e96-43e8425ccb5a",
+  "created_at": "2025-07-21T04:03:00Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/81cb2cf4-92f3-40c2-82f9-f82e4ec5e6af.json
+++ b/.github/doc-updates/81cb2cf4-92f3-40c2-82f9-f82e4ec5e6af.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-feature",
+  "content": "Added TransactionService and MigrationService with new request/response messages",
+  "guid": "81cb2cf4-92f3-40c2-82f9-f82e4ec5e6af",
+  "created_at": "2025-07-21T04:02:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8dc83216-7a39-4c88-aeb7-871c797bc6bb.json
+++ b/.github/doc-updates/8dc83216-7a39-4c88-aeb7-871c797bc6bb.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Implemented TransactionService and MigrationService protobufs",
+  "guid": "8dc83216-7a39-4c88-aeb7-871c797bc6bb",
+  "created_at": "2025-07-21T04:02:56Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/aace8fba-dea2-4da8-ae13-df61a8fe2271.json
+++ b/.github/doc-updates/aace8fba-dea2-4da8-ae13-df61a8fe2271.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_HANDOFF_COMPLETE.md",
+  "mode": "append",
+  "content": "Added TransactionService and MigrationService protobuf implementations",
+  "guid": "aace8fba-dea2-4da8-ae13-df61a8fe2271",
+  "created_at": "2025-07-21T04:03:05Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f3077631-e3c5-4e4d-b3f3-7f3cbf4808cf.json
+++ b/.github/doc-updates/f3077631-e3c5-4e4d-b3f3-7f3cbf4808cf.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement TransactionService and MigrationService protobufs",
+  "guid": "f3077631-e3c5-4e4d-b3f3-7f3cbf4808cf",
+  "created_at": "2025-07-21T04:02:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f4a7bfe1-81c0-4d52-a516-45f7f4f49673.json
+++ b/.github/doc-updates/f4a7bfe1-81c0-4d52-a516-45f7f4f49673.json
@@ -1,0 +1,16 @@
+{
+  "file": "SESSION_SUMMARY.md",
+  "mode": "append",
+  "content": "Implemented new database protobuf services",
+  "guid": "f4a7bfe1-81c0-4d52-a516-45f7f4f49673",
+  "created_at": "2025-07-21T04:03:10Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/issue_updates.json
+++ b/issue_updates.json
@@ -1,22 +1,8 @@
 [
   {
     "action": "create",
-    "title": "Add GRPCService implementations to SQLite and CockroachDB drivers",
-    "body": "Expose DatabaseServer via GRPCService for SQLite and CockroachDB database drivers.",
-    "labels": [
-      "codex",
-      "enhancement",
-      "module:database"
-    ]
-  },
-  {
-    "action": "create",
-    "title": "Organize GitHub Project Board",
-    "body": "Setup Kanban columns and prioritize issues across modules.",
-    "labels": [
-      "project",
-      "documentation",
-      "completed"
-    ]
+    "title": "Implement TransactionService and MigrationService protobufs",
+    "body": "Add new protobuf service definitions and associated request/response messages for database migrations and transaction status.",
+    "labels": ["codex", "module:database", "enhancement"]
   }
 ]

--- a/pkg/db/proto/database.proto
+++ b/pkg/db/proto/database.proto
@@ -27,15 +27,17 @@ package gcommon.v1.database;
 
 // Import all 1-1-1 protobuf files with public visibility for backward compatibility
 
-// Services (2 total)
+// Services (4 total)
 import public "pkg/db/proto/services/database_service.proto";
 import public "pkg/db/proto/services/database_admin_service.proto";
+import public "pkg/db/proto/services/transaction_service.proto";
+import public "pkg/db/proto/services/migration_service.proto";
 
 // Enums (2 total)
 import public "pkg/db/proto/enums/consistency_level.proto";
 import public "pkg/db/proto/enums/isolation_level.proto";
 
-// Messages (13 total)
+// Messages (14 total)
 import public "pkg/db/proto/messages/batch_execute_options.proto";
 import public "pkg/db/proto/messages/batch_operation.proto";
 import public "pkg/db/proto/messages/batch_operation_result.proto";
@@ -49,8 +51,9 @@ import public "pkg/db/proto/messages/query_options.proto";
 import public "pkg/db/proto/messages/query_stats.proto";
 import public "pkg/db/proto/messages/result_set.proto";
 import public "pkg/db/proto/messages/transaction_options.proto";
+import public "pkg/db/proto/messages/migration_info.proto";
 
-// Request types (18 total)
+// Request types (21 total)
 import public "pkg/db/proto/requests/begin_transaction_request.proto";
 import public "pkg/db/proto/requests/commit_transaction_request.proto";
 import public "pkg/db/proto/requests/create_database_request.proto";
@@ -62,14 +65,17 @@ import public "pkg/db/proto/requests/execute_request.proto";
 import public "pkg/db/proto/requests/get_connection_info_request.proto";
 import public "pkg/db/proto/requests/get_database_info_request.proto";
 import public "pkg/db/proto/requests/get_migration_status_request.proto";
+import public "pkg/db/proto/requests/list_migrations_request.proto";
 import public "pkg/db/proto/requests/health_check_request.proto";
 import public "pkg/db/proto/requests/list_databases_request.proto";
 import public "pkg/db/proto/requests/list_schemas_request.proto";
 import public "pkg/db/proto/requests/query_request.proto";
 import public "pkg/db/proto/requests/rollback_transaction_request.proto";
+import public "pkg/db/proto/requests/revert_migration_request.proto";
 import public "pkg/db/proto/requests/run_migration_request.proto";
+import public "pkg/db/proto/requests/transaction_status_request.proto";
 
-// Response types (13 total)
+// Response types (16 total)
 import public "pkg/db/proto/responses/begin_transaction_response.proto";
 import public "pkg/db/proto/responses/create_database_response.proto";
 import public "pkg/db/proto/responses/create_schema_response.proto";
@@ -78,11 +84,14 @@ import public "pkg/db/proto/responses/execute_response.proto";
 import public "pkg/db/proto/responses/get_connection_info_response.proto";
 import public "pkg/db/proto/responses/get_database_info_response.proto";
 import public "pkg/db/proto/responses/get_migration_status_response.proto";
+import public "pkg/db/proto/responses/list_migrations_response.proto";
 import public "pkg/db/proto/responses/health_check_response.proto";
 import public "pkg/db/proto/responses/list_databases_response.proto";
 import public "pkg/db/proto/responses/list_schemas_response.proto";
 import public "pkg/db/proto/responses/query_response.proto";
 import public "pkg/db/proto/responses/run_migration_response.proto";
+import public "pkg/db/proto/responses/revert_migration_response.proto";
+import public "pkg/db/proto/responses/transaction_status_response.proto";
 
 // Domain types (4 total)
 import public "pkg/db/proto/types/column_metadata.proto";

--- a/pkg/db/proto/messages/migration_info.proto
+++ b/pkg/db/proto/messages/migration_info.proto
@@ -1,0 +1,27 @@
+// file: pkg/db/proto/messages/migration_info.proto
+// version: 1.0.0
+// guid: 4b59457d-20d4-4134-af01-340fe289787e
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * MigrationInfo provides metadata about an applied or pending migration.
+ */
+message MigrationInfo {
+  // Version identifier of the migration
+  string version = 1;
+
+  // Descriptive name of the migration
+  string description = 2;
+
+  // Timestamp when the migration was applied
+  google.protobuf.Timestamp applied_at = 3;
+}

--- a/pkg/db/proto/requests/list_migrations_request.proto
+++ b/pkg/db/proto/requests/list_migrations_request.proto
@@ -1,0 +1,27 @@
+// file: pkg/db/proto/requests/list_migrations_request.proto
+// version: 1.0.0
+// guid: e09ee131-1388-41e5-973c-3c7eb4308349
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/common/proto/messages/request_metadata.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * ListMigrationsRequest lists migrations for a database with optional filtering.
+ */
+message ListMigrationsRequest {
+  // Database name to list migrations for
+  string database = 1;
+
+  // Return only applied or pending migrations (optional)
+  string status_filter = 2;
+
+  // Request metadata for tracing and authentication
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/db/proto/requests/revert_migration_request.proto
+++ b/pkg/db/proto/requests/revert_migration_request.proto
@@ -1,0 +1,27 @@
+// file: pkg/db/proto/requests/revert_migration_request.proto
+// version: 1.0.0
+// guid: 02d407f4-a362-4009-b8be-dc47f6588d24
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/common/proto/messages/request_metadata.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * RevertMigrationRequest reverts the database to a previous migration version.
+ */
+message RevertMigrationRequest {
+  // Database name to apply the reversion to
+  string database = 1;
+
+  // Target migration version to revert to
+  string target_version = 2;
+
+  // Request metadata for tracing and authentication
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/db/proto/requests/transaction_status_request.proto
+++ b/pkg/db/proto/requests/transaction_status_request.proto
@@ -1,0 +1,24 @@
+// file: pkg/db/proto/requests/transaction_status_request.proto
+// version: 1.0.0
+// guid: 8934c096-ef4b-455b-b318-20395a6b4962
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/common/proto/messages/request_metadata.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * TransactionStatusRequest queries the status of an active transaction.
+ */
+message TransactionStatusRequest {
+  // Identifier of the transaction
+  string transaction_id = 1;
+
+  // Request metadata for tracing and authentication
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/db/proto/responses/list_migrations_response.proto
+++ b/pkg/db/proto/responses/list_migrations_response.proto
@@ -1,0 +1,21 @@
+// file: pkg/db/proto/responses/list_migrations_response.proto
+// version: 1.0.0
+// guid: 2d1040e2-056b-4264-8f84-d731b345d924
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/db/proto/messages/migration_info.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * ListMigrationsResponse returns a list of migrations for a database.
+ */
+message ListMigrationsResponse {
+  // List of migration metadata entries
+  repeated MigrationInfo migrations = 1 [lazy = true];
+}

--- a/pkg/db/proto/responses/revert_migration_response.proto
+++ b/pkg/db/proto/responses/revert_migration_response.proto
@@ -1,0 +1,27 @@
+// file: pkg/db/proto/responses/revert_migration_response.proto
+// version: 1.0.0
+// guid: 93e7bf68-8691-4063-91b7-247a1dad6e67
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/common/proto/messages/error.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * RevertMigrationResponse indicates the result of a migration reversion.
+ */
+message RevertMigrationResponse {
+  // Whether the migration was reverted successfully
+  bool success = 1;
+
+  // Version that the database was reverted to
+  string reverted_to = 2;
+
+  // Error information if the revert failed
+  gcommon.v1.common.Error error = 3 [lazy = true];
+}

--- a/pkg/db/proto/responses/transaction_status_response.proto
+++ b/pkg/db/proto/responses/transaction_status_response.proto
@@ -1,0 +1,24 @@
+// file: pkg/db/proto/responses/transaction_status_response.proto
+// version: 1.0.0
+// guid: 9cba586d-35b2-48c1-a923-dc28fcc06359
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/common/proto/messages/error.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * TransactionStatusResponse returns the current status of a transaction.
+ */
+message TransactionStatusResponse {
+  // Current status of the transaction (e.g., ACTIVE, COMMITTED, ROLLED_BACK)
+  string status = 1;
+
+  // Error information if the transaction encountered an issue
+  gcommon.v1.common.Error error = 2 [lazy = true];
+}

--- a/pkg/db/proto/services/migration_service.proto
+++ b/pkg/db/proto/services/migration_service.proto
@@ -1,0 +1,37 @@
+// file: pkg/db/proto/services/migration_service.proto
+// version: 1.0.0
+// guid: e6a810ad-ad41-4afb-9340-84b009cfdd59
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/db/proto/requests/run_migration_request.proto";
+import "pkg/db/proto/responses/run_migration_response.proto";
+import "pkg/db/proto/requests/revert_migration_request.proto";
+import "pkg/db/proto/responses/revert_migration_response.proto";
+import "pkg/db/proto/requests/get_migration_status_request.proto";
+import "pkg/db/proto/responses/get_migration_status_response.proto";
+import "pkg/db/proto/requests/list_migrations_request.proto";
+import "pkg/db/proto/responses/list_migrations_response.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * MigrationService manages database schema migrations.
+ */
+service MigrationService {
+  // Apply one or more migration scripts
+  rpc ApplyMigration(RunMigrationRequest) returns (RunMigrationResponse);
+
+  // Revert to a previous migration version
+  rpc RevertMigration(RevertMigrationRequest) returns (RevertMigrationResponse);
+
+  // Retrieve migration status for a database
+  rpc GetMigrationStatus(GetMigrationStatusRequest) returns (GetMigrationStatusResponse);
+
+  // List migrations and their status
+  rpc ListMigrations(ListMigrationsRequest) returns (ListMigrationsResponse);
+}

--- a/pkg/db/proto/services/transaction_service.proto
+++ b/pkg/db/proto/services/transaction_service.proto
@@ -1,0 +1,36 @@
+// file: pkg/db/proto/services/transaction_service.proto
+// version: 1.0.0
+// guid: 48c127b3-f9fa-4a27-bdd8-a41127f3d449
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/db/proto/requests/begin_transaction_request.proto";
+import "pkg/db/proto/responses/begin_transaction_response.proto";
+import "pkg/db/proto/requests/commit_transaction_request.proto";
+import "pkg/db/proto/requests/rollback_transaction_request.proto";
+import "pkg/db/proto/requests/transaction_status_request.proto";
+import "pkg/db/proto/responses/transaction_status_response.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * TransactionService manages database transactions.
+ */
+service TransactionService {
+  // Begin a new transaction
+  rpc BeginTransaction(BeginTransactionRequest) returns (BeginTransactionResponse);
+
+  // Commit the specified transaction
+  rpc CommitTransaction(CommitTransactionRequest) returns (google.protobuf.Empty);
+
+  // Roll back the specified transaction
+  rpc RollbackTransaction(RollbackTransactionRequest) returns (google.protobuf.Empty);
+
+  // Retrieve status information for a transaction
+  rpc GetTransactionStatus(TransactionStatusRequest) returns (TransactionStatusResponse);
+}


### PR DESCRIPTION
## Summary
Implemented new protobuf definitions for database migration management and transaction status tracking. Added MigrationService and TransactionService along with related request/response messages and a MigrationInfo type. Updated the database aggregator to include these files and created documentation update entries.

## Testing
- `./scripts/validate-protos.sh` *(failed: protoc 3.21.12 does not support edition 2023)*

------
https://chatgpt.com/codex/tasks/task_e_687db98768688321bd3bfd41a546ffa5