### PR TITLE
Implement QueryRow RPC and proto

### DIFF
--- a/.github/doc-updates/5f1a26d1-7aed-4139-834a-cf7c0765dd8e.json
+++ b/.github/doc-updates/5f1a26d1-7aed-4139-834a-cf7c0765dd8e.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "replace-section",
+  "content": "### Module Implementation Status\\n\\n| Module       | Total Files | Empty | Implemented | Completion | Priority    |\\n| ------------ | ----------- | ----- | ----------- | ---------- | ----------- |\\n| **Queue**    | 177         | 175   | 2           | 1.1%       | 🔴 CRITICAL |\\n| **Web**      | 178         | 176   | 2           | 1.1%       | 🔴 CRITICAL |\\n| **Metrics**  | 97          | 95    | 2           | 2.1%       | 🔴 CRITICAL |\\n| **Auth**     | 126         | 109   | 17          | 13.5%      | 🟠 HIGH     |\\n| **Cache**    | 44          | 36    | 8           | 18.2%      | 🟠 HIGH     |\\n| **Config**   | 23          | 20    | 3           | 13.0%      | 🟡 MEDIUM   |\\n| **Health**   | 16          | 14    | 2           | 12.5%      | 🟡 MEDIUM   |\\n| **Common**   | 40          | 0     | 40          | 100%       | ✅ COMPLETE |\\n| **Database** | 53          | 0     | 53          | 100%       | ✅ COMPLETE |\\n| **Log**      | 11          | 0     | 11          | 100%       | ✅ COMPLETE |",
+  "guid": "5f1a26d1-7aed-4139-834a-cf7c0765dd8e",
+  "created_at": "2025-07-23T03:13:07Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ab1f48cd-8458-464b-aa8c-b3cb89b7bba0.json
+++ b/.github/doc-updates/ab1f48cd-8458-464b-aa8c-b3cb89b7bba0.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Implemented QueryRowResponse message and QueryRow RPC",
+  "guid": "ab1f48cd-8458-464b-aa8c-b3cb89b7bba0",
+  "created_at": "2025-07-23T03:12:08Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c7cc29ed-2376-4b52-bf90-bcb14c2deffd.json
+++ b/.github/doc-updates/c7cc29ed-2376-4b52-bf90-bcb14c2deffd.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add QueryRowResponse message and QueryRow RPC to DatabaseService",
+  "guid": "c7cc29ed-2376-4b52-bf90-bcb14c2deffd",
+  "created_at": "2025-07-23T03:12:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ecc6cbf0-ba27-4307-8e6f-4defc688c4da.json
+++ b/.github/doc-updates/ecc6cbf0-ba27-4307-8e6f-4defc688c4da.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "replace-section",
+  "content": "**Current Module Status (June 8, 2025):**\\n\\n- **✅ Common Module**: 100% complete (40/40 files) - **Shared Types Foundation**\\n- **✅ Database Module**: 100% complete (53/53 files) - **Gold Standard Reference** (QueryRow RPC implemented)\\n- **✅ Log Module**: 100% complete (1/1 files) - **Minimal Implementation**\\n- **🔄 Auth Module**: 13.5% complete (17/126 files) - 109 files need implementation\\n- **🔄 Cache Module**: 18.2% complete (8/44 files) - 36 files need implementation\\n- **🔄 Config Module**: 13.0% complete (3/23 files) - 20 files need implementation\\n- **✅ Health Module**: 100% complete (16/16 files) - Stable and production-ready\\n- **❌ Metrics Module**: 2.1% complete (2/97 files) - **95 files need implementation**\\n- **❌ Queue Module**: 1.1% complete (2/177 files) - **175 files need implementation**\\n- **❌ Web Module**: 1.1% complete (2/178 files) - **176 files need implementation**",
+  "guid": "ecc6cbf0-ba27-4307-8e6f-4defc688c4da",
+  "created_at": "2025-07-23T03:12:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/20d6e6d3-248f-4c86-9941-692806fce85a.json
+++ b/.github/issue-updates/20d6e6d3-248f-4c86-9941-692806fce85a.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Add QueryRow RPC",
+  "body": "Implement QueryRowResponse message and QueryRow RPC in DatabaseService",
+  "labels": ["module:db", "protobuf"],
+  "guid": "20d6e6d3-248f-4c86-9941-692806fce85a",
+  "legacy_guid": "create-add-queryrow-rpc-2025-07-23"
+}

--- a/pkg/db/proto/database.proto
+++ b/pkg/db/proto/database.proto
@@ -15,7 +15,7 @@
 //
 // STRUCTURE:
 //   Services: DatabaseService, DatabaseAdminService
-//   Messages: 47 request/response/message types
+//   Messages: 48 request/response/message types
 //   Enums: ConsistencyLevel, IsolationLevel
 //   Types: 4 domain types (MigrationScript, QueryParameter, etc.)
 //
@@ -75,7 +75,7 @@ import public "pkg/db/proto/requests/revert_migration_request.proto";
 import public "pkg/db/proto/requests/run_migration_request.proto";
 import public "pkg/db/proto/requests/transaction_status_request.proto";
 
-// Response types (16 total)
+// Response types (17 total)
 import public "pkg/db/proto/responses/begin_transaction_response.proto";
 import public "pkg/db/proto/responses/create_database_response.proto";
 import public "pkg/db/proto/responses/create_schema_response.proto";
@@ -89,6 +89,7 @@ import public "pkg/db/proto/responses/health_check_response.proto";
 import public "pkg/db/proto/responses/list_databases_response.proto";
 import public "pkg/db/proto/responses/list_schemas_response.proto";
 import public "pkg/db/proto/responses/query_response.proto";
+import public "pkg/db/proto/responses/query_row_response.proto";
 import public "pkg/db/proto/responses/run_migration_response.proto";
 import public "pkg/db/proto/responses/revert_migration_response.proto";
 import public "pkg/db/proto/responses/transaction_status_response.proto";

--- a/pkg/db/proto/responses/query_row_response.proto
+++ b/pkg/db/proto/responses/query_row_response.proto
@@ -1,0 +1,36 @@
+// file: pkg/db/proto/responses/query_row_response.proto
+// version: 1.0.0
+// guid: dff9c212-0d7d-4f0a-bcca-8a0a641a29f9
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "pkg/db/proto/messages/query_stats.proto";
+import "pkg/common/proto/messages/error.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * QueryRowResponse contains the result of a single-row query.
+ * If no row was found, `found` will be false and `values` will be empty.
+ */
+message QueryRowResponse {
+  // Indicates whether a row was found
+  bool found = 1;
+
+  // Column names matching the returned values
+  repeated string columns = 2;
+
+  // Row values encoded as generic Any values
+  repeated google.protobuf.Any values = 3 [lazy = true];
+
+  // Query execution statistics
+  QueryStats stats = 4 [lazy = true];
+
+  // Error information if the query failed
+  gcommon.v1.common.Error error = 5 [lazy = true];
+}

--- a/pkg/db/proto/services/database_service.proto
+++ b/pkg/db/proto/services/database_service.proto
@@ -5,6 +5,7 @@ package gcommon.v1.database;
 
 import "pkg/db/proto/requests/query_request.proto";
 import "pkg/db/proto/responses/query_response.proto";
+import "pkg/db/proto/responses/query_row_response.proto";
 import "pkg/db/proto/requests/execute_request.proto";
 import "pkg/db/proto/responses/execute_response.proto";
 import "pkg/db/proto/requests/execute_batch_request.proto";
@@ -30,6 +31,9 @@ option features.(pb.go).api_level = API_HYBRID;
 service DatabaseService {
   // Execute a read-only query and return results
   rpc Query(QueryRequest) returns (QueryResponse);
+
+  // Execute a query expected to return at most one row
+  rpc QueryRow(QueryRequest) returns (QueryRowResponse);
 
   // Execute a write operation (INSERT, UPDATE, DELETE)
   rpc Execute(ExecuteRequest) returns (ExecuteResponse);


### PR DESCRIPTION
## Summary
- add `QueryRowResponse` proto for single row queries
- support `QueryRow` RPC in `DatabaseService`
- include new response import in database aggregator
- log doc updates and issue for the new RPC

## Testing
- `make proto-compile` *(fails: Compilation failed for 1044 files)*

------
https://chatgpt.com/codex/tasks/task_e_6880514f3098832197a81244586ed5e7