### PR TITLE
Add CockroachDB config proto

### DIFF
--- a/.github/doc-updates/0d1047d9-0f7f-490f-88eb-d5d71b7b4b04.json
+++ b/.github/doc-updates/0d1047d9-0f7f-490f-88eb-d5d71b7b4b04.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_HANDOFF_COMPLETE.md",
+  "mode": "append",
+  "content": "Created CockroachConfig proto",
+  "guid": "0d1047d9-0f7f-490f-88eb-d5d71b7b4b04",
+  "created_at": "2025-07-23T03:40:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/6d2ff9e9-fe65-45c9-88e7-6ea044b2e5fb.json
+++ b/.github/doc-updates/6d2ff9e9-fe65-45c9-88e7-6ea044b2e5fb.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Implemented CockroachConfig message for CockroachDB driver",
+  "guid": "6d2ff9e9-fe65-45c9-88e7-6ea044b2e5fb",
+  "created_at": "2025-07-23T03:40:03Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/6fea8390-b7b8-4806-9c06-b0fa0c96ab5c.json
+++ b/.github/doc-updates/6fea8390-b7b8-4806-9c06-b0fa0c96ab5c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement CockroachDB config protobuf message",
+  "guid": "6fea8390-b7b8-4806-9c06-b0fa0c96ab5c",
+  "created_at": "2025-07-23T03:39:55Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/97b9983e-5ddb-4edc-b5d0-6cd6d3677857.json
+++ b/.github/doc-updates/97b9983e-5ddb-4edc-b5d0-6cd6d3677857.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added CockroachDB config protobuf",
+  "guid": "97b9983e-5ddb-4edc-b5d0-6cd6d3677857",
+  "created_at": "2025-07-23T03:39:57Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/be6a3049-ede6-41bb-8b59-7f71659b8648.json
+++ b/.github/doc-updates/be6a3049-ede6-41bb-8b59-7f71659b8648.json
@@ -1,0 +1,16 @@
+{
+  "file": "PACKAGE_NAMING_RESOLUTION.md",
+  "mode": "append",
+  "content": "Document CockroachDB proto addition",
+  "guid": "be6a3049-ede6-41bb-8b59-7f71659b8648",
+  "created_at": "2025-07-23T03:40:14Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/db1e796e-a2bb-45c8-8d27-eb01cb974606.json
+++ b/.github/doc-updates/db1e796e-a2bb-45c8-8d27-eb01cb974606.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "Added CockroachDB configuration protobuf description",
+  "guid": "db1e796e-a2bb-45c8-8d27-eb01cb974606",
+  "created_at": "2025-07-23T03:40:08Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e19bb783-352b-475c-95c5-16bc1ddda877.json
+++ b/.github/doc-updates/e19bb783-352b-475c-95c5-16bc1ddda877.json
@@ -1,0 +1,16 @@
+{
+  "file": "SESSION_SUMMARY.md",
+  "mode": "append",
+  "content": "Implemented CockroachConfig protobuf",
+  "guid": "e19bb783-352b-475c-95c5-16bc1ddda877",
+  "created_at": "2025-07-23T03:40:04Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/7165a812-967c-4d94-aec9-5b726925ae31.json
+++ b/.github/issue-updates/7165a812-967c-4d94-aec9-5b726925ae31.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "CockroachDB Config Protobufs",
+  "body": "Implement CockroachConfig and related messages for database module",
+  "labels": ["enhancement", "proto", "cockroachdb"],
+  "guid": "7165a812-967c-4d94-aec9-5b726925ae31",
+  "legacy_guid": "create-cockroachdb-config-protobufs-2025-07-23"
+}

--- a/pkg/db/proto/database.proto
+++ b/pkg/db/proto/database.proto
@@ -37,7 +37,7 @@ import public "pkg/db/proto/services/migration_service.proto";
 import public "pkg/db/proto/enums/consistency_level.proto";
 import public "pkg/db/proto/enums/isolation_level.proto";
 
-// Messages (14 total)
+// Messages (15 total)
 import public "pkg/db/proto/messages/batch_execute_options.proto";
 import public "pkg/db/proto/messages/batch_operation.proto";
 import public "pkg/db/proto/messages/batch_operation_result.proto";
@@ -52,6 +52,7 @@ import public "pkg/db/proto/messages/query_stats.proto";
 import public "pkg/db/proto/messages/result_set.proto";
 import public "pkg/db/proto/messages/transaction_options.proto";
 import public "pkg/db/proto/messages/migration_info.proto";
+import public "pkg/db/proto/messages/cockroach_config.proto";
 
 // Request types (21 total)
 import public "pkg/db/proto/requests/begin_transaction_request.proto";

--- a/pkg/db/proto/messages/cockroach_config.proto
+++ b/pkg/db/proto/messages/cockroach_config.proto
@@ -1,0 +1,45 @@
+// file: pkg/db/proto/messages/cockroach_config.proto
+// version: 1.0.0
+// guid: a505881e-946a-4a19-9fd5-1e81405e1f73
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * CockroachConfig provides CockroachDB-specific connection configuration.
+ * Includes retry behavior and identification options for robust connections.
+ */
+message CockroachConfig {
+  // Host is the database host.
+  string host = 1;
+
+  // Port is the database port.
+  int32 port = 2;
+
+  // User is the database user.
+  string user = 3;
+
+  // Password is the database password.
+  string password = 4;
+
+  // Database is the database name.
+  string database = 5;
+
+  // SSLMode is the SSL mode.
+  string ssl_mode = 6;
+
+  // ApplicationName is the application name.
+  string application_name = 7;
+
+  // RetryBackoffFactor is the retry backoff factor.
+  float retry_backoff_factor = 8;
+
+  // MaxRetries is the maximum number of retries.
+  int32 max_retries = 9;
+}


### PR DESCRIPTION
## Summary
- create `CockroachConfig` protobuf for CockroachDB driver
- include new config in database aggregator
- document CockroachDB protobuf implementation

## Testing
- `make proto-compile` *(fails: Compilation failed)*
- `buf lint` *(fails: buf version error)*

------
https://chatgpt.com/codex/tasks/task_e_688058b00fe083218a85069efb7685b5