### PR TITLE
Implement initial auth permission protos

### DIFF
--- a/.github/doc-updates/4b5a4d7f-bbe4-4fdd-b61b-822485d50a92.json
+++ b/.github/doc-updates/4b5a4d7f-bbe4-4fdd-b61b-822485d50a92.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "replace",
+  "content": "| **Auth**     | 126         | 104   | 22          | 17.5%      | 🟠 HIGH     |",
+  "guid": "4b5a4d7f-bbe4-4fdd-b61b-822485d50a92",
+  "created_at": "2025-07-23T03:45:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5c8dee29-95d8-4764-81ea-2f63c7b1c739.json
+++ b/.github/doc-updates/5c8dee29-95d8-4764-81ea-2f63c7b1c739.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Continue implementing remaining Auth protobufs",
+  "guid": "5c8dee29-95d8-4764-81ea-2f63c7b1c739",
+  "created_at": "2025-07-23T03:46:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/6095eecb-57f9-4d41-a7a0-28e1951bd8c9.json
+++ b/.github/doc-updates/6095eecb-57f9-4d41-a7a0-28e1951bd8c9.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "replace-section",
+  "content": "- **✅ Common Module**: 100% complete (40/40 files) - **Shared Types Foundation**\n- **✅ Database Module**: 100% complete (52/52 files) - **Gold Standard Reference**\n- **✅ Log Module**: 100% complete (1/1 files) - **Minimal Implementation**\n- **🔄 Auth Module**: 17.5% complete (22/126 files) - 104 files need implementation\n- **🔄 Cache Module**: 18.2% complete (8/44 files) - 36 files need implementation\n- **🔄 Config Module**: 13.0% complete (3/23 files) - 20 files need implementation\n- **✅ Health Module**: 100% complete (16/16 files) - Stable and production-ready\n- **❌ Metrics Module**: 2.1% complete (2/97 files) - **95 files need implementation**\n- **❌ Queue Module**: 1.1% complete (2/177 files) - **175 files need implementation**\n- **❌ Web Module**: 1.1% complete (2/178 files) - **176 files need implementation**",
+  "guid": "6095eecb-57f9-4d41-a7a0-28e1951bd8c9",
+  "created_at": "2025-07-23T03:46:05Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a4eb2af3-e903-4e61-85f8-d2b0c6e00e5a.json
+++ b/.github/doc-updates/a4eb2af3-e903-4e61-85f8-d2b0c6e00e5a.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "replace-section",
+  "content": "- **✅ Common Module**: 100% complete (40/40 files) - **Shared Types Foundation**\n- **✅ Database Module**: 100% complete (52/52 files) - **Gold Standard Reference**\n- **✅ Log Module**: 100% complete (1/1 files) - **Minimal Implementation**\n- **🔄 Auth Module**: 17.5% complete (22/126 files) - 104 files need implementation\n- **🔄 Cache Module**: 18.2% complete (8/44 files) - 36 files need implementation\n- **🔄 Config Module**: 13.0% complete (3/23 files) - 20 files need implementation\n- **✅ Health Module**: 100% complete (16/16 files) - Stable and production-ready\n- **❌ Metrics Module**: 2.1% complete (2/97 files) - **95 files need implementation**\n- **❌ Queue Module**: 1.1% complete (2/177 files) - **175 files need implementation**\n- **❌ Web Module**: 1.1% complete (2/178 files) - **176 files need implementation**",
+  "guid": "a4eb2af3-e903-4e61-85f8-d2b0c6e00e5a",
+  "created_at": "2025-07-23T03:45:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/dfe204c5-99d2-4e31-a278-68505a0b40dc.json
+++ b/.github/doc-updates/dfe204c5-99d2-4e31-a278-68505a0b40dc.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "replace-section",
+  "content": "#### Auth Module (Priority 4)\n\n- **104 files to implement** across 5 categories (now 17.5% complete)\n- **Issues**: #76-80 (Auth Messages, Types, Enums, Responses, Requests)",
+  "guid": "dfe204c5-99d2-4e31-a278-68505a0b40dc",
+  "created_at": "2025-07-23T03:46:16Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e7d7ba40-e804-4d39-ac81-4e317afaa354.json
+++ b/.github/doc-updates/e7d7ba40-e804-4d39-ac81-4e317afaa354.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "replace-section",
+  "content": "| Module           | Completion | Ready for Production | gRPC Services | Recent Progress                           |\n| ---------------- | ---------- | -------------------- | ------------- | ------------------------------------------ |\n| **Health**       | ✅ 100%     | ✅ Yes                | ✅ Complete    | **✅ Complete 1-1-1 migration (36 types)** |\n| **Common**       | ✅ 100%     | ✅ Yes                | ✅ Complete    | **✅ 40 shared types implemented**         |\n| **Database**     | ✅ 100%     | ✅ Yes                | ✅ Complete    | **✅ Complete 1-1-1 migration (52 types)** |\n| **Log**          | ✅ 100%     | ✅ Yes                | ✅ Complete    | **✅ Minimal logging implementation**      |\n| **Auth**         | 🔄 17.5%    | ⚠️ Partial            | 🔄 Partial     | **🔄 22/126 files implemented**            |\n| **Cache**        | 🔄 18.2%    | ❌ No                 | 🔄 In Progress | **🔄 8/44 files implemented**              |\n| **Config**       | 🔄 13.0%    | ❌ No                 | ❌ Planned     | **🔄 3/23 files implemented**              |\n| **Notification** | 🔄 25%      | ❌ No                 | ❌ Planned     | **🔄 Initial message types defined**       |\n| **Metrics**      | 🔄 2.1%     | ❌ No                 | 🔄 In Progress | **❌ 95/97 files need implementation**     |\n| **Queue**        | 🔄 1.1%     | ❌ No                 | ❌ Planned     | **❌ 175/177 files need implementation**   |\n| **Web**          | 🔄 1.1%     | ❌ No                 | ❌ Planned     | **❌ 176/178 files need implementation**   |",
+  "guid": "e7d7ba40-e804-4d39-ac81-4e317afaa354",
+  "created_at": "2025-07-23T03:45:12Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/fa0a3b9a-1ce6-4500-8c81-62c6294d047a.json
+++ b/.github/doc-updates/fa0a3b9a-1ce6-4500-8c81-62c6294d047a.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented core permission and auth context protobufs",
+  "guid": "fa0a3b9a-1ce6-4500-8c81-62c6294d047a",
+  "created_at": "2025-07-23T03:45:01Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/0111c8c9-e85b-4637-aeb7-b0698235ccb3.json
+++ b/.github/issue-updates/0111c8c9-e85b-4637-aeb7-b0698235ccb3.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 80,
+  "body": "Added CheckPermission request/response",
+  "guid": "0111c8c9-e85b-4637-aeb7-b0698235ccb3",
+  "legacy_guid": "comment-issue-80-2025-07-23"
+}

--- a/.github/issue-updates/2a87ca7d-e35d-4168-9293-5950d17a35fb.json
+++ b/.github/issue-updates/2a87ca7d-e35d-4168-9293-5950d17a35fb.json
@@ -1,0 +1,7 @@
+{
+  "action": "comment",
+  "number": 79,
+  "body": "Implemented permission and auth context messages",
+  "guid": "2a87ca7d-e35d-4168-9293-5950d17a35fb",
+  "legacy_guid": "comment-issue-79-2025-07-23"
+}

--- a/pkg/auth/proto/enums/mfa_type.proto
+++ b/pkg/auth/proto/enums/mfa_type.proto
@@ -1,18 +1,29 @@
-// filepath: pkg/auth/proto/enums/mfa_type.proto
-// file: auth/proto/enums/mfa_type.proto
-//
-// Enum definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/enums/mfa_type.proto
+// version: 1.0.0
+// guid: a5e413ea-00e3-4585-9e9d-30348138c407
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
-
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * MFAType enumerates supported multi-factor authentication methods.
+ */
+enum MFAType {
+  // Unknown or unspecified MFA method
+  MFA_TYPE_UNSPECIFIED = 0;
+
+  // Time-based one-time password via authenticator apps
+  MFA_TYPE_TOTP = 1;
+
+  // One-time code delivered via SMS
+  MFA_TYPE_SMS = 2;
+
+  // One-time code delivered via email
+  MFA_TYPE_EMAIL = 3;
+
+  // Push notification to a trusted device
+  MFA_TYPE_PUSH = 4;
+}

--- a/pkg/auth/proto/messages/permission.proto
+++ b/pkg/auth/proto/messages/permission.proto
@@ -1,18 +1,33 @@
-// filepath: pkg/auth/proto/messages/permission.proto
-// file: auth/proto/messages/permission.proto
-//
-// Message definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/messages/permission.proto
+// version: 1.0.0
+// guid: 38e2195b-8510-48b4-9c7c-2f87ab8e9a1a
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/auth/proto/enums/scope_type.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Permission represents a specific action that can be granted
+ * to a user or role within the authentication system.
+ */
+message Permission {
+  // Unique identifier for the permission
+  string id = 1;
+
+  // Short machine friendly permission name
+  string name = 2;
+
+  // Human readable description of what the permission allows
+  string description = 3;
+
+  // Scope at which this permission applies
+  ScopeType scope = 4;
+
+  // Timestamp when the permission was created
+  google.protobuf.Timestamp created_at = 5 [lazy = true];
+}

--- a/pkg/auth/proto/requests/check_permission_request.proto
+++ b/pkg/auth/proto/requests/check_permission_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/requests/check_permission_request.proto
-// file: auth/proto/requests/check_permission_request.proto
-//
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/requests/check_permission_request.proto
+// version: 1.0.0
+// guid: db7aca7d-742a-443b-b641-448ddf4a8518
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Request to verify that a user possesses a specific permission.
+ */
+message CheckPermissionRequest {
+  // Metadata for tracing and audit purposes
+  gcommon.v1.common.RequestMetadata metadata = 1 [lazy = true];
+
+  // User ID being verified
+  string user_id = 2;
+
+  // Permission ID to check
+  string permission_id = 3;
+}

--- a/pkg/auth/proto/responses/check_permission_response.proto
+++ b/pkg/auth/proto/responses/check_permission_response.proto
@@ -1,18 +1,17 @@
-// filepath: pkg/auth/proto/responses/check_permission_response.proto
-// file: auth/proto/responses/check_permission_response.proto
-//
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/responses/check_permission_response.proto
+// version: 1.0.0
+// guid: 909a647b-cd2d-44d1-b612-5ea1e54bda39
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
-
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Response indicating whether the user has the requested permission.
+ */
+message CheckPermissionResponse {
+  // True if the user possesses the permission
+  bool allowed = 1;
+}

--- a/pkg/auth/proto/types/auth_context.proto
+++ b/pkg/auth/proto/types/auth_context.proto
@@ -1,18 +1,32 @@
-// filepath: pkg/auth/proto/types/auth_context.proto
-// file: auth/proto/types/auth_context.proto
-//
-// Type definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/types/auth_context.proto
+// version: 1.0.0
+// guid: 70848c6a-eeb6-46ee-b108-9159435b2475
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add type definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * AuthContext carries user identity and authorization details
+ * generated during authentication.
+ */
+message AuthContext {
+  // ID of the authenticated user
+  string user_id = 1;
+
+  // Roles assigned to the user
+  repeated string roles = 2;
+
+  // Permissions granted to the user
+  repeated string permissions = 3;
+
+  // When this context was generated
+  google.protobuf.Timestamp issued_at = 4 [lazy = true];
+
+  // Arbitrary metadata passed between services
+  map<string, string> metadata = 5;
+}


### PR DESCRIPTION
## Summary
- implement Permission and AuthContext messages
- define MFAType enum
- add CheckPermission request/response messages
- document progress for Auth protobufs
- note progress in linked issues

## Testing
- `make proto-compile` *(fails: compilation failed for 1089 files)*

------
https://chatgpt.com/codex/tasks/task_e_68805888d01c832198151b5cd4e821f2