### PR TITLE
Add ConfigAdminService protobufs

### DIFF
--- a/.github/doc-updates/33c909f0-3d2f-4575-a17b-4bf99af7f051.json
+++ b/.github/doc-updates/33c909f0-3d2f-4575-a17b-4bf99af7f051.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "- Config module progress: 8/23 files implemented including ConfigAdminService",
+  "guid": "33c909f0-3d2f-4575-a17b-4bf99af7f051",
+  "created_at": "2025-07-23T03:17:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/3aad169d-506c-40a7-8852-2fec95c0b95c.json
+++ b/.github/doc-updates/3aad169d-506c-40a7-8852-2fec95c0b95c.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Config module progress now at 35% with ConfigAdminService implemented",
+  "guid": "3aad169d-506c-40a7-8852-2fec95c0b95c",
+  "created_at": "2025-07-23T03:17:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/6008997a-41ad-4e02-8518-5c8c37130953.json
+++ b/.github/doc-updates/6008997a-41ad-4e02-8518-5c8c37130953.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Implemented ConfigAdminService and new config messages",
+  "guid": "6008997a-41ad-4e02-8518-5c8c37130953",
+  "created_at": "2025-07-23T03:17:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/60f7ae9c-ae51-4e39-862d-460c3d066b4b.json
+++ b/.github/doc-updates/60f7ae9c-ae51-4e39-862d-460c3d066b4b.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Implemented ConfigAdminService protobufs",
+  "guid": "60f7ae9c-ae51-4e39-862d-460c3d066b4b",
+  "created_at": "2025-07-23T03:17:24Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/2c8838d6-87a6-444d-a51e-8ddc45ae1950.json
+++ b/.github/issue-updates/2c8838d6-87a6-444d-a51e-8ddc45ae1950.json
@@ -1,0 +1,8 @@
+{
+  "action": "update",
+  "number": 77,
+  "body": "Implemented ConfigAdminService and related protobufs",
+  "labels": ["completed"],
+  "guid": "2c8838d6-87a6-444d-a51e-8ddc45ae1950",
+  "legacy_guid": "update-issue-77-2025-07-23"
+}

--- a/pkg/config/proto/messages/config_stats.proto
+++ b/pkg/config/proto/messages/config_stats.proto
@@ -1,0 +1,26 @@
+// file: pkg/config/proto/messages/config_stats.proto
+// version: 1.0.0
+// guid: 57dfad7b-0867-4628-a18b-0846e8f0bf0c
+
+edition = "2023";
+
+package gcommon.v1.config;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/config/proto;configpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * ConfigStats provides statistics about configuration data.
+ */
+message ConfigStats {
+  // Total number of configuration keys
+  int64 total_keys = 1;
+
+  // Number of namespaces/environments
+  int64 namespaces = 2;
+
+  // Number of configuration versions
+  int64 versions = 3;
+}

--- a/pkg/config/proto/responses/get_config_history_response.proto
+++ b/pkg/config/proto/responses/get_config_history_response.proto
@@ -1,0 +1,21 @@
+// file: pkg/config/proto/responses/get_config_history_response.proto
+// version: 1.0.0
+// guid: a0368a84-a298-4ed2-bccf-799e1e11f6ba
+
+edition = "2023";
+
+package gcommon.v1.config;
+
+import "google/protobuf/go_features.proto";
+import "pkg/config/proto/messages/config_change.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/config/proto;configpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * GetConfigHistoryResponse returns configuration change history.
+ */
+message GetConfigHistoryResponse {
+  // List of configuration changes
+  repeated ConfigChange changes = 1;
+}

--- a/pkg/config/proto/responses/get_config_stats_response.proto
+++ b/pkg/config/proto/responses/get_config_stats_response.proto
@@ -1,0 +1,21 @@
+// file: pkg/config/proto/responses/get_config_stats_response.proto
+// version: 1.0.0
+// guid: c97a7226-491a-45fd-bf2d-4c045dbd0054
+
+edition = "2023";
+
+package gcommon.v1.config;
+
+import "google/protobuf/go_features.proto";
+import "pkg/config/proto/messages/config_stats.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/config/proto;configpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * GetConfigStatsResponse contains statistics about configuration.
+ */
+message GetConfigStatsResponse {
+  // Statistics data
+  ConfigStats stats = 1;
+}

--- a/pkg/config/proto/responses/health_check_response.proto
+++ b/pkg/config/proto/responses/health_check_response.proto
@@ -1,0 +1,24 @@
+// file: pkg/config/proto/responses/health_check_response.proto
+// version: 1.0.0
+// guid: 4f491273-ecd5-4d3c-b13d-b7ef6219a25d
+
+edition = "2023";
+
+package gcommon.v1.config;
+
+import "google/protobuf/go_features.proto";
+import "pkg/common/proto/enums/health_status.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/config/proto;configpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * HealthCheckResponse provides health status for the config service.
+ */
+message HealthCheckResponse {
+  // Overall health status
+  gcommon.v1.common.HealthStatus status = 1;
+
+  // Optional human-readable message
+  string message = 2;
+}

--- a/pkg/config/proto/services/config_admin_service.proto
+++ b/pkg/config/proto/services/config_admin_service.proto
@@ -1,18 +1,67 @@
-// filepath: pkg/config/proto/services/config_admin_service.proto
-// file: config/proto/services/config_admin_service.proto
-//
-// Service definitions for config module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/config/proto/services/config_admin_service.proto
+// version: 1.0.0
+// guid: 115f65c3-94f2-4c4d-892d-27eb6c9fcece
+
 edition = "2023";
 
 package gcommon.v1.config;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/empty.proto";
+import "pkg/config/proto/requests/backup_config_request.proto";
+import "pkg/config/proto/messages/config_backup.proto";
+import "pkg/config/proto/requests/restore_config_request.proto";
+import "pkg/config/proto/requests/import_config_request.proto";
+import "pkg/config/proto/requests/export_config_request.proto";
+import "pkg/config/proto/messages/config_snapshot.proto";
+import "pkg/config/proto/requests/reload_config_request.proto";
+import "pkg/config/proto/requests/rollback_config_request.proto";
+import "pkg/config/proto/requests/set_config_schema_request.proto";
+import "pkg/config/proto/requests/get_config_history_request.proto";
+import "pkg/config/proto/responses/get_config_history_response.proto";
+import "pkg/config/proto/requests/get_config_stats_request.proto";
+import "pkg/config/proto/responses/get_config_stats_response.proto";
+import "pkg/config/proto/requests/health_check_request.proto";
+import "pkg/config/proto/responses/health_check_response.proto";
+import "pkg/config/proto/requests/unwatch_config_request.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/config/proto;configpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add service definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the config module requirements
+/**
+ * ConfigAdminService provides administrative configuration operations.
+ */
+service ConfigAdminService {
+  // Create a configuration backup
+  rpc BackupConfig(BackupConfigRequest) returns (ConfigBackup);
+
+  // Restore configuration from a backup or restore point
+  rpc RestoreConfig(RestoreConfigRequest) returns (google.protobuf.Empty);
+
+  // Import configuration values
+  rpc ImportConfig(ImportConfigRequest) returns (google.protobuf.Empty);
+
+  // Export configuration snapshot
+  rpc ExportConfig(ExportConfigRequest) returns (ConfigSnapshot);
+
+  // Reload configuration from persistent storage
+  rpc ReloadConfig(ReloadConfigRequest) returns (google.protobuf.Empty);
+
+  // Roll back configuration to a previous restore point
+  rpc RollbackConfig(RollbackConfigRequest) returns (google.protobuf.Empty);
+
+  // Update configuration schema
+  rpc SetConfigSchema(SetConfigSchemaRequest) returns (google.protobuf.Empty);
+
+  // Retrieve configuration change history
+  rpc GetConfigHistory(GetConfigHistoryRequest) returns (GetConfigHistoryResponse);
+
+  // Retrieve configuration statistics
+  rpc GetConfigStats(GetConfigStatsRequest) returns (GetConfigStatsResponse);
+
+  // Perform service health check
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Stop watching configuration changes
+  rpc UnwatchConfig(UnwatchConfigRequest) returns (google.protobuf.Empty);
+}


### PR DESCRIPTION
## Summary
Implemented remaining protobuf definitions for the Config module.

## Issues Addressed

### feat(config): add admin service and stats messages (#77)
**Description:** Implemented `ConfigAdminService` with administrative RPCs and added supporting messages/responses. Created documentation updates and linked issue.

**Files Modified:**
- [`pkg/config/proto/services/config_admin_service.proto`](./pkg/config/proto/services/config_admin_service.proto)
- [`pkg/config/proto/messages/config_stats.proto`](./pkg/config/proto/messages/config_stats.proto)
- [`pkg/config/proto/responses/get_config_history_response.proto`](./pkg/config/proto/responses/get_config_history_response.proto)
- [`pkg/config/proto/responses/get_config_stats_response.proto`](./pkg/config/proto/responses/get_config_stats_response.proto)
- [`pkg/config/proto/responses/health_check_response.proto`](./pkg/config/proto/responses/health_check_response.proto)
- `.github/doc-updates/*.json` and `.github/issue-updates/2c8838d6-87a6-444d-a51e-8ddc45ae1950.json`

## Testing
- `bash test_protoc.sh` *(fails: missing implementations in other modules)*
- `python3 validate_protobuf_coverage.py` *(reports untracked files)*

------
https://chatgpt.com/codex/tasks/task_e_688051ab37248321af97b22f98ab3647