### PR TITLE
feat: start migrating log protos to 1-1-1 structure

### DIFF
--- a/.github/doc-updates/605a781f-6fc3-4116-b911-8785ee8baa31.json
+++ b/.github/doc-updates/605a781f-6fc3-4116-b911-8785ee8baa31.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "Started migrating LoggerConfig, AppenderConfig, LogStatistics, and ArchiveCriteria to separate files",
+  "guid": "605a781f-6fc3-4116-b911-8785ee8baa31",
+  "created_at": "2025-07-28T03:30:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c27128e6-23d8-4d52-a637-afc7d8c27361.json
+++ b/.github/doc-updates/c27128e6-23d8-4d52-a637-afc7d8c27361.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Started migrating log protobufs to 1-1-1",
+  "guid": "c27128e6-23d8-4d52-a637-afc7d8c27361",
+  "created_at": "2025-07-28T03:29:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/fb4784b5-9734-4612-80cb-fec9bae552d8.json
+++ b/.github/doc-updates/fb4784b5-9734-4612-80cb-fec9bae552d8.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement initial log protobuf refactor",
+  "guid": "fb4784b5-9734-4612-80cb-fec9bae552d8",
+  "created_at": "2025-07-28T03:30:00Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/log/proto/log.proto
+++ b/pkg/log/proto/log.proto
@@ -3,25 +3,29 @@ edition = "2023";
 
 package gcommon.v1.log;
 
-import "pkg/common/proto/common.proto";
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/go_features.proto";
-import public "pkg/log/proto/messages/log_entry.proto";
-import public "pkg/log/proto/messages/source_location.proto";
-import public "pkg/log/proto/messages/error_info.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/common.proto";
+import public "pkg/log/proto/enums/appender_type.proto";
+import public "pkg/log/proto/enums/compression_type.proto";
+import public "pkg/log/proto/enums/filter_type.proto";
+import public "pkg/log/proto/enums/formatter_type.proto";
 import public "pkg/log/proto/enums/log_level.proto";
 import public "pkg/log/proto/enums/log_sort_field.proto";
-import public "pkg/log/proto/enums/appender_type.proto";
-import public "pkg/log/proto/enums/formatter_type.proto";
-import public "pkg/log/proto/enums/filter_type.proto";
 import public "pkg/log/proto/enums/logger_status.proto";
-import public "pkg/log/proto/enums/compression_type.proto";
+import public "pkg/log/proto/messages/appender_config.proto";
+import public "pkg/log/proto/messages/archive_criteria.proto";
+import public "pkg/log/proto/messages/error_info.proto";
+import public "pkg/log/proto/messages/log_entry.proto";
+import public "pkg/log/proto/messages/log_statistics.proto";
+import public "pkg/log/proto/messages/logger_config.proto";
+import public "pkg/log/proto/messages/source_location.proto";
 
-option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
 option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
 
 // LogService provides comprehensive logging capabilities
 service LogService {
@@ -311,25 +315,7 @@ message GetLogStatsResponse {
 }
 
 // Log statistics
-message LogStatistics {
-  // Total log entries
-  int64 total_entries = 1;
-
-  // Entries per second (rate)
-  double entries_per_second = 2;
-
-  // Average entry size
-  int64 average_size = 3;
-
-  // Total size
-  int64 total_size = 4;
-
-  // Error count
-  int64 error_count = 5;
-
-  // Warning count
-  int64 warning_count = 6;
-}
+// message moved to messages/log_statistics.proto
 
 // Admin service messages
 
@@ -346,54 +332,10 @@ message CreateLoggerRequest {
 }
 
 // Logger configuration
-message LoggerConfig {
-  // Log level
-  LogLevel level = 1;
-
-  // Output appenders
-  repeated AppenderConfig appenders = 2;
-
-  // Whether to inherit from parent
-  bool inherit_appenders = 3;
-
-  // Whether to propagate to parent logger
-  bool propagate = 4;
-
-  // Additional properties
-  map<string, string> properties = 5;
-}
+// message moved to messages/logger_config.proto
 
 // Appender configuration
-message AppenderConfig {
-  // Appender name
-  string name = 1;
-
-  // Appender type
-  AppenderType type = 2;
-
-  // Output configuration
-// Appender types
-
-// Output configuration
-message OutputConfig {
-  // Output target (file path, network address, etc.)
-  string target = 1;
-
-  // Additional output options
-  map<string, string> options = 2;
-}
-
-// Formatter configuration
-message FormatterConfig {
-  // Formatter type
-  FormatterType type = 1;
-
-  // Format pattern
-}
-
-
-}
-
+// message moved to messages/appender_config.proto
 
 // Create logger response
 message CreateLoggerResponse {
@@ -494,7 +436,6 @@ message LoggerInfo {
   LoggerStatus status = 8;
 }
 
-
 // Configure appender request
 message ConfigureAppenderRequest {
   // Appender configuration
@@ -556,13 +497,7 @@ message ArchiveLogsRequest {
 }
 
 // Archive criteria
-message ArchiveCriteria {
-  // Older than duration
-  google.protobuf.Duration older_than = 1;
-
-  // Size threshold
-  int64 size_threshold_bytes = 2;
-}
+// message moved to messages/archive_criteria.proto
 
 // Archive logs response
 message ArchiveLogsResponse {

--- a/pkg/log/proto/messages/appender_config.proto
+++ b/pkg/log/proto/messages/appender_config.proto
@@ -1,0 +1,50 @@
+// file: pkg/log/proto/messages/appender_config.proto
+// version: 1.0.0
+// guid: fbec1110-0be5-48a4-8a3a-e748a66b4764
+
+edition = "2023";
+
+package gcommon.v1.log;
+
+import "google/protobuf/go_features.proto";
+import "pkg/log/proto/enums/appender_type.proto";
+import "pkg/log/proto/enums/formatter_type.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
+
+// AppenderConfig describes how logs are output
+message AppenderConfig {
+  // Unique appender name
+  string name = 1;
+
+  // Appender backend type
+  AppenderType type = 2;
+
+  // Output destination details
+  OutputConfig output = 3;
+
+  // Formatting configuration
+  FormatterConfig formatter = 4;
+
+  // Arbitrary appender properties
+  map<string, string> properties = 5;
+
+  // OutputConfig defines the destination for log entries
+  message OutputConfig {
+    // Output target (file path, network address, etc.)
+    string target = 1;
+
+    // Additional output options
+    map<string, string> options = 2;
+  }
+
+  // FormatterConfig defines how log entries are formatted
+  message FormatterConfig {
+    // Formatting strategy
+    FormatterType type = 1;
+
+    // Optional format pattern
+    string pattern = 2;
+  }
+}

--- a/pkg/log/proto/messages/archive_criteria.proto
+++ b/pkg/log/proto/messages/archive_criteria.proto
@@ -1,0 +1,22 @@
+// file: pkg/log/proto/messages/archive_criteria.proto
+// version: 1.0.0
+// guid: b7d23f2c-0017-462f-a6d2-51ca4405bc2c
+
+edition = "2023";
+
+package gcommon.v1.log;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/go_features.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
+
+// ArchiveCriteria defines rules for selecting log files to archive
+message ArchiveCriteria {
+  // Only archive logs older than this duration
+  google.protobuf.Duration older_than = 1;
+
+  // Minimum size threshold in bytes
+  int64 size_threshold_bytes = 2;
+}

--- a/pkg/log/proto/messages/log_statistics.proto
+++ b/pkg/log/proto/messages/log_statistics.proto
@@ -1,0 +1,33 @@
+// file: pkg/log/proto/messages/log_statistics.proto
+// version: 1.0.0
+// guid: 98acfd30-4a7f-43f6-ac8d-f10a598a805a
+
+edition = "2023";
+
+package gcommon.v1.log;
+
+import "google/protobuf/go_features.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
+
+// LogStatistics provides aggregated metrics about log entries
+message LogStatistics {
+  // Total log entries
+  int64 total_entries = 1;
+
+  // Entries per second
+  double entries_per_second = 2;
+
+  // Average entry size
+  int64 average_size = 3;
+
+  // Total size of all log entries
+  int64 total_size = 4;
+
+  // Count of log entries with level ERROR
+  int64 error_count = 5;
+
+  // Count of log entries with level WARNING
+  int64 warning_count = 6;
+}

--- a/pkg/log/proto/messages/logger_config.proto
+++ b/pkg/log/proto/messages/logger_config.proto
@@ -1,0 +1,32 @@
+// file: pkg/log/proto/messages/logger_config.proto
+// version: 1.0.0
+// guid: 37c6c755-fc97-46c2-8116-248fc5a0ce3c
+
+edition = "2023";
+
+package gcommon.v1.log;
+
+import "google/protobuf/go_features.proto";
+import "pkg/log/proto/enums/log_level.proto";
+import "pkg/log/proto/messages/appender_config.proto";
+
+option features.(pb.go).api_level = API_HYBRID;
+option go_package = "github.com/jdfalk/gcommon/pkg/log/proto;logpb";
+
+// LoggerConfig defines configuration for a logger instance
+message LoggerConfig {
+  // Minimum log level for this logger
+  LogLevel level = 1;
+
+  // Output appenders used by this logger
+  repeated AppenderConfig appenders = 2;
+
+  // Inherit appenders from parent logger
+  bool inherit_appenders = 3;
+
+  // Propagate log entries to parent logger
+  bool propagate = 4;
+
+  // Additional logger properties
+  map<string, string> properties = 5;
+}


### PR DESCRIPTION
## Summary
- begin migration of log protobuf definitions to individual files
- add new protobuf messages: `LogStatistics`, `ArchiveCriteria`, `LoggerConfig`, and `AppenderConfig`
- update `log.proto` to import the new definitions
- document the migration in TODO and CHANGELOG

## Testing
- `scripts/validate-protos.sh` *(fails: compilation for 1102 files)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea8b265483219f963bc039a86a09