### PR TITLE
Implement additional auth protobufs

### DIFF
--- a/.github/doc-updates/056a6acf-7252-4638-bdf9-914b13ca015d.json
+++ b/.github/doc-updates/056a6acf-7252-4638-bdf9-914b13ca015d.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Finish remaining auth protobuf implementations",
+  "guid": "056a6acf-7252-4638-bdf9-914b13ca015d",
+  "created_at": "2025-07-28T03:25:03Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/3ad4e0ad-2d85-4434-aa86-f1b5a5b768ce.json
+++ b/.github/doc-updates/3ad4e0ad-2d85-4434-aa86-f1b5a5b768ce.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Implemented refresh_token, security_policy, audit_event, get_role_request/response, get_permission_request/response",
+  "guid": "3ad4e0ad-2d85-4434-aa86-f1b5a5b768ce",
+  "created_at": "2025-07-28T03:25:10Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5f90d03a-122f-4cfa-9fef-5507758ac16e.json
+++ b/.github/doc-updates/5f90d03a-122f-4cfa-9fef-5507758ac16e.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented new auth protobufs: refresh token, security policy, audit event",
+  "guid": "5f90d03a-122f-4cfa-9fef-5507758ac16e",
+  "created_at": "2025-07-28T03:24:53Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/auth/proto/requests/get_permission_request.proto
+++ b/pkg/auth/proto/requests/get_permission_request.proto
@@ -1,18 +1,22 @@
-// filepath: pkg/auth/proto/requests/get_permission_request.proto
-// file: auth/proto/requests/get_permission_request.proto
-//
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/requests/get_permission_request.proto
+// version: 1.0.0
+// guid: 0658829b-708a-480e-942d-42b7ce0e4fdd
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Request to fetch details about a permission entry.
+ */
+message GetPermissionRequest {
+  // Permission identifier
+  string permission_id = 1;
+
+  // Request metadata for tracing and correlation
+  gcommon.v1.common.RequestMetadata metadata = 2;
+}

--- a/pkg/auth/proto/requests/get_role_request.proto
+++ b/pkg/auth/proto/requests/get_role_request.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/requests/get_role_request.proto
-// file: auth/proto/requests/get_role_request.proto
-//
-// Request definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/requests/get_role_request.proto
+// version: 1.0.0
+// guid: 554e7499-0070-40fe-a99c-3428bec2651f
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
-import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
-option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Request to retrieve details about a specific role.
+ */
+message GetRoleRequest {
+  // Unique identifier of the role
+  string role_id = 1;
+
+  // Include permissions in the response
+  bool include_permissions = 2;
+
+  // Request metadata for tracing
+  gcommon.v1.common.RequestMetadata metadata = 3;
+}

--- a/pkg/auth/proto/responses/get_permission_response.proto
+++ b/pkg/auth/proto/responses/get_permission_response.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/responses/get_permission_response.proto
-// file: auth/proto/responses/get_permission_response.proto
-//
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/responses/get_permission_response.proto
+// version: 1.0.0
+// guid: fabb3420-290d-4f58-8be9-b363ef1adefd
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/auth/proto/messages/permission.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Response for a permission retrieval request.
+ */
+message GetPermissionResponse {
+  // Permission details if found
+  Permission permission = 1 [lazy = true];
+
+  // Error information if retrieval failed
+  gcommon.v1.common.Error error = 2 [lazy = true];
+}

--- a/pkg/auth/proto/responses/get_role_response.proto
+++ b/pkg/auth/proto/responses/get_role_response.proto
@@ -1,18 +1,25 @@
-// filepath: pkg/auth/proto/responses/get_role_response.proto
-// file: auth/proto/responses/get_role_response.proto
-//
-// Response definitions for auth module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/auth/proto/responses/get_role_response.proto
+// version: 1.0.0
+// guid: 4da329f9-4bb7-4695-85e7-a7083ae930e1
+
 edition = "2023";
 
 package gcommon.v1.auth;
 
 import "google/protobuf/go_features.proto";
+import "pkg/auth/proto/types/role.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the auth module requirements
+/**
+ * Response containing role information or an error.
+ */
+message GetRoleResponse {
+  // Role details if found
+  Role role = 1 [lazy = true];
+
+  // Error information if retrieval failed
+  gcommon.v1.common.Error error = 2 [lazy = true];
+}

--- a/pkg/auth/proto/types/audit_event.proto
+++ b/pkg/auth/proto/types/audit_event.proto
@@ -1,0 +1,30 @@
+// file: pkg/auth/proto/types/audit_event.proto
+// version: 1.0.0
+// guid: 07442bc2-38fe-42b3-aecd-0ffda724fa86
+
+edition = "2023";
+
+package gcommon.v1.auth;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * AuditEvent records authentication-related actions for auditing.
+ */
+message AuditEvent {
+  // Type of event (e.g., LOGIN, LOGOUT)
+  string event_type = 1;
+
+  // User ID associated with the event
+  string user_id = 2;
+
+  // Time event occurred
+  google.protobuf.Timestamp timestamp = 3 [lazy = true];
+
+  // Additional metadata about the event
+  map<string, string> metadata = 4;
+}

--- a/pkg/auth/proto/types/refresh_token.proto
+++ b/pkg/auth/proto/types/refresh_token.proto
@@ -1,0 +1,27 @@
+// file: pkg/auth/proto/types/refresh_token.proto
+// version: 1.0.0
+// guid: 19426e54-07ed-40a6-bb1a-739ec97c225f
+
+edition = "2023";
+
+package gcommon.v1.auth;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * Refresh token details for token renewal workflows.
+ */
+message RefreshToken {
+  // Refresh token string
+  string value = 1;
+
+  // Associated user ID
+  string user_id = 2;
+
+  // When the refresh token expires
+  google.protobuf.Timestamp expires_at = 3 [lazy = true];
+}

--- a/pkg/auth/proto/types/security_policy.proto
+++ b/pkg/auth/proto/types/security_policy.proto
@@ -1,0 +1,27 @@
+// file: pkg/auth/proto/types/security_policy.proto
+// version: 1.0.0
+// guid: 1d12dbb5-c796-48b9-beab-f89a58a4d115
+
+edition = "2023";
+
+package gcommon.v1.auth;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/auth/proto;authpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * SecurityPolicy defines account and token security requirements.
+ */
+message SecurityPolicy {
+  // Minimum password length requirement
+  uint32 min_password_length = 1;
+
+  // Password expiration duration
+  google.protobuf.Duration password_ttl = 2;
+
+  // Maximum failed login attempts before lockout
+  uint32 max_failed_attempts = 3;
+}


### PR DESCRIPTION
## Summary
- define RefreshToken, SecurityPolicy, and AuditEvent protobuf types
- add GetRole and GetPermission request/response messages
- document remaining auth protobuf work in TODO and CHANGELOG

## Testing
- `protoc --go_out=. --go-grpc_out=. pkg/auth/proto/types/refresh_token.proto pkg/auth/proto/types/security_policy.proto pkg/auth/proto/types/audit_event.proto pkg/auth/proto/requests/get_role_request.proto pkg/auth/proto/requests/get_permission_request.proto pkg/auth/proto/responses/get_role_response.proto pkg/auth/proto/responses/get_permission_response.proto`
- `buf generate` *(failed: vendor proto requires unavailable gogo.proto)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea6ac6dc83218e0bf7a2058439da