### PR TITLE
Implement initial auth protobufs

### DIFF
--- a/.github/doc-updates/3536fa7b-b4f2-419c-8f3c-e308c3edf2e8.json
+++ b/.github/doc-updates/3536fa7b-b4f2-419c-8f3c-e308c3edf2e8.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Updated auth module progress to 24/126 implemented",
+  "guid": "3536fa7b-b4f2-419c-8f3c-e308c3edf2e8",
+  "created_at": "2025-07-23T03:10:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7d1693ea-0eac-474e-933d-43a33c75758e.json
+++ b/.github/doc-updates/7d1693ea-0eac-474e-933d-43a33c75758e.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement additional auth protobuf definitions",
+  "guid": "7d1693ea-0eac-474e-933d-43a33c75758e",
+  "created_at": "2025-07-23T03:10:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a1da58e6-5afb-43b8-9cf6-bc22347012b1.json
+++ b/.github/doc-updates/a1da58e6-5afb-43b8-9cf6-bc22347012b1.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented initial auth provider and password reset protobufs",
+  "guid": "a1da58e6-5afb-43b8-9cf6-bc22347012b1",
+  "created_at": "2025-07-23T03:10:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ba34a99b-e283-4be6-a3f1-4e72c12781a1.json
+++ b/.github/doc-updates/ba34a99b-e283-4be6-a3f1-4e72c12781a1.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 24, 2025 - Implemented initial auth provider and password reset protobuf definitions",
+  "guid": "ba34a99b-e283-4be6-a3f1-4e72c12781a1",
+  "created_at": "2025-07-23T03:10:51Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/336fff8a-d2ac-4fc8-b1e6-179e00620c5d.json
+++ b/.github/issue-updates/336fff8a-d2ac-4fc8-b1e6-179e00620c5d.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 76,
+  "body": "Implemented initial auth protobufs",
+  "guid": "336fff8a-d2ac-4fc8-b1e6-179e00620c5d",
+  "legacy_guid": "comment-issue-76-2025-07-23"
+}

--- a/pkg/auth/proto/enums/auth_method.proto
+++ b/pkg/auth/proto/enums/auth_method.proto
@@ -1,18 +1,35 @@
-// filepath: pkg/auth/proto/enums/auth_method.proto
-// file: auth/proto/enums/auth_method.proto
-//
-// Enum definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/enums/auth_method.proto
+// version: 1.0.0
+// guid: 815bb886-5864-44fd-ae07-c6102c110fd7
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
-
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * AuthMethod enumerates the supported authentication mechanisms.
+ */
+enum AuthMethod {
+  // Default unknown method
+  AUTH_METHOD_UNSPECIFIED = 0;
+
+  // Traditional username and password authentication
+  AUTH_METHOD_PASSWORD = 1;
+
+  // API key based authentication
+  AUTH_METHOD_API_KEY = 2;
+
+  // OAuth2 or OpenID Connect authentication
+  AUTH_METHOD_OAUTH2 = 3;
+
+  // SAML identity provider authentication
+  AUTH_METHOD_SAML = 4;
+
+  // LDAP directory authentication
+  AUTH_METHOD_LDAP = 5;
+
+  // Multi-factor authentication method
+  AUTH_METHOD_MFA = 6;
+}

--- a/pkg/auth/proto/messages/auth_provider.proto
+++ b/pkg/auth/proto/messages/auth_provider.proto
@@ -1,18 +1,31 @@
-// filepath: pkg/auth/proto/messages/auth_provider.proto
-// file: auth/proto/messages/auth_provider.proto
-//
-// Message definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/messages/auth_provider.proto
+// version: 1.0.0
+// guid: 7293f6cc-7049-493d-9e7c-b17f00dd8a76
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/auth/proto/enums/provider_type.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * AuthProvider represents an external authentication provider configuration.
+ * It defines the provider type and connection details used for authentication.
+ */
+message AuthProvider {
+  // Unique provider identifier
+  string id = 1;
+
+  // Human readable provider name
+  string name = 2;
+
+  // Provider type (e.g., LDAP, OAUTH2, SAML)
+  ProviderType type = 3;
+
+  // Provider-specific configuration reference or JSON blob
+  string config = 4;
+}

--- a/pkg/auth/proto/requests/generate_api_key_request.proto
+++ b/pkg/auth/proto/requests/generate_api_key_request.proto
@@ -1,18 +1,30 @@
-// filepath: pkg/auth/proto/requests/generate_api_key_request.proto
-// file: auth/proto/requests/generate_api_key_request.proto
-//
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/requests/generate_api_key_request.proto
+// version: 1.0.0
+// guid: 5590365e-02f0-4a3d-96eb-15bc615c14ef
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * GenerateAPIKeyRequest requests creation of a new API key for a user.
+ */
+message GenerateAPIKeyRequest {
+  // User ID for whom to generate the key
+  string user_id = 1;
+
+  // Optional name/description for the key
+  string name = 2;
+
+  // Optional expiration in seconds
+  int32 expires_in = 3;
+
+  // Metadata for tracing and correlation
+  gcommon.v1.common.RequestMetadata metadata = 4;
+}

--- a/pkg/auth/proto/requests/reset_password_request.proto
+++ b/pkg/auth/proto/requests/reset_password_request.proto
@@ -1,18 +1,30 @@
-// filepath: pkg/auth/proto/requests/reset_password_request.proto
-// file: auth/proto/requests/reset_password_request.proto
-//
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/requests/reset_password_request.proto
+// version: 1.0.0
+// guid: 79c62bc6-23ed-4b2e-9bb4-4e3091880b22
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * ResetPasswordRequest triggers a password reset for a user.
+ */
+message ResetPasswordRequest {
+  // User ID to reset password for
+  string user_id = 1;
+
+  // Temporary reset token provided to the user
+  string token = 2;
+
+  // New password to set
+  string new_password = 3;
+
+  // Metadata for tracing and correlation
+  gcommon.v1.common.RequestMetadata metadata = 4;
+}

--- a/pkg/auth/proto/responses/generate_api_key_response.proto
+++ b/pkg/auth/proto/responses/generate_api_key_response.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/auth/proto/responses/generate_api_key_response.proto
-// file: auth/proto/responses/generate_api_key_response.proto
-//
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/responses/generate_api_key_response.proto
+// version: 1.0.0
+// guid: 026770a4-919a-4111-818f-ab932e8523ea
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/response_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * GenerateAPIKeyResponse returns the newly created API key.
+ */
+message GenerateAPIKeyResponse {
+  // Generated API key value
+  string key = 1;
+
+  // Optional key identifier
+  string key_id = 2;
+
+  // Response metadata for rate limiting and tracing
+  gcommon.v1.common.ResponseMetadata metadata = 3;
+}

--- a/pkg/auth/proto/responses/reset_password_response.proto
+++ b/pkg/auth/proto/responses/reset_password_response.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/auth/proto/responses/reset_password_response.proto
-// file: auth/proto/responses/reset_password_response.proto
-//
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/responses/reset_password_response.proto
+// version: 1.0.0
+// guid: 9de139b4-5d77-49c3-b18b-7cf12ea5c132
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/response_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * ResetPasswordResponse indicates success or failure of password reset.
+ */
+message ResetPasswordResponse {
+  // Whether the reset was successful
+  bool success = 1;
+
+  // Optional message describing the result
+  string message = 2;
+
+  // Response metadata for rate limiting and tracing
+  gcommon.v1.common.ResponseMetadata metadata = 3;
+}

--- a/pkg/auth/proto/types/role_metadata.proto
+++ b/pkg/auth/proto/types/role_metadata.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/auth/proto/types/role_metadata.proto
-// file: auth/proto/types/role_metadata.proto
-//
-// Type definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/types/role_metadata.proto
+// version: 1.0.0
+// guid: 1b935f51-d35c-4113-aa68-03457b4294db
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add type definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * RoleMetadata provides metadata about role creation and updates.
+ */
+message RoleMetadata {
+  // Timestamp when the role was created
+  google.protobuf.Timestamp created_at = 1 [lazy = true];
+
+  // Timestamp of the last update to the role
+  google.protobuf.Timestamp updated_at = 2 [lazy = true];
+
+  // User ID that created the role
+  string created_by = 3;
+}


### PR DESCRIPTION
## Summary
Implemented several foundational protobuf definitions for the auth module. Added documentation updates via the repository scripts and logged progress with an issue comment. Validation attempt was made but the proto compilation pipeline failed as expected due to remaining empty files.

## Issues Addressed
### feat(auth): implement initial auth protobufs
- [`pkg/auth/proto/enums/auth_method.proto`](./pkg/auth/proto/enums/auth_method.proto) - added AuthMethod enum
- [`pkg/auth/proto/messages/auth_provider.proto`](./pkg/auth/proto/messages/auth_provider.proto) - added AuthProvider message
- [`pkg/auth/proto/types/role_metadata.proto`](./pkg/auth/proto/types/role_metadata.proto) - added RoleMetadata message
- [`pkg/auth/proto/requests/generate_api_key_request.proto`](./pkg/auth/proto/requests/generate_api_key_request.proto) - added request definition
- [`pkg/auth/proto/responses/generate_api_key_response.proto`](./pkg/auth/proto/responses/generate_api_key_response.proto) - added response definition
- [`pkg/auth/proto/requests/reset_password_request.proto`](./pkg/auth/proto/requests/reset_password_request.proto) - added request definition
- [`pkg/auth/proto/responses/reset_password_response.proto`](./pkg/auth/proto/responses/reset_password_response.proto) - added response definition
- `.github/doc-updates/*.json` - generated documentation update records
- `.github/issue-updates/336fff8a-d2ac-4fc8-b1e6-179e00620c5d.json` - added progress comment for issue #76

## Testing
- `make proto-compile` *(failed: Compilation failed for 1043 files)*

------
https://chatgpt.com/codex/tasks/task_e_6880513722408321bc19854903ea5101