### PR TITLE
Add PebbleConfig proto and update plan

### DIFF
--- a/.github/doc-updates/29ffb04b-0a17-42aa-874f-aabc78e7778b.json
+++ b/.github/doc-updates/29ffb04b-0a17-42aa-874f-aabc78e7778b.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "### July 23, 2025 - Added PebbleConfig protobuf for Pebble driver",
+  "guid": "29ffb04b-0a17-42aa-874f-aabc78e7778b",
+  "created_at": "2025-07-23T03:44:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/89237136-7f9b-4912-ad4f-8483ebf652f2.json
+++ b/.github/doc-updates/89237136-7f9b-4912-ad4f-8483ebf652f2.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added PebbleConfig protobuf for Pebble driver",
+  "guid": "89237136-7f9b-4912-ad4f-8483ebf652f2",
+  "created_at": "2025-07-23T03:44:03Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a3c423a0-065f-4ccc-8139-de51ebcb00c9.json
+++ b/.github/doc-updates/a3c423a0-065f-4ccc-8139-de51ebcb00c9.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add PebbleConfig protobuf message",
+  "guid": "a3c423a0-065f-4ccc-8139-de51ebcb00c9",
+  "created_at": "2025-07-23T03:43:55Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/a7ed26cd-c023-49c6-a5e5-e9d6431a88ef.json
+++ b/.github/issue-updates/a7ed26cd-c023-49c6-a5e5-e9d6431a88ef.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Pebble DB: Add configuration protobuf",
+  "body": "Define PebbleConfig proto message for Pebble driver",
+  "labels": ["enhancement", "database", "proto"],
+  "guid": "a7ed26cd-c023-49c6-a5e5-e9d6431a88ef",
+  "legacy_guid": "create-pebble-db-add-configuration-protobuf-2025-07-23"
+}

--- a/pkg/db/proto/database.proto
+++ b/pkg/db/proto/database.proto
@@ -99,6 +99,7 @@ import public "pkg/db/proto/types/column_metadata.proto";
 import public "pkg/db/proto/types/migration_script.proto";
 import public "pkg/db/proto/types/query_parameter.proto";
 import public "pkg/db/proto/types/row.proto";
+import public "pkg/db/proto/types/pebble_config.proto";
 
 import "google/protobuf/go_features.proto";
 

--- a/pkg/db/proto/types/pebble_config.proto
+++ b/pkg/db/proto/types/pebble_config.proto
@@ -1,0 +1,33 @@
+// file: pkg/db/proto/types/pebble_config.proto
+// version: 1.0.0
+// guid: 3d548f91-9c4d-4fe7-b610-fd2cafd073ef
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * PebbleConfig represents Pebble-specific configuration options
+ * for the embedded key-value store driver.
+ */
+message PebbleConfig {
+  // Path is the directory where the database files are stored
+  string path = 1;
+
+  // CacheSize is the size of the block cache in bytes
+  int64 cache_size = 2;
+
+  // MemtableSize is the memtable size in bytes
+  int64 memtable_size = 3;
+
+  // MaxOpenFiles is the maximum number of open files
+  int32 max_open_files = 4;
+
+  // Compression enables on-disk compression when true
+  bool compression = 5;
+}

--- a/scripts/validate-protos.sh
+++ b/scripts/validate-protos.sh
@@ -14,8 +14,9 @@ print_status "Running protobuf compilation test"
 
 # Compile all proto files with protoc to verify they compile
 proto_failures=()
+PROTO_INCLUDE="$(go env GOPATH)/pkg/mod/google.golang.org/protobuf@*/src"
 for proto in $(find pkg -name "*.proto" -type f); do
-    if ! protoc --proto_path=. --go_out=/tmp --go-grpc_out=/tmp "$proto" 2> /dev/null; then
+    if ! protoc --proto_path=. --proto_path="$PROTO_INCLUDE" --go_out=/tmp --go-grpc_out=/tmp "$proto" 2> /dev/null; then
         proto_failures+=("$proto")
     fi
 done


### PR DESCRIPTION
## Summary

Implemented configuration message for the Pebble database driver and updated documentation.

## Issues Addressed

### feat(db): add PebbleConfig protobuf

**Description:**
- Added new `PebbleConfig` message to configure the Pebble key‑value store.
- Added import in `database.proto` aggregator.
- Updated validation script to include Go module proto path.
- Created issue and documentation updates for tracking.

**Files Modified:**
- [`pkg/db/proto/types/pebble_config.proto`](./pkg/db/proto/types/pebble_config.proto) – new protobuf message | [[diff]](../../pull/PR_NUMBER/files#diff-NEW) [[repo]](../../blob/main/pkg/db/proto/types/pebble_config.proto)
- [`pkg/db/proto/database.proto`](./pkg/db/proto/database.proto) – public import for PebbleConfig | [[diff]](../../pull/PR_NUMBER/files#diff-NEW) [[repo]](../../blob/main/pkg/db/proto/database.proto)
- [`scripts/validate-protos.sh`](./scripts/validate-protos.sh) – added GOPATH include path | [[diff]](../../pull/PR_NUMBER/files#diff-NEW) [[repo]](../../blob/main/scripts/validate-protos.sh)
- Documentation updates generated in `.github/doc-updates/`.
- Issue file `.github/issue-updates/a7ed26cd-c023-49c6-a5e5-e9d6431a88ef.json` created.

## Testing

- `make proto-compile` *(fails: protoc lacks Edition 2023 support)*


------
https://chatgpt.com/codex/tasks/task_e_6880589b8d6083219d5df02cdf1f8542