### PR TITLE
Implement DatabaseStatus proto

### DIFF
--- a/.github/doc-updates/3d547882-9765-4d19-bc4d-f14679b252ba.json
+++ b/.github/doc-updates/3d547882-9765-4d19-bc4d-f14679b252ba.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added DatabaseStatus message and DatabaseStatusCode enum for database module",
+  "guid": "3d547882-9765-4d19-bc4d-f14679b252ba",
+  "created_at": "2025-07-28T03:21:39Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/84d01eb5-e432-43e5-a70c-b94c945451c2.json
+++ b/.github/doc-updates/84d01eb5-e432-43e5-a70c-b94c945451c2.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 28, 2025 - Added DatabaseStatusCode enum and DatabaseStatus message",
+  "guid": "84d01eb5-e432-43e5-a70c-b94c945451c2",
+  "created_at": "2025-07-28T03:21:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/eaae9567-9e90-484c-b001-1fe20f67e319.json
+++ b/.github/doc-updates/eaae9567-9e90-484c-b001-1fe20f67e319.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Implemented DatabaseStatusCode enum and DatabaseStatus message for database module",
+  "guid": "eaae9567-9e90-484c-b001-1fe20f67e319",
+  "created_at": "2025-07-28T03:21:36Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b2de81c7-8ebb-470d-ba6a-53999dd88e4b.json
+++ b/.github/issue-updates/b2de81c7-8ebb-470d-ba6a-53999dd88e4b.json
@@ -1,0 +1,11 @@
+{
+  "action": "create",
+  "title": "Implement DatabaseStatus proto",
+  "body": "Add DatabaseStatusCode enum and DatabaseStatus message in DB module for runtime connection status.",
+  "labels": ["db","proto"],
+  "guid": "b2de81c7-8ebb-470d-ba6a-53999dd88e4b",
+  "legacy_guid": "create-implement-databasestatus-proto-2025-07-28",
+  "file_created_at": "2025-07-28T03:20:51Z",
+  "file_modified_at": "2025-07-28T03:20:51Z",
+  "created_at": "2025-07-28T03:20:51Z"
+}

--- a/pkg/db/proto/database.proto
+++ b/pkg/db/proto/database.proto
@@ -36,6 +36,7 @@ import public "pkg/db/proto/services/migration_service.proto";
 // Enums (2 total)
 import public "pkg/db/proto/enums/consistency_level.proto";
 import public "pkg/db/proto/enums/isolation_level.proto";
+import public "pkg/db/proto/enums/database_status_code.proto";
 
 // Messages (16 total)
 import public "pkg/db/proto/messages/batch_execute_options.proto";
@@ -54,6 +55,7 @@ import public "pkg/db/proto/messages/transaction_options.proto";
 import public "pkg/db/proto/messages/migration_info.proto";
 import public "pkg/db/proto/messages/mysql_config.proto";
 import public "pkg/db/proto/messages/mysql_status.proto";
+import public "pkg/db/proto/messages/database_status.proto";
 
 // Request types (21 total)
 import public "pkg/db/proto/requests/begin_transaction_request.proto";

--- a/pkg/db/proto/enums/database_status_code.proto
+++ b/pkg/db/proto/enums/database_status_code.proto
@@ -1,0 +1,27 @@
+// file: pkg/db/proto/enums/database_status_code.proto
+// version: 1.0.0
+// guid: 9849ce1c-df0e-418d-9de6-27b7b1b99d99
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * DatabaseStatusCode represents the health state of a database
+ * connection or service.
+ */
+enum DatabaseStatusCode {
+  // Default unspecified status
+  DATABASE_STATUS_CODE_UNSPECIFIED = 0;
+
+  // Database is reachable and operational
+  DATABASE_STATUS_CODE_OK = 1;
+
+  // Database is unreachable or returned an error
+  DATABASE_STATUS_CODE_ERROR = 2;
+}

--- a/pkg/db/proto/messages/database_status.proto
+++ b/pkg/db/proto/messages/database_status.proto
@@ -1,0 +1,25 @@
+// file: pkg/db/proto/messages/database_status.proto
+// version: 1.0.0
+// guid: 67bfa96b-764e-4290-adc8-2387c9b456b4
+
+edition = "2023";
+
+package gcommon.v1.database;
+
+import "google/protobuf/go_features.proto";
+import "pkg/db/proto/enums/database_status_code.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/db/proto;dbpb";
+option features.(pb.go).api_level = API_HYBRID;
+
+/**
+ * DatabaseStatus reports the current connection status for a
+ * database driver or service.
+ */
+message DatabaseStatus {
+  // Code indicates the health state of the database
+  DatabaseStatusCode code = 1;
+
+  // Human readable status details
+  string message = 2;
+}

--- a/pkg/db/proto/proto.go
+++ b/pkg/db/proto/proto.go
@@ -74,4 +74,5 @@ type (
 	Field          = dbpb_messages.Field
 	Transaction    = dbpb_messages.Transaction
 	BatchOperation = dbpb_messages.BatchOperation
+	DatabaseStatus = dbpb_messages.DatabaseStatus
 )


### PR DESCRIPTION
## Summary
- add DatabaseStatusCode enum and DatabaseStatus message
- update database.proto aggregator imports
- re-export DatabaseStatus in proto.go
- document new proto work and changelog entry via doc-updates
- create issue update for new proto work

## Testing
- `./scripts/validate-protos.sh` *(fails: compilation failed for 1100 files)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea80880083219eb30daaae2abdf7