### PR TITLE
Implement Queue acknowledgment protobufs

### DIFF
--- a/.github/doc-updates/1efe2d84-4345-44f3-80a0-bfe509759f6e.json
+++ b/.github/doc-updates/1efe2d84-4345-44f3-80a0-bfe509759f6e.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 21, 2025 - Implemented AckRequest/AckResponse, AcknowledgmentMode enum, MessageId and TimestampRange types. Queue module completion: 11/177 files (~6%).",
+  "guid": "1efe2d84-4345-44f3-80a0-bfe509759f6e",
+  "created_at": "2025-07-21T03:58:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/21346bf9-b885-4891-b9ed-e92d3e41ce3e.json
+++ b/.github/doc-updates/21346bf9-b885-4891-b9ed-e92d3e41ce3e.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🔴 **General**: Implement queue ack request/response and related types",
+  "guid": "21346bf9-b885-4891-b9ed-e92d3e41ce3e",
+  "created_at": "2025-07-21T03:58:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": "HIGH",
+    "category": null
+  }
+}

--- a/.github/doc-updates/6bbb76b4-6227-4e94-81d3-77aaae50f9e4.json
+++ b/.github/doc-updates/6bbb76b4-6227-4e94-81d3-77aaae50f9e4.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented queue acknowledgment messages and types",
+  "guid": "6bbb76b4-6227-4e94-81d3-77aaae50f9e4",
+  "created_at": "2025-07-21T03:57:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d33ffb2f-7adb-45ce-8617-a6062a32b278.json
+++ b/.github/doc-updates/d33ffb2f-7adb-45ce-8617-a6062a32b278.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Queue module progress: implemented acknowledgment messages and types (approx. 6% complete)",
+  "guid": "d33ffb2f-7adb-45ce-8617-a6062a32b278",
+  "created_at": "2025-07-21T03:57:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/0e2c4005-a832-4f70-bf23-acd267fa21ff.json
+++ b/.github/issue-updates/0e2c4005-a832-4f70-bf23-acd267fa21ff.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 90,
+  "body": "Implemented AckResponse",
+  "labels": ["in-progress"],
+  "guid": "0e2c4005-a832-4f70-bf23-acd267fa21ff",
+  "legacy_guid": "update-issue-90-2025-07-21"
+}

--- a/.github/issue-updates/aaf43433-4247-4de6-8594-7257e833e578.json
+++ b/.github/issue-updates/aaf43433-4247-4de6-8594-7257e833e578.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 89,
+  "body": "Implemented AcknowledgmentMode enum",
+  "labels": ["in-progress"],
+  "guid": "aaf43433-4247-4de6-8594-7257e833e578",
+  "legacy_guid": "update-issue-89-2025-07-21"
+}

--- a/.github/issue-updates/cc32e36e-5a4d-491c-9157-c12881631424.json
+++ b/.github/issue-updates/cc32e36e-5a4d-491c-9157-c12881631424.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 91,
+  "body": "Implemented AckRequest",
+  "labels": ["in-progress"],
+  "guid": "cc32e36e-5a4d-491c-9157-c12881631424",
+  "legacy_guid": "update-issue-91-2025-07-21"
+}

--- a/.github/issue-updates/d21623ba-6b73-4815-8799-cd479e6d70db.json
+++ b/.github/issue-updates/d21623ba-6b73-4815-8799-cd479e6d70db.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 88,
+  "body": "Implemented MessageId and TimestampRange types",
+  "labels": ["in-progress"],
+  "guid": "d21623ba-6b73-4815-8799-cd479e6d70db",
+  "legacy_guid": "update-issue-88-2025-07-21"
+}

--- a/pkg/queue/proto/enums/acknowledgment_mode.proto
+++ b/pkg/queue/proto/enums/acknowledgment_mode.proto
@@ -1,9 +1,10 @@
-// filepath: pkg/queue/proto/enums/acknowledgment_mode.proto
-// file: queue/proto/enums/acknowledgment_mode.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/enums/acknowledgment_mode.proto
+// version: 1.0.0
+// guid: 6f4b2414-998e-4fc3-bc68-188dff6d2f25
+
+// Enumeration describing how message acknowledgments are handled by a
+// queue consumer. This was previously left as a placeholder during the
+// 1-1-1 migration.
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +14,23 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// AcknowledgmentMode specifies how a message should be acknowledged
+// by the consumer. It provides flexibility for different delivery
+// guarantees and consumer implementations.
+enum AcknowledgmentMode {
+  // Default mode. The broker chooses a sensible default based on
+  // queue configuration.
+  ACKNOWLEDGMENT_MODE_UNSPECIFIED = 0;
+
+  // Messages are automatically acknowledged immediately after
+  // successful processing by the consumer.
+  ACKNOWLEDGMENT_MODE_AUTO = 1;
+
+  // The consumer is responsible for explicitly sending an AckRequest
+  // after processing the message.
+  ACKNOWLEDGMENT_MODE_MANUAL = 2;
+
+  // No acknowledgment is required. Messages are considered processed
+  // once delivered. Use with care.
+  ACKNOWLEDGMENT_MODE_NONE = 3;
+}

--- a/pkg/queue/proto/requests/ack_request.proto
+++ b/pkg/queue/proto/requests/ack_request.proto
@@ -1,18 +1,31 @@
-// filepath: pkg/queue/proto/requests/ack_request.proto
-// file: queue/proto/requests/ack_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/ack_request.proto
+// version: 1.0.0
+// guid: 3a91b3b5-86fd-443c-876b-5b7b4da2fa73
+
+// AckRequest acknowledges successful processing of a message and
+// removes it from the queue. This file was previously a placeholder
+// and now contains the full request definition following the 1-1-1
+// protobuf pattern.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// AckRequest contains the information required to acknowledge a
+// single message. The receipt handle is provided by the queue when
+// the message is received.
+message AckRequest {
+  // Name of the queue containing the message.
+  string queue_name = 1;
+
+  // Receipt handle identifying the message instance.
+  string receipt_handle = 2;
+
+  // Standard request metadata including authentication and tracing.
+  gcommon.v1.common.RequestMetadata metadata = 3;
+}

--- a/pkg/queue/proto/responses/ack_response.proto
+++ b/pkg/queue/proto/responses/ack_response.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/queue/proto/responses/ack_response.proto
-// file: queue/proto/responses/ack_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/ack_response.proto
+// version: 1.0.0
+// guid: e0629319-177a-44c0-9ec6-f97c73c03cbc
+
+// AckResponse indicates whether a message acknowledgment was
+// successfully processed. This replaces the previous placeholder
+// created during the 1-1-1 migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// AckResponse is returned after successfully acknowledging a message.
+// If `success` is false, the `error` field contains additional
+// information about why the acknowledgment failed.
+message AckResponse {
+  // True if the message was removed from the queue.
+  bool success = 1;
+
+  // Optional error information when success is false.
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/queue/proto/types/message_id.proto
+++ b/pkg/queue/proto/types/message_id.proto
@@ -1,9 +1,10 @@
-// filepath: pkg/queue/proto/types/message_id.proto
-// file: queue/proto/types/message_id.proto
-//
-// Type definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/types/message_id.proto
+// version: 1.0.0
+// guid: 9bd8b62d-3655-4ff5-9f3a-4d5da241dc77
+
+// MessageId is a simple wrapper type used for referencing messages
+// in a type-safe manner across the Queue API. This replaces the
+// placeholder created during the migration.
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +14,9 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add type definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// MessageId uniquely identifies a message within a queue.
+// It can be referenced by other messages or API calls.
+message MessageId {
+  // Opaque identifier assigned by the queue implementation.
+  string value = 1;
+}

--- a/pkg/queue/proto/types/timestamp_range.proto
+++ b/pkg/queue/proto/types/timestamp_range.proto
@@ -1,18 +1,26 @@
-// filepath: pkg/queue/proto/types/timestamp_range.proto
-// file: queue/proto/types/timestamp_range.proto
-//
-// Type definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/types/timestamp_range.proto
+// version: 1.0.0
+// guid: 4fdb7c93-4616-4db9-a2d6-50f41676b4b6
+
+// TimestampRange defines a start and end time for filtering or
+// statistics queries. This implementation replaces the placeholder
+// added during the 1-1-1 migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add type definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// TimestampRange is used to specify a time window when querying
+// statistics or messages.
+message TimestampRange {
+  // Start of the range (inclusive).
+  google.protobuf.Timestamp start = 1;
+
+  // End of the range (exclusive).
+  google.protobuf.Timestamp end = 2;
+}


### PR DESCRIPTION
## Summary
- flesh out queue AckRequest and AckResponse messages
- define AcknowledgmentMode enum
- add MessageId and TimestampRange types
- document progress in CHANGELOG, TODO, README, and plan
- mark related issues in progress

## Testing
- `./scripts/validate-protos.sh` *(fails: Compilation failed for 1020 files)*

------
https://chatgpt.com/codex/tasks/task_e_687db92d5d9c8321adfd0729be2d1a07