### PR TITLE
Implement Notification subscription protobufs

### DIFF
--- a/.github/issue-updates/d217fcc9-b050-4c41-9955-bc42b18f8bca.json
+++ b/.github/issue-updates/d217fcc9-b050-4c41-9955-bc42b18f8bca.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Notification: implement subscription management protobufs",
+  "body": "Add GetPreferences and UpdatePreferences requests/responses with service methods",
+  "labels": ["codex", "module:notification", "enhancement"],
+  "guid": "d217fcc9-b050-4c41-9955-bc42b18f8bca",
+  "legacy_guid": "create-notification-implement-subscription-management-protobufs-2025-07-23"
+}

--- a/pkg/notification/proto/requests/get_preferences_request.proto
+++ b/pkg/notification/proto/requests/get_preferences_request.proto
@@ -1,0 +1,24 @@
+// file: pkg/notification/proto/requests/get_preferences_request.proto
+// version: 1.0.0
+// guid: fb16c45a-545c-4d05-b3fd-34dbc4a9d0c1
+
+edition = "2023";
+
+package gcommon.v1.notification;
+
+import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/notification/proto;notificationpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * GetPreferencesRequest retrieves a user's current notification preferences.
+ */
+message GetPreferencesRequest {
+  // Standard request metadata for tracing and auth.
+  gcommon.v1.common.RequestMetadata metadata = 1;
+
+  // Identifier for the user whose preferences are being requested.
+  string user_id = 2;
+}

--- a/pkg/notification/proto/responses/get_preferences_response.proto
+++ b/pkg/notification/proto/responses/get_preferences_response.proto
@@ -1,0 +1,25 @@
+// file: pkg/notification/proto/responses/get_preferences_response.proto
+// version: 1.0.0
+// guid: 3c2f540d-f827-4df1-9afe-6f31f6d73dd9
+
+edition = "2023";
+
+package gcommon.v1.notification;
+
+import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/response_metadata.proto";
+import "pkg/notification/proto/messages/subscription_preferences.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/notification/proto;notificationpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * GetPreferencesResponse returns a user's subscription preferences.
+ */
+message GetPreferencesResponse {
+  // Current subscription preferences.
+  SubscriptionPreferences preferences = 1;
+
+  // Response metadata for rate limiting and tracing.
+  gcommon.v1.common.ResponseMetadata metadata = 2;
+}


### PR DESCRIPTION
## Summary

Adds subscription management protobufs for notifications and updates documentation via scripts.

## Issues Addressed

### docs(notification): document subscription preferences

**Description:** Records implementation of preferences RPCs and updates README progress metrics.

**Files Modified:**
- [`CHANGELOG.md`](./CHANGELOG.md) - added changelog entry | [[diff]](../../pull/PR_NUMBER/files#diff-CHANGELOG) [[repo]](../../blob/main/CHANGELOG.md)
- [`README.md`](./README.md) - noted subscription protobufs | [[diff]](../../pull/PR_NUMBER/files#diff-README) [[repo]](../../blob/main/README.md)
- [`TODO.md`](./TODO.md) - added NotificationService task | [[diff]](../../pull/PR_NUMBER/files#diff-TODO) [[repo]](../../blob/main/TODO.md)

## Testing

- ❌ `make clean-rebuild` (protobuf compilation failed)
- ✅ `python3 doc_update_manager.py --updates-dir new_updates`


------
https://chatgpt.com/codex/tasks/task_e_688058cb10148321964396c354b8e3ae