### PR TITLE
Implement web health check config protobuf

### DIFF
--- a/.github/doc-updates/16c85dce-b2f3-4035-92ee-f82c11cc71f2.json
+++ b/.github/doc-updates/16c85dce-b2f3-4035-92ee-f82c11cc71f2.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement Web HealthCheckConfig protobuf",
+  "guid": "16c85dce-b2f3-4035-92ee-f82c11cc71f2",
+  "created_at": "2025-07-28T03:17:39Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/57e94cef-b7aa-46cb-a337-92dadb55c97d.json
+++ b/.github/doc-updates/57e94cef-b7aa-46cb-a337-92dadb55c97d.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 26, 2025 - Implemented HealthCheckConfig message for Web module",
+  "guid": "57e94cef-b7aa-46cb-a337-92dadb55c97d",
+  "created_at": "2025-07-28T03:17:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b5b7c038-133f-4d7b-bda1-01a866129ef5.json
+++ b/.github/doc-updates/b5b7c038-133f-4d7b-bda1-01a866129ef5.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented Web HealthCheckConfig protobuf",
+  "guid": "b5b7c038-133f-4d7b-bda1-01a866129ef5",
+  "created_at": "2025-07-28T03:17:36Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/web/proto/messages/health_check_config.proto
+++ b/pkg/web/proto/messages/health_check_config.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/messages/health_check_config.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7aea6b7c-133f-4443-b7b6-c1cdeb194f0b
 
 edition = "2023";
@@ -11,7 +11,23 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// HealthCheckConfig message definition.
+// HealthCheckConfig defines parameters for performing HTTP health checks.
 message HealthCheckConfig {
-  string placeholder = 1;
+  // HTTP path used for the health check request.
+  string path = 1;
+
+  // Interval between health checks in seconds.
+  double interval_seconds = 2;
+
+  // Timeout for a single health check in seconds.
+  double timeout_seconds = 3;
+
+  // Expected HTTP status code indicating a healthy response.
+  int32 expected_status = 4;
+
+  // Additional headers to include with the request.
+  map<string, string> headers = 5;
+
+  // Whether the health check is enabled.
+  bool enabled = 6;
 }


### PR DESCRIPTION
## Summary
- implement `HealthCheckConfig` message in `web` module
- add TODO, changelog, and implementation plan updates via script

## Testing
- `./scripts/validate-protos.sh` *(fails: compilation failed for 1098 files)*
- `go test ./...` *(fails: module lookup disabled by -mod=vendor)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea8536d88321b43e2fc0f872c7e6