### PR TITLE
Implement queue publish and offset proto messages

### DIFF
--- a/.github/doc-updates/3f08d6c9-b5e5-490a-8918-4553d4a60418.json
+++ b/.github/doc-updates/3f08d6c9-b5e5-490a-8918-4553d4a60418.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "Queue module progress: implemented publish and offset request/response messages (approx. 8% complete)",
+  "guid": "3f08d6c9-b5e5-490a-8918-4553d4a60418",
+  "created_at": "2025-07-23T03:41:23Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/76d64133-df96-41d6-9cc1-b251742ef6e9.json
+++ b/.github/doc-updates/76d64133-df96-41d6-9cc1-b251742ef6e9.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented additional Queue protobuf definitions for publish and offset operations",
+  "guid": "76d64133-df96-41d6-9cc1-b251742ef6e9",
+  "created_at": "2025-07-23T03:41:04Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/83e2ee1c-1795-4be0-b9ea-bd5c355c84d8.json
+++ b/.github/doc-updates/83e2ee1c-1795-4be0-b9ea-bd5c355c84d8.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "after",
+  "content": "July 30, 2025 - Implemented PublishRequest, PublishResponse, CommitOffsetRequest and GetOffsetResponse. Queue module completion: 15/177 files (~8%).",
+  "guid": "83e2ee1c-1795-4be0-b9ea-bd5c355c84d8",
+  "created_at": "2025-07-23T03:41:34Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ab202f8b-bb97-4fd8-89a9-0e48839c3894.json
+++ b/.github/doc-updates/ab202f8b-bb97-4fd8-89a9-0e48839c3894.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement publish and offset queue protobufs",
+  "guid": "ab202f8b-bb97-4fd8-89a9-0e48839c3894",
+  "created_at": "2025-07-23T03:41:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/issue_updates.json
+++ b/issue_updates.json
@@ -1,20 +1,8 @@
 [
   {
     "action": "create",
-    "title": "Implement TransactionService and MigrationService protobufs",
-    "body": "Add new protobuf service definitions and associated request/response messages for database migrations and transaction status.",
-    "labels": ["codex", "module:database", "enhancement"]
-  },
-  {
-    "action": "update",
-    "number": 74,
-    "state": "closed",
-    "labels": ["completed"]
-  },
-  {
-    "action": "update",
-    "number": 75,
-    "state": "closed",
-    "labels": ["completed"]
+    "title": "Queue: implement publish and offset protos",
+    "body": "Implement PublishRequest/PublishResponse and CommitOffsetRequest/GetOffsetResponse for queue module to expand pub-sub functionality.",
+    "labels": ["module:queue", "type:protobuf", "enhancement"]
   }
 ]

--- a/pkg/queue/proto/requests/commit_offset_request.proto
+++ b/pkg/queue/proto/requests/commit_offset_request.proto
@@ -1,18 +1,33 @@
-// filepath: pkg/queue/proto/requests/commit_offset_request.proto
-// file: queue/proto/requests/commit_offset_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/commit_offset_request.proto
+// version: 1.0.0
+// guid: dd17ade2-5399-4fe8-83ba-ffe1227da728
+
+syntax = "proto3";
+// CommitOffsetRequest records the latest processed offset for a
+// consumer group. This allows the queue provider to resume message
+// delivery from the correct position on reconnect.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// CommitOffsetRequest stores the offset a consumer has successfully
+// processed within a queue or topic.
+message CommitOffsetRequest {
+  // Name of the queue or topic.
+  string queue_name = 1;
+
+  // Identifier for the consumer group.
+  string consumer_group = 2;
+
+  // Offset that was last processed successfully.
+  int64 offset = 3;
+
+  // Optional request metadata for tracing and auth.
+  gcommon.v1.common.RequestMetadata metadata = 4;
+}

--- a/pkg/queue/proto/requests/publish_request.proto
+++ b/pkg/queue/proto/requests/publish_request.proto
@@ -1,18 +1,35 @@
-// filepath: pkg/queue/proto/requests/publish_request.proto
-// file: queue/proto/requests/publish_request.proto
-//
-// Request definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/requests/publish_request.proto
+// version: 1.0.0
+// guid: 59dc8120-bc2f-4d56-a9f1-f0957cb9bafb
+
+syntax = "proto3";
+// PublishRequest publishes a single message to a named topic. It is
+// used for pub/sub style messaging where consumers subscribe to
+// topics rather than specific queues.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
+import "pkg/queue/proto/messages/queue_message.proto";
+import "pkg/queue/proto/messages/delivery_options.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// PublishRequest contains all information required to publish a
+// message to a topic.
+message PublishRequest {
+  // Name of the topic to publish to.
+  string topic_name = 1;
+
+  // Message to publish.
+  QueueMessage message = 2;
+
+  // Optional delivery parameters controlling retries and delays.
+  DeliveryOptions delivery_options = 3;
+
+  // Standard request metadata for tracing and auth.
+  gcommon.v1.common.RequestMetadata metadata = 4;
+}

--- a/pkg/queue/proto/responses/get_offset_response.proto
+++ b/pkg/queue/proto/responses/get_offset_response.proto
@@ -1,18 +1,28 @@
-// filepath: pkg/queue/proto/responses/get_offset_response.proto
-// file: queue/proto/responses/get_offset_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/get_offset_response.proto
+// version: 1.0.0
+// guid: 28ce7fa9-da40-4119-8167-285e4ff6179a
+
+syntax = "proto3";
+// GetOffsetResponse returns the current committed offset for a
+// consumer group within a queue or topic.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// GetOffsetResponse provides offset information for a consumer group.
+message GetOffsetResponse {
+  // The currently committed offset.
+  int64 offset = 1;
+
+  // Name of the queue or topic.
+  string queue_name = 2;
+
+  // Optional request metadata.
+  gcommon.v1.common.RequestMetadata metadata = 3;
+}

--- a/pkg/queue/proto/responses/publish_response.proto
+++ b/pkg/queue/proto/responses/publish_response.proto
@@ -1,18 +1,32 @@
-// filepath: pkg/queue/proto/responses/publish_response.proto
-// file: queue/proto/responses/publish_response.proto
-//
-// Response definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/responses/publish_response.proto
+// version: 1.0.0
+// guid: 8b12b279-f7c6-40fe-9147-4a663fb0c9c6
+
+syntax = "proto3";
+// PublishResponse reports the outcome of publishing a message to a
+// topic.
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/common.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// PublishResponse contains the identifier of the published message
+// and success status.
+message PublishResponse {
+  // Unique identifier of the message as stored by the broker.
+  string message_id = 1;
+
+  // Whether the publish operation succeeded.
+  bool success = 2;
+
+  // Error information when success is false.
+  gcommon.v1.common.Error error = 3;
+
+  // Request metadata echoed back for tracing.
+  gcommon.v1.common.RequestMetadata request_metadata = 4;
+}


### PR DESCRIPTION
## Summary
- add commit offset & publish protobuf messages for queue module
- add issue update for queue protobuf implementation
- document queue progress via doc updates

## Testing
- `make proto-compile` *(fails: Compilation failed for 1089 files)*

------
https://chatgpt.com/codex/tasks/task_e_6880588c3d3c83218f347fc8cb3adef3