### PR TITLE
Implement web cache config

### DIFF
--- a/.github/doc-updates/04b82b29-a2cb-4b8d-a6f9-b5c2558fabba.json
+++ b/.github/doc-updates/04b82b29-a2cb-4b8d-a6f9-b5c2558fabba.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Web cache config and admin service implemented",
+  "guid": "04b82b29-a2cb-4b8d-a6f9-b5c2558fabba",
+  "created_at": "2025-07-28T03:19:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e9e98f39-b1f5-49c4-ba2e-cbad0db7ad12.json
+++ b/.github/doc-updates/e9e98f39-b1f5-49c4-ba2e-cbad0db7ad12.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Implemented web cache config and admin service",
+  "guid": "e9e98f39-b1f5-49c4-ba2e-cbad0db7ad12",
+  "created_at": "2025-07-28T03:19:34Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f6ddfec1-25c6-47ab-8458-282af4158428.json
+++ b/.github/doc-updates/f6ddfec1-25c6-47ab-8458-282af4158428.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Implemented web cache configuration message and admin service",
+  "guid": "f6ddfec1-25c6-47ab-8458-282af4158428",
+  "created_at": "2025-07-28T03:19:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/web/proto/messages/cache_config.proto
+++ b/pkg/web/proto/messages/cache_config.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/messages/cache_config.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 21e9abdf-bf09-4c22-b45b-eb9c092d9664
 
 edition = "2023";
@@ -7,11 +7,27 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/common/proto/messages/cache_policy.proto";
+import "pkg/web/proto/enums/cache_strategy.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// CacheConfig message definition.
+// CacheConfig defines caching behavior for web responses.
 message CacheConfig {
-  string placeholder = 1;
+  // Selected cache strategy for responses
+  CacheStrategy strategy = 1;
+
+  // Detailed cache policy settings
+  gcommon.v1.common.CachePolicy policy = 2 [lazy = true];
+
+  // Override time to live for web resources
+  google.protobuf.Duration ttl = 3;
+
+  // Whether caching is enabled for this server
+  bool enabled = 4;
+
+  // Optional namespace or cache name
+  string cache_name = 5;
 }

--- a/pkg/web/proto/services/web_admin_service.proto
+++ b/pkg/web/proto/services/web_admin_service.proto
@@ -1,18 +1,32 @@
 // filepath: pkg/web/proto/services/web_admin_service.proto
-// file: web/proto/services/web_admin_service.proto
+// file: pkg/web/proto/services/web_admin_service.proto
 //
-// Service definitions for web module
-// TODO: Implement actual protobuf definitions
+// Administrative service for managing web server cache settings.
 //
 edition = "2023";
 
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/empty.proto";
+import "pkg/web/proto/messages/cache_config.proto";
+import "pkg/cache/proto/requests/flush_request.proto";
+import "pkg/cache/proto/responses/flush_response.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add service definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the web module requirements
+/**
+ * WebAdminService provides cache administration endpoints
+ * for web server management tools.
+ */
+service WebAdminService {
+  // Retrieve current cache configuration
+  rpc GetCacheConfig(google.protobuf.Empty) returns (CacheConfig);
+
+  // Update cache configuration
+  rpc UpdateCacheConfig(CacheConfig) returns (google.protobuf.Empty);
+
+  // Flush all cached entries
+  rpc FlushCache(gcommon.v1.cache.FlushRequest) returns (gcommon.v1.cache.FlushResponse);
+}


### PR DESCRIPTION
## Summary
- implement CacheConfig message in web module
- add WebAdminService with methods for caching management
- record doc updates for TODO, changelog, and implementation plan

## Issues Addressed

### feat(web): implement cache protobufs
- [`pkg/web/proto/messages/cache_config.proto`](./pkg/web/proto/messages/cache_config.proto) - define cache settings
- [`pkg/web/proto/services/web_admin_service.proto`](./pkg/web/proto/services/web_admin_service.proto) - add admin service

## Testing
- `protoc --proto_path=. --proto_path=$(go env GOPATH)/pkg/mod --go_out=/tmp/proto_gen --go-grpc_out=/tmp/proto_gen pkg/web/proto/messages/cache_config.proto pkg/web/proto/services/web_admin_service.proto` *(failed: edition 2023 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea753cc88321b5c192bb38c85756