### PR TITLE
Implement OpenTelemetry scraping protos

### DIFF
--- a/.github/doc-updates/67f1cfc3-236c-4cd1-9eb0-0aa8e305e514.json
+++ b/.github/doc-updates/67f1cfc3-236c-4cd1-9eb0-0aa8e305e514.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 23, 2025 - Implemented OpenTelemetry scraping and export protobufs. Metrics module progress updated.",
+  "guid": "67f1cfc3-236c-4cd1-9eb0-0aa8e305e514",
+  "created_at": "2025-07-23T03:17:01Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/92818f3a-7eab-4531-8b2d-07bb0d7421ad.json
+++ b/.github/doc-updates/92818f3a-7eab-4531-8b2d-07bb0d7421ad.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added OpenTelemetry metrics protobufs for scraping and export",
+  "guid": "92818f3a-7eab-4531-8b2d-07bb0d7421ad",
+  "created_at": "2025-07-23T03:16:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/941b088a-61da-4d97-a395-f1411ff49e70.json
+++ b/.github/doc-updates/941b088a-61da-4d97-a395-f1411ff49e70.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Implemented OpenTelemetry scraping and export protobufs",
+  "guid": "941b088a-61da-4d97-a395-f1411ff49e70",
+  "created_at": "2025-07-23T03:16:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d89903af-e0a4-41f6-8867-1889eb562b1c.json
+++ b/.github/doc-updates/d89903af-e0a4-41f6-8867-1889eb562b1c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "OpenTelemetry metrics protobufs implemented for scraping and export",
+  "guid": "d89903af-e0a4-41f6-8867-1889eb562b1c",
+  "created_at": "2025-07-23T03:16:56Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b12239bb-ecbd-43bd-8d56-ba0d6abf0887.json
+++ b/.github/issue-updates/b12239bb-ecbd-43bd-8d56-ba0d6abf0887.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "OpenTelemetry metrics protobufs",
+  "body": "Implement metrics protobufs for scraping and export operations",
+  "labels": ["module:metrics", "enhancement"],
+  "guid": "b12239bb-ecbd-43bd-8d56-ba0d6abf0887",
+  "legacy_guid": "create-opentelemetry-metrics-protobufs-2025-07-23"
+}

--- a/pkg/metrics/proto/messages/scrape_job.proto
+++ b/pkg/metrics/proto/messages/scrape_job.proto
@@ -1,18 +1,34 @@
-// filepath: pkg/metrics/proto/messages/scrape_job.proto
-// file: metrics/proto/messages/scrape_job.proto
-//
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/messages/scrape_job.proto
+// version: 1.1.0
+// guid: 4c4b2cc6-1c94-4bd4-9a40-e1e36e1f9d02
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/metrics/proto/messages/scrape_config.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ScrapeJob represents a scheduled scraping task for metrics collection.
+ */
+message ScrapeJob {
+  // Unique identifier for the scrape job
+  string job_id = 1;
+
+  // Configuration used for the scrape
+  ScrapeConfig config = 2;
+
+  // Whether the job is currently active
+  bool active = 3;
+
+  // Timestamp of the last successful scrape
+  google.protobuf.Timestamp last_scrape_time = 4;
+
+  // Timestamp of the next scheduled scrape
+  google.protobuf.Timestamp next_scrape_time = 5;
+}

--- a/pkg/metrics/proto/requests/export_metrics_request.proto
+++ b/pkg/metrics/proto/requests/export_metrics_request.proto
@@ -1,18 +1,37 @@
-// filepath: pkg/metrics/proto/requests/export_metrics_request.proto
-// file: metrics/proto/requests/export_metrics_request.proto
-//
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/requests/export_metrics_request.proto
+// version: 1.1.0
+// guid: 2c9c223d-523d-4b0c-aa30-6249240e59d6
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/enums/export_format.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ExportMetricsRequest requests export of collected metrics.
+ */
+message ExportMetricsRequest {
+  // Standard request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Metrics provider to export from
+  string provider_id = 2;
+
+  // Desired export format
+  ExportFormat format = 3;
+
+  // Destination URI or path
+  string destination = 4;
+
+  // Specific metrics to include (optional)
+  repeated string metric_names = 5;
+
+  // Include metadata such as descriptions and units
+  bool include_metadata = 6;
+}

--- a/pkg/metrics/proto/requests/start_scraping_request.proto
+++ b/pkg/metrics/proto/requests/start_scraping_request.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/metrics/proto/requests/start_scraping_request.proto
-// file: metrics/proto/requests/start_scraping_request.proto
-//
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/requests/start_scraping_request.proto
+// version: 1.1.0
+// guid: 3bf09215-7dbf-4f23-97b5-911aeb40f125
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/scrape_config.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * StartScrapingRequest initiates a new scrape job for the given provider.
+ */
+message StartScrapingRequest {
+  // Standard request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Metrics provider identifier
+  string provider_id = 2;
+
+  // Scrape configuration to use
+  ScrapeConfig config = 3;
+}

--- a/pkg/metrics/proto/requests/stop_scraping_request.proto
+++ b/pkg/metrics/proto/requests/stop_scraping_request.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/metrics/proto/requests/stop_scraping_request.proto
-// file: metrics/proto/requests/stop_scraping_request.proto
-//
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/requests/stop_scraping_request.proto
+// version: 1.1.0
+// guid: 4fac5447-f3bb-4627-94d7-4d6115c265f1
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * StopScrapingRequest stops an active scrape job.
+ */
+message StopScrapingRequest {
+  // Standard request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Identifier of the job to stop
+  string job_id = 2;
+}

--- a/pkg/metrics/proto/responses/export_metrics_response.proto
+++ b/pkg/metrics/proto/responses/export_metrics_response.proto
@@ -1,18 +1,34 @@
-// filepath: pkg/metrics/proto/responses/export_metrics_response.proto
-// file: metrics/proto/responses/export_metrics_response.proto
-//
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/responses/export_metrics_response.proto
+// version: 1.1.0
+// guid: 0d2df1e4-76e3-437b-855e-4dcc2b6f6b9e
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ExportMetricsResponse returns the result of a metrics export operation.
+ */
+message ExportMetricsResponse {
+  // Whether the export succeeded
+  bool success = 1;
+
+  // Error information if the export failed
+  gcommon.v1.common.Error error = 2;
+
+  // Number of records exported
+  int64 exported_records = 3;
+
+  // Timestamp when the export completed
+  google.protobuf.Timestamp exported_at = 4;
+
+  // Location of the exported data
+  string file_url = 5;
+}

--- a/pkg/metrics/proto/responses/start_scraping_response.proto
+++ b/pkg/metrics/proto/responses/start_scraping_response.proto
@@ -1,18 +1,32 @@
-// filepath: pkg/metrics/proto/responses/start_scraping_response.proto
-// file: metrics/proto/responses/start_scraping_response.proto
-//
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/responses/start_scraping_response.proto
+// version: 1.1.0
+// guid: 83543cf4-50e7-4161-9c5f-5ddca3a0655f
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/scrape_job.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * StartScrapingResponse returns the result of starting a scrape job.
+ */
+message StartScrapingResponse {
+  // Whether the job was started successfully
+  bool success = 1;
+
+  // Error information if unsuccessful
+  gcommon.v1.common.Error error = 2;
+
+  // Details of the started scrape job
+  ScrapeJob job = 3;
+
+  // Timestamp when the job started
+  google.protobuf.Timestamp started_at = 4;
+}

--- a/pkg/metrics/proto/responses/stop_scraping_response.proto
+++ b/pkg/metrics/proto/responses/stop_scraping_response.proto
@@ -1,18 +1,32 @@
-// filepath: pkg/metrics/proto/responses/stop_scraping_response.proto
-// file: metrics/proto/responses/stop_scraping_response.proto
-//
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/metrics/proto/responses/stop_scraping_response.proto
+// version: 1.1.0
+// guid: 7d2eb263-b398-4b98-af07-c9950ab73d05
+
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/scrape_job.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * StopScrapingResponse returns the result of stopping a scrape job.
+ */
+message StopScrapingResponse {
+  // Whether the job was stopped successfully
+  bool success = 1;
+
+  // Error information if unsuccessful
+  gcommon.v1.common.Error error = 2;
+
+  // Details of the stopped job
+  ScrapeJob job = 3;
+
+  // Timestamp when the job stopped
+  google.protobuf.Timestamp stopped_at = 4;
+}


### PR DESCRIPTION
## Summary
Implemented OpenTelemetry integration protobufs for the metrics module and added related documentation updates.

## Issues Addressed

### feat(metrics): add OpenTelemetry scraping protos
- [`pkg/metrics/proto/messages/scrape_job.proto`](./pkg/metrics/proto/messages/scrape_job.proto) - new message defining scrape job configuration
- [`pkg/metrics/proto/requests/start_scraping_request.proto`](./pkg/metrics/proto/requests/start_scraping_request.proto) - new request to start scraping
- [`pkg/metrics/proto/responses/start_scraping_response.proto`](./pkg/metrics/proto/responses/start_scraping_response.proto) - response with job details
- [`pkg/metrics/proto/requests/stop_scraping_request.proto`](./pkg/metrics/proto/requests/stop_scraping_request.proto) - request to stop scraping
- [`pkg/metrics/proto/responses/stop_scraping_response.proto`](./pkg/metrics/proto/responses/stop_scraping_response.proto) - response confirming stop
- [`pkg/metrics/proto/requests/export_metrics_request.proto`](./pkg/metrics/proto/requests/export_metrics_request.proto) - request to export metrics
- [`pkg/metrics/proto/responses/export_metrics_response.proto`](./pkg/metrics/proto/responses/export_metrics_response.proto) - response for metrics export
- `.github/issue-updates/b12239bb-ecbd-43bd-8d56-ba0d6abf0887.json` - created issue for OpenTelemetry protobuf work
- `.github/doc-updates/*.json` - documentation updates for CHANGELOG, README, TODO, and implementation plan

## Testing
- `bash scripts/validate-protos.sh` *(failed: compilation errors due to edition features)*

------
https://chatgpt.com/codex/tasks/task_e_68805175c64483219ae9c17a57e8fb78