### PR TITLE
Implement web session protobufs

### DIFF
--- a/.github/doc-updates/0a878621-8c96-4694-b1f7-ab536c02c703.json
+++ b/.github/doc-updates/0a878621-8c96-4694-b1f7-ab536c02c703.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Web: implement session management protobufs",
+  "guid": "0a878621-8c96-4694-b1f7-ab536c02c703",
+  "created_at": "2025-07-28T03:26:58Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/107c2db0-e81f-46bb-ab5a-503cd7d62c72.json
+++ b/.github/doc-updates/107c2db0-e81f-46bb-ab5a-503cd7d62c72.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented session management protobufs for web module",
+  "guid": "107c2db0-e81f-46bb-ab5a-503cd7d62c72",
+  "created_at": "2025-07-28T03:26:55Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/4b23e65f-3dfa-46b9-bbbe-c69974744329.json
+++ b/.github/doc-updates/4b23e65f-3dfa-46b9-bbbe-c69974744329.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "### July 28, 2025 - Web module session management protobufs implemented\\n\\nImplemented SessionConfig and SessionData messages.\\nImplemented session CRUD request/response messages.",
+  "guid": "4b23e65f-3dfa-46b9-bbbe-c69974744329",
+  "created_at": "2025-07-28T03:27:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a783769d-7d7b-410b-b20e-ecfe6a63111c.json
+++ b/.github/doc-updates/a783769d-7d7b-410b-b20e-ecfe6a63111c.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_HANDOFF_COMPLETE.md",
+  "mode": "append",
+  "content": "Implemented session management protobufs for web module",
+  "guid": "a783769d-7d7b-410b-b20e-ecfe6a63111c",
+  "created_at": "2025-07-28T03:27:32Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/issue_updates.json
+++ b/issue_updates.json
@@ -3,12 +3,30 @@
     "action": "create",
     "title": "Queue: implement publish and offset protos",
     "body": "Implement PublishRequest/PublishResponse and CommitOffsetRequest/GetOffsetResponse for queue module to expand pub-sub functionality.",
-    "labels": ["module:queue", "type:protobuf", "enhancement"]
+    "labels": [
+      "module:queue",
+      "type:protobuf",
+      "enhancement"
+    ]
   },
   {
     "action": "create",
     "title": "Implement audit logging protobufs",
     "body": "Add AuditLog message and logout request/response protobuf definitions in auth module.",
-    "labels": ["module:auth", "module:log", "enhancement"]
+    "labels": [
+      "module:auth",
+      "module:log",
+      "enhancement"
+    ]
+  },
+  {
+    "action": "create",
+    "title": "Web: implement session management protobufs",
+    "body": "Implement SessionConfig, SessionData messages and session CRUD request/response protobufs.",
+    "labels": [
+      "module:web",
+      "type:protobuf",
+      "enhancement"
+    ]
   }
 ]

--- a/pkg/web/proto/messages/session_config.proto
+++ b/pkg/web/proto/messages/session_config.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/messages/session_config.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 78ffbac0-1dba-4e18-85e1-ecce179da015
 
 edition = "2023";
@@ -7,11 +7,29 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
+import "pkg/web/proto/enums/cookie_same_site.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // SessionConfig message definition.
 message SessionConfig {
-  string placeholder = 1;
+  // Session idle timeout before automatic expiration
+  google.protobuf.Duration idle_timeout = 1;
+
+  // Absolute session lifetime regardless of activity
+  google.protobuf.Duration absolute_timeout = 2;
+
+  // Name of the session cookie
+  string cookie_name = 3;
+
+  // Use secure cookies (HTTPS only)
+  bool secure_cookies = 4;
+
+  // Restrict cookie to HTTP only
+  bool http_only = 5;
+
+  // Cookie SameSite policy
+  CookieSameSite same_site = 6;
 }

--- a/pkg/web/proto/messages/session_data.proto
+++ b/pkg/web/proto/messages/session_data.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/messages/session_data.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: f93f7cc5-48c6-4b64-98d2-35549cf19b02
 
 edition = "2023";
@@ -7,11 +7,38 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/web/proto/enums/session_state.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // SessionData message definition.
 message SessionData {
-  string placeholder = 1;
+  // Unique session identifier
+  string session_id = 1;
+
+  // User ID associated with the session
+  string user_id = 2;
+
+  // Current session state
+  SessionState state = 3;
+
+  // Session creation timestamp
+  google.protobuf.Timestamp created_at = 4 [lazy = true];
+
+  // Last access timestamp
+  google.protobuf.Timestamp last_access_at = 5 [lazy = true];
+
+  // Session expiration timestamp
+  google.protobuf.Timestamp expires_at = 6 [lazy = true];
+
+  // Client IP address
+  string ip_address = 7;
+
+  // Client user agent
+  string user_agent = 8;
+
+  // Custom session metadata
+  map<string, string> metadata = 9;
 }

--- a/pkg/web/proto/requests/create_session_request.proto
+++ b/pkg/web/proto/requests/create_session_request.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/requests/create_session_request.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1022341d-b551-43d4-b090-2354a82b624c
 
 edition = "2023";
@@ -13,5 +13,9 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // CreateSessionRequest request definition.
 message CreateSessionRequest {
-  string placeholder = 1;
+  // User ID for the new session
+  string user_id = 1;
+
+  // Optional initial metadata
+  map<string, string> metadata = 2;
 }

--- a/pkg/web/proto/requests/delete_session_request.proto
+++ b/pkg/web/proto/requests/delete_session_request.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/requests/delete_session_request.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 90ce1e00-4c38-47bf-b246-fba60817030a
 
 edition = "2023";
@@ -13,5 +13,6 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // DeleteSessionRequest request definition.
 message DeleteSessionRequest {
-  string placeholder = 1;
+  // Identifier of the session to delete
+  string session_id = 1;
 }

--- a/pkg/web/proto/requests/get_session_request.proto
+++ b/pkg/web/proto/requests/get_session_request.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/requests/get_session_request.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5ab16058-a2a8-463c-b101-b1f24df275ef
 
 edition = "2023";
@@ -13,5 +13,6 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // GetSessionRequest request definition.
 message GetSessionRequest {
-  string placeholder = 1;
+  // Identifier of the session to retrieve
+  string session_id = 1;
 }

--- a/pkg/web/proto/requests/list_sessions_request.proto
+++ b/pkg/web/proto/requests/list_sessions_request.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/requests/list_sessions_request.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: a6c1c53c-e5dd-4cbc-9a88-357c8c22e179
 
 edition = "2023";
@@ -13,5 +13,6 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // ListSessionsRequest request definition.
 message ListSessionsRequest {
-  string placeholder = 1;
+  // Filter sessions by user ID (optional)
+  string user_id = 1;
 }

--- a/pkg/web/proto/requests/update_session_request.proto
+++ b/pkg/web/proto/requests/update_session_request.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/requests/update_session_request.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c543371-4882-4a5c-9fe2-481de3738e67
 
 edition = "2023";
@@ -13,5 +13,9 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // UpdateSessionRequest request definition.
 message UpdateSessionRequest {
-  string placeholder = 1;
+  // Identifier of the session to update
+  string session_id = 1;
+
+  // New metadata to apply
+  map<string, string> metadata = 2;
 }

--- a/pkg/web/proto/responses/create_session_response.proto
+++ b/pkg/web/proto/responses/create_session_response.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/responses/create_session_response.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5b7bc14e-bb7d-4d0d-bd5b-c35bc5fb7bda
 
 edition = "2023";
@@ -7,11 +7,13 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "pkg/web/proto/messages/session_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // CreateSessionResponse response definition.
 message CreateSessionResponse {
-  string placeholder = 1;
+  // Newly created session details
+  SessionData session = 1;
 }

--- a/pkg/web/proto/responses/delete_session_response.proto
+++ b/pkg/web/proto/responses/delete_session_response.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/responses/delete_session_response.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4115c974-f373-4e67-aeb0-fff852ec685a
 
 edition = "2023";
@@ -13,5 +13,6 @@ option features.(pb.go).api_level = API_HYBRID;
 
 // DeleteSessionResponse response definition.
 message DeleteSessionResponse {
-  string placeholder = 1;
+  // Indicates if the session was deleted
+  bool success = 1;
 }

--- a/pkg/web/proto/responses/get_session_response.proto
+++ b/pkg/web/proto/responses/get_session_response.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/responses/get_session_response.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: 97fcede8-5243-4901-b423-41a0723fb0c7
 
 edition = "2023";
@@ -7,11 +7,13 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "pkg/web/proto/messages/session_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // GetSessionResponse response definition.
 message GetSessionResponse {
-  string placeholder = 1;
+  // Retrieved session data
+  SessionData session = 1;
 }

--- a/pkg/web/proto/responses/list_sessions_response.proto
+++ b/pkg/web/proto/responses/list_sessions_response.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/responses/list_sessions_response.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: f9b7c78a-576f-4603-9a83-de8d0abb2341
 
 edition = "2023";
@@ -7,11 +7,13 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "pkg/web/proto/messages/session_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // ListSessionsResponse response definition.
 message ListSessionsResponse {
-  string placeholder = 1;
+  // List of active sessions
+  repeated SessionData sessions = 1;
 }

--- a/pkg/web/proto/responses/update_session_response.proto
+++ b/pkg/web/proto/responses/update_session_response.proto
@@ -1,5 +1,5 @@
 // file: pkg/web/proto/responses/update_session_response.proto
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1b380a2-162b-44ad-a6c0-5fd39e3add91
 
 edition = "2023";
@@ -7,11 +7,13 @@ edition = "2023";
 package gcommon.v1.web;
 
 import "google/protobuf/go_features.proto";
+import "pkg/web/proto/messages/session_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/web/proto;webpb";
 option features.(pb.go).api_level = API_HYBRID;
 
 // UpdateSessionResponse response definition.
 message UpdateSessionResponse {
-  string placeholder = 1;
+  // Updated session data
+  SessionData session = 1;
 }


### PR DESCRIPTION
## Summary
- define `SessionConfig` and `SessionData` messages for web module
- implement CRUD requests and responses for sessions
- record progress in implementation plan and changelog
- add TODO entry for session protobufs and issue update

## Testing
- `make validate` *(fails: many protobuf files still missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886ec73a8788321979a58d18edecccf