### PR TITLE
Implement cross-module health check protobufs

### DIFF
--- a/.github/doc-updates/43f72d5d-99e8-4030-8b64-1954d481280a.json
+++ b/.github/doc-updates/43f72d5d-99e8-4030-8b64-1954d481280a.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "after",
+  "content": "July 26, 2025 - Implemented cross-module health check messages for metrics, auth, queue, and web",
+  "guid": "43f72d5d-99e8-4030-8b64-1954d481280a",
+  "created_at": "2025-07-23T03:10:03Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5827ff57-8fcf-47af-ae33-73f99f693f6b.json
+++ b/.github/doc-updates/5827ff57-8fcf-47af-ae33-73f99f693f6b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "Implemented health check protobufs across metrics, auth, queue, and web modules",
+  "guid": "5827ff57-8fcf-47af-ae33-73f99f693f6b",
+  "created_at": "2025-07-23T03:09:58Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bce94c30-ee47-447b-8ba2-bef3d7cec6b3.json
+++ b/.github/doc-updates/bce94c30-ee47-447b-8ba2-bef3d7cec6b3.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added cross-module health check protobufs for metrics, auth, queue, and web modules",
+  "guid": "bce94c30-ee47-447b-8ba2-bef3d7cec6b3",
+  "created_at": "2025-07-23T03:10:05Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d94089b0-ce01-4608-96f2-f1f0dc0b27eb.json
+++ b/.github/doc-updates/d94089b0-ce01-4608-96f2-f1f0dc0b27eb.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "after",
+  "content": "Implemented health check request and response messages for metrics, auth, queue, and web modules",
+  "guid": "d94089b0-ce01-4608-96f2-f1f0dc0b27eb",
+  "created_at": "2025-07-23T03:10:00Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/auth/proto/requests/health_check_request.proto
+++ b/pkg/auth/proto/requests/health_check_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/requests/health_check_request.proto
-// file: auth/proto/requests/health_check_request.proto
+// file: pkg/auth/proto/requests/health_check_request.proto
+// version: 1.0.0
+// guid: 6fb9b4a2-72b2-4e24-8f41-5611a6f6217b
 //
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckRequest for the auth module
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * HealthCheckRequest verifies the health of the authentication subsystem.
+ */
+message HealthCheckRequest {
+  // Optional target auth provider.
+  string provider = 1;
+
+  // Metadata for tracing.
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/auth/proto/responses/health_check_response.proto
+++ b/pkg/auth/proto/responses/health_check_response.proto
@@ -1,18 +1,30 @@
-// filepath: pkg/auth/proto/responses/health_check_response.proto
-// file: auth/proto/responses/health_check_response.proto
+// file: pkg/auth/proto/responses/health_check_response.proto
+// version: 1.0.0
+// guid: fef90e32-7ccd-4a2d-bcc8-7c86a5f15d36
 //
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckResponse for the auth module
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/enums/health_status.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * HealthCheckResponse conveys the authentication service health status.
+ */
+message HealthCheckResponse {
+  // Overall health status.
+  gcommon.v1.common.HealthStatus status = 1;
+
+  // Response time for the health check.
+  google.protobuf.Duration response_time = 2 [lazy = true];
+
+  // Error information if unhealthy.
+  gcommon.v1.common.Error error = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/health_check_request.proto
+++ b/pkg/metrics/proto/requests/health_check_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/metrics/proto/requests/health_check_request.proto
-// file: metrics/proto/requests/health_check_request.proto
+// file: pkg/metrics/proto/requests/health_check_request.proto
+// version: 1.0.0
+// guid: ffa1c922-b413-4b2d-a7fd-0d58fcd0b048
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckRequest for the metrics module
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * HealthCheckRequest verifies the health of the metrics subsystem.
+ */
+message HealthCheckRequest {
+  // Metrics subsystem name (e.g., "prometheus").
+  string subsystem = 1;
+
+  // Request metadata for tracing and auth.
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/responses/health_check_response.proto
+++ b/pkg/metrics/proto/responses/health_check_response.proto
@@ -1,18 +1,33 @@
-// filepath: pkg/metrics/proto/responses/health_check_response.proto
-// file: metrics/proto/responses/health_check_response.proto
+// file: pkg/metrics/proto/responses/health_check_response.proto
+// version: 1.0.0
+// guid: 2d9c7ce3-2e5b-42d7-9473-70bef7518cdd
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckResponse for the metrics module
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/enums/health_status.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * HealthCheckResponse contains the result of a metrics subsystem health check.
+ */
+message HealthCheckResponse {
+  // Health status of the subsystem.
+  gcommon.v1.common.HealthStatus status = 1;
+
+  // Time taken to execute the health check.
+  google.protobuf.Duration response_time = 2 [lazy = true];
+
+  // Optional human-readable message.
+  string message = 3;
+
+  // Error details if unhealthy.
+  gcommon.v1.common.Error error = 4 [lazy = true];
+}

--- a/pkg/queue/proto/enums/health_status.proto
+++ b/pkg/queue/proto/enums/health_status.proto
@@ -1,9 +1,8 @@
-// filepath: pkg/queue/proto/enums/health_status.proto
-// file: queue/proto/enums/health_status.proto
+// file: pkg/queue/proto/enums/health_status.proto
+// version: 1.0.0
+// guid: c5459257-5e52-46bb-a6f6-fb2b6a1e315d
 //
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// HealthStatus enumeration for the queue module
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +12,19 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+/**
+ * HealthStatus represents queue service availability.
+ */
+enum HealthStatus {
+  // Unspecified status.
+  HEALTH_STATUS_UNSPECIFIED = 0;
+
+  // Queue service operating normally.
+  HEALTH_STATUS_HEALTHY = 1;
+
+  // Queue service experiencing issues.
+  HEALTH_STATUS_DEGRADED = 2;
+
+  // Queue service unavailable.
+  HEALTH_STATUS_UNAVAILABLE = 3;
+}

--- a/pkg/queue/proto/requests/health_check_request.proto
+++ b/pkg/queue/proto/requests/health_check_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/queue/proto/requests/health_check_request.proto
-// file: queue/proto/requests/health_check_request.proto
+// file: pkg/queue/proto/requests/health_check_request.proto
+// version: 1.0.0
+// guid: e9e95e53-7d2b-4dbf-896d-e9dea8853bd0
 //
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckRequest for the queue module
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+/**
+ * HealthCheckRequest checks the health of a specific queue.
+ */
+message HealthCheckRequest {
+  // Name of the queue to check.
+  string queue = 1;
+
+  // Request metadata for tracing.
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/queue/proto/responses/health_check_response.proto
+++ b/pkg/queue/proto/responses/health_check_response.proto
@@ -1,18 +1,33 @@
-// filepath: pkg/queue/proto/responses/health_check_response.proto
-// file: queue/proto/responses/health_check_response.proto
+// file: pkg/queue/proto/responses/health_check_response.proto
+// version: 1.0.0
+// guid: 24f4fcb1-f84d-4f02-845d-01b9759bfb6a
 //
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// HealthCheckResponse for the queue module
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/enums/health_status.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+/**
+ * HealthCheckResponse returns queue service health status.
+ */
+message HealthCheckResponse {
+  // Overall queue service health.
+  gcommon.v1.common.HealthStatus status = 1;
+
+  // Whether the queue connection is operational.
+  bool connection_ok = 2;
+
+  // Time taken to check the queue health.
+  google.protobuf.Duration response_time = 3 [lazy = true];
+
+  // Error information if the check failed.
+  gcommon.v1.common.Error error = 4 [lazy = true];
+}

--- a/pkg/web/proto/requests/health_check_request.proto
+++ b/pkg/web/proto/requests/health_check_request.proto
@@ -7,11 +7,13 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // HealthCheckRequest request definition.
 message HealthCheckRequest {
-  string placeholder = 1;
+  // Request metadata for the HTTP server.
+  gcommon.v1.common.RequestMetadata metadata = 1 [lazy = true];
 }

--- a/pkg/web/proto/responses/health_check_response.proto
+++ b/pkg/web/proto/responses/health_check_response.proto
@@ -7,11 +7,21 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/enums/health_status.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // HealthCheckResponse response definition.
 message HealthCheckResponse {
-  string placeholder = 1;
+  // Web server health status.
+  gcommon.v1.common.HealthStatus status = 1;
+
+  // Time taken to respond to the health check.
+  google.protobuf.Duration response_time = 2 [lazy = true];
+
+  // Error details if the server is unhealthy.
+  gcommon.v1.common.Error error = 3 [lazy = true];
 }


### PR DESCRIPTION
## Summary
Implemented health check request/response messages across multiple modules and documented the work using the repository's doc update system.

## Issues Addressed

### feat(health): implement cross-module health checks
- [`pkg/metrics/proto/requests/health_check_request.proto`](./pkg/metrics/proto/requests/health_check_request.proto) - Added subsystem and metadata fields | [[diff]](../../pull/PR_NUMBER/files#diff-dcbb2a) [[repo]](../../blob/main/pkg/metrics/proto/requests/health_check_request.proto)
- [`pkg/metrics/proto/responses/health_check_response.proto`](./pkg/metrics/proto/responses/health_check_response.proto) - Defined HealthCheckResponse message | [[diff]](../../pull/PR_NUMBER/files#diff-2e0118) [[repo]](../../blob/main/pkg/metrics/proto/responses/health_check_response.proto)
- [`pkg/auth/proto/requests/health_check_request.proto`](./pkg/auth/proto/requests/health_check_request.proto) - Implemented request message with provider and metadata | [[diff]](../../pull/PR_NUMBER/files#diff-c5d4e9) [[repo]](../../blob/main/pkg/auth/proto/requests/health_check_request.proto)
- [`pkg/auth/proto/responses/health_check_response.proto`](./pkg/auth/proto/responses/health_check_response.proto) - Implemented response with status and error | [[diff]](../../pull/PR_NUMBER/files#diff-39c8a2) [[repo]](../../blob/main/pkg/auth/proto/responses/health_check_response.proto)
- [`pkg/queue/proto/enums/health_status.proto`](./pkg/queue/proto/enums/health_status.proto) - Added queue-specific HealthStatus enum | [[diff]](../../pull/PR_NUMBER/files#diff-531136) [[repo]](../../blob/main/pkg/queue/proto/enums/health_status.proto)
- [`pkg/queue/proto/requests/health_check_request.proto`](./pkg/queue/proto/requests/health_check_request.proto) - Implemented queue health check request | [[diff]](../../pull/PR_NUMBER/files#diff-e34672) [[repo]](../../blob/main/pkg/queue/proto/requests/health_check_request.proto)
- [`pkg/queue/proto/responses/health_check_response.proto`](./pkg/queue/proto/responses/health_check_response.proto) - Implemented response with connection status | [[diff]](../../pull/PR_NUMBER/files#diff-2cfa29) [[repo]](../../blob/main/pkg/queue/proto/responses/health_check_response.proto)
- [`pkg/web/proto/requests/health_check_request.proto`](./pkg/web/proto/requests/health_check_request.proto) - Replaced placeholder with metadata field | [[diff]](../../pull/PR_NUMBER/files#diff-0633d8) [[repo]](../../blob/main/pkg/web/proto/requests/health_check_request.proto)
- [`pkg/web/proto/responses/health_check_response.proto`](./pkg/web/proto/responses/health_check_response.proto) - Added status, response time, and error fields | [[diff]](../../pull/PR_NUMBER/files#diff-2206e3) [[repo]](../../blob/main/pkg/web/proto/responses/health_check_response.proto)
- Documentation updates recorded via `.github/doc-updates/` JSON files.

## Testing
- `./scripts/validate-protos.sh` *(failed: Compilation failed for 1043 files)*

------
https://chatgpt.com/codex/tasks/task_e_68805154fb2083219c455f3ad5029175