### PR TITLE
Implement initial queue protobufs

### DIFF
--- a/.github/doc-updates/78165210-a465-4701-8823-363b4403d86c.json
+++ b/.github/doc-updates/78165210-a465-4701-8823-363b4403d86c.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "after",
+  "content": "July 25, 2025 - Implemented queue listing and pull protobuf definitions (8 files). Queue module completion: 19/177 files (~10%).",
+  "guid": "78165210-a465-4701-8823-363b4403d86c",
+  "created_at": "2025-07-23T03:30:08Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7c570f14-a7d6-459a-a7b2-ddd63b8f08ea.json
+++ b/.github/doc-updates/7c570f14-a7d6-459a-a7b2-ddd63b8f08ea.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Implemented queue list and pull protobufs",
+  "guid": "7c570f14-a7d6-459a-a7b2-ddd63b8f08ea",
+  "created_at": "2025-07-23T03:29:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a1eccd9a-683f-4527-ae42-817123cb417c.json
+++ b/.github/doc-updates/a1eccd9a-683f-4527-ae42-817123cb417c.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "Queue module progress updated: implemented listing and pull protobufs (approx. 10% complete)",
+  "guid": "a1eccd9a-683f-4527-ae42-817123cb417c",
+  "created_at": "2025-07-23T03:37:38Z",
+  "options": {
+    "section": null,
+    "after": "Queue module progress: implemented acknowledgment messages and types (approx. 6% complete)",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/fb1823a3-c966-4644-ab8e-c71b5e75a045.json
+++ b/.github/doc-updates/fb1823a3-c966-4644-ab8e-c71b5e75a045.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented additional queue protobufs for listing and pull operations",
+  "guid": "fb1823a3-c966-4644-ab8e-c71b5e75a045",
+  "created_at": "2025-07-23T03:29:30Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b32871f0-069c-4908-b1a5-2c6b3074d8df.json
+++ b/.github/issue-updates/b32871f0-069c-4908-b1a5-2c6b3074d8df.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 91,
+  "body": "Implemented QueueInfo and SubscriptionInfo messages",
+  "guid": "b32871f0-069c-4908-b1a5-2c6b3074d8df",
+  "legacy_guid": "comment-issue-91-2025-07-23"
+}

--- a/.github/issue-updates/c8a08160-26cf-42c0-a17c-d066441137be.json
+++ b/.github/issue-updates/c8a08160-26cf-42c0-a17c-d066441137be.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 94,
+  "body": "Implemented ListQueuesResponse, ListSubscriptionsResponse, and PullResponse",
+  "guid": "c8a08160-26cf-42c0-a17c-d066441137be",
+  "legacy_guid": "comment-issue-94-2025-07-23"
+}

--- a/.github/issue-updates/d8c744af-4704-43d8-9960-cb5bbb55018f.json
+++ b/.github/issue-updates/d8c744af-4704-43d8-9960-cb5bbb55018f.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 95,
+  "body": "Added ListQueuesRequest, ListSubscriptionsRequest, and PullRequest",
+  "guid": "d8c744af-4704-43d8-9960-cb5bbb55018f",
+  "legacy_guid": "comment-issue-95-2025-07-23"
+}

--- a/pkg/queue/proto/messages/queue_info.proto
+++ b/pkg/queue/proto/messages/queue_info.proto
@@ -1,18 +1,40 @@
-// filepath: pkg/queue/proto/messages/queue_info.proto
-// file: queue/proto/messages/queue_info.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/queue_info.proto
+// version: 1.0.0
+// guid: d2ab2b72-14e2-4afe-80f7-2ecf00daacac
+
+// QueueInfo provides metadata about a queue instance. This replaces the
+// empty placeholder created during the 1-1-1 migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+/**
+ * QueueInfo describes the configuration and current status of a queue.
+ * It is returned by administrative APIs such as ListQueues.
+ */
+message QueueInfo {
+  // Name of the queue
+  string name = 1;
+
+  // Type of queue implementation (e.g., "rabbitmq", "nats")
+  string type = 2;
+
+  // Current approximate number of messages in the queue
+  int64 message_count = 3;
+
+  // Number of active consumers
+  int32 consumer_count = 4;
+
+  // Time when the queue was created
+  google.protobuf.Timestamp created_at = 5;
+
+  // Additional metadata or labels for the queue
+  map<string, string> labels = 6;
+}

--- a/pkg/queue/proto/messages/subscription_info.proto
+++ b/pkg/queue/proto/messages/subscription_info.proto
@@ -1,18 +1,40 @@
-// filepath: pkg/queue/proto/messages/subscription_info.proto
-// file: queue/proto/messages/subscription_info.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/subscription_info.proto
+// version: 1.0.0
+// guid: 9b9d0532-72ff-4a42-b3b2-689a1a26dd9f
+
+// SubscriptionInfo provides metadata about a subscription to a topic
+// or queue. It replaces the placeholder file created during the
+// 1-1-1 migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+/**
+ * SubscriptionInfo describes a subscriber's configuration and status.
+ */
+message SubscriptionInfo {
+  // Name of the subscription
+  string name = 1;
+
+  // Topic or queue this subscription belongs to
+  string topic = 2;
+
+  // Whether the subscription is currently active
+  bool active = 3;
+
+  // Number of pending messages for this subscription
+  int64 pending_message_count = 4;
+
+  // Time when the subscription was created
+  google.protobuf.Timestamp created_at = 5;
+
+  // Arbitrary labels associated with the subscription
+  map<string, string> labels = 6;
+}

--- a/pkg/queue/proto/requests/list_queues_request.proto
+++ b/pkg/queue/proto/requests/list_queues_request.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/queue/proto/requests/list_queues_request.proto
-// file: queue/proto/requests/list_queues_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/list_queues_request.proto
+// version: 1.0.0
+// guid: 10aa0104-6a4e-4092-98f4-8eabba61ea69
+
+// ListQueuesRequest retrieves available queues for the current
+// user or service account. This file was a placeholder and now
+// implements the request following the 1-1-1 pattern.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message ListQueuesRequest {
+  // Standard request metadata used across all services
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Optional page size for results
+  int32 page_size = 2;
+
+  // Optional token for fetching the next page
+  string page_token = 3;
+}

--- a/pkg/queue/proto/requests/list_subscriptions_request.proto
+++ b/pkg/queue/proto/requests/list_subscriptions_request.proto
@@ -1,18 +1,29 @@
-// filepath: pkg/queue/proto/requests/list_subscriptions_request.proto
-// file: queue/proto/requests/list_subscriptions_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/list_subscriptions_request.proto
+// version: 1.0.0
+// guid: 781a6513-601b-4ef8-87bf-7c881f4b8a79
+
+// ListSubscriptionsRequest returns subscriptions for a given topic or queue.
+// Previously a placeholder, this file now contains the full request definition.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message ListSubscriptionsRequest {
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Name of the topic or queue to list subscriptions for
+  string parent = 2;
+
+  // Optional page size
+  int32 page_size = 3;
+
+  // Optional page token
+  string page_token = 4;
+}

--- a/pkg/queue/proto/requests/pull_request.proto
+++ b/pkg/queue/proto/requests/pull_request.proto
@@ -1,18 +1,27 @@
-// filepath: pkg/queue/proto/requests/pull_request.proto
-// file: queue/proto/requests/pull_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/pull_request.proto
+// version: 1.0.0
+// guid: dae5ea8a-77c7-4b90-ab25-d2981ba423df
+
+// PullRequest retrieves a single message from the specified queue
+// without establishing a subscription. This file replaces the
+// placeholder generated during migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message PullRequest {
+  // Request metadata for tracing and authentication
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Queue to pull from
+  string queue_name = 2;
+
+  // Optional visibility timeout for the pulled message
+  int32 visibility_timeout_seconds = 3;
+}

--- a/pkg/queue/proto/responses/list_queues_response.proto
+++ b/pkg/queue/proto/responses/list_queues_response.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/queue/proto/responses/list_queues_response.proto
-// file: queue/proto/responses/list_queues_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/list_queues_response.proto
+// version: 1.0.0
+// guid: c2ffc959-d7b5-451f-94f4-a9334e02725f
+
+// ListQueuesResponse returns a list of queues visible to the
+// requester along with pagination information. This replaces the
+// placeholder file generated during the migration.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+import "pkg/queue/proto/messages/queue_info.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message ListQueuesResponse {
+  // Collection of queues
+  repeated QueueInfo queues = 1;
+
+  // Token to retrieve the next page
+  string next_page_token = 2;
+
+  // Standard response metadata
+  gcommon.v1.common.ResponseMetadata metadata = 3;
+}

--- a/pkg/queue/proto/responses/list_subscriptions_response.proto
+++ b/pkg/queue/proto/responses/list_subscriptions_response.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/queue/proto/responses/list_subscriptions_response.proto
-// file: queue/proto/responses/list_subscriptions_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/list_subscriptions_response.proto
+// version: 1.0.0
+// guid: c20dc6c8-336b-4626-b709-22be9663d29d
+
+// ListSubscriptionsResponse contains the subscriptions under a
+// specific topic or queue. This file now implements the message
+// rather than acting as a placeholder.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+import "pkg/queue/proto/messages/subscription_info.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message ListSubscriptionsResponse {
+  // Subscriptions returned
+  repeated SubscriptionInfo subscriptions = 1;
+
+  // Token for fetching the next page
+  string next_page_token = 2;
+
+  // Response metadata common across services
+  gcommon.v1.common.ResponseMetadata metadata = 3;
+}

--- a/pkg/queue/proto/responses/pull_response.proto
+++ b/pkg/queue/proto/responses/pull_response.proto
@@ -1,18 +1,24 @@
-// filepath: pkg/queue/proto/responses/pull_response.proto
-// file: queue/proto/responses/pull_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/pull_response.proto
+// version: 1.0.0
+// guid: 5c55b3fd-beda-4758-90c9-2084f2d6ea8f
+
+// PullResponse returns a message pulled from the queue. This file
+// now contains the actual response definition instead of a placeholder.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+import "pkg/queue/proto/queue.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+message PullResponse {
+  // The received message. May be null if no message was available.
+  ReceivedMessage message = 1;
+
+  // Response metadata including error details
+  gcommon.v1.common.ResponseMetadata metadata = 2;
+}


### PR DESCRIPTION
## Summary
- implement queue metadata message files
- add list and pull request/response protobufs
- update protobuf implementation docs
- record progress notes for queue issues

## Testing
- `make proto-compile` *(fails: compilation failed for 1043 files)*
- `buf lint pkg/queue/proto` *(fails: `buf` not installed)*
- `go test ./...` *(fails: no required module provides package pkg/db/mock)*

------
https://chatgpt.com/codex/tasks/task_e_688051431b74832187cb56952f5d7e60