### PR TITLE
Implement queue configuration protobufs

### DIFF
--- a/.github/doc-updates/85556a99-93f7-46a3-8325-3a4cc3c6924a.json
+++ b/.github/doc-updates/85556a99-93f7-46a3-8325-3a4cc3c6924a.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 31, 2025 - Implemented queue configuration messages and enums",
+  "guid": "85556a99-93f7-46a3-8325-3a4cc3c6924a",
+  "created_at": "2025-07-28T03:36:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/a6932b86-2de1-432b-90d0-c48b52cbfa20.json
+++ b/.github/doc-updates/a6932b86-2de1-432b-90d0-c48b52cbfa20.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented initial queue configuration messages and enums",
+  "guid": "a6932b86-2de1-432b-90d0-c48b52cbfa20",
+  "created_at": "2025-07-28T03:36:02Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e93db97f-85dc-443e-af85-1dcb3156297e.json
+++ b/.github/doc-updates/e93db97f-85dc-443e-af85-1dcb3156297e.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement basic queue configuration messages and enums",
+  "guid": "e93db97f-85dc-443e-af85-1dcb3156297e",
+  "created_at": "2025-07-28T03:36:12Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/f2aae00d-26ba-4152-b3b5-5854d854e805.json
+++ b/.github/issue-updates/f2aae00d-26ba-4152-b3b5-5854d854e805.json
@@ -1,0 +1,12 @@
+{
+  "action": "comment",
+  "number": 88,
+  "body": "Implemented queue configuration messages and enums",
+  "guid": "f2aae00d-26ba-4152-b3b5-5854d854e805",
+  "legacy_guid": "comment-issue-88-2025-07-28",
+  "created_at": "2025-07-28T03:36:23.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/queue/proto/enums/priority_level.proto
+++ b/pkg/queue/proto/enums/priority_level.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/enums/priority_level.proto
-// file: queue/proto/enums/priority_level.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/enums/priority_level.proto
+// version: 1.0.0
+// guid: e13c77fc-1bf7-42ed-947a-6e1ed4914bb2
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,16 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// PriorityLevel defines generic priority classes for queue messages.
+enum PriorityLevel {
+  // Default unspecified priority.
+  PRIORITY_LEVEL_UNSPECIFIED = 0;
+  // Low priority messages are processed after normal traffic.
+  PRIORITY_LEVEL_LOW = 1;
+  // Normal priority for standard workload.
+  PRIORITY_LEVEL_MEDIUM = 2;
+  // High priority messages are processed before others.
+  PRIORITY_LEVEL_HIGH = 3;
+  // Critical messages are processed immediately with highest importance.
+  PRIORITY_LEVEL_CRITICAL = 4;
+}

--- a/pkg/queue/proto/enums/queue_type.proto
+++ b/pkg/queue/proto/enums/queue_type.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/enums/queue_type.proto
-// file: queue/proto/enums/queue_type.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/enums/queue_type.proto
+// version: 1.0.0
+// guid: d6bb0e83-91d3-406a-9a66-519b5860d137
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,16 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// QueueType enumerates supported queue implementations.
+enum QueueType {
+  // Default unspecified implementation.
+  QUEUE_TYPE_UNSPECIFIED = 0;
+  // In-memory queue for testing or lightweight workloads.
+  QUEUE_TYPE_MEMORY = 1;
+  // Redis-backed queue.
+  QUEUE_TYPE_REDIS = 2;
+  // NATS-based streaming queue.
+  QUEUE_TYPE_NATS = 3;
+  // Cloud provider queue (e.g., AWS SQS).
+  QUEUE_TYPE_CLOUD = 4;
+}

--- a/pkg/queue/proto/enums/routing_strategy.proto
+++ b/pkg/queue/proto/enums/routing_strategy.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/enums/routing_strategy.proto
-// file: queue/proto/enums/routing_strategy.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/enums/routing_strategy.proto
+// version: 1.0.0
+// guid: 7470584d-8517-42b3-b7f1-c5d5a594001c
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,16 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// RoutingStrategy defines how messages are distributed to consumers.
+enum RoutingStrategy {
+  // Implementation-defined default strategy.
+  ROUTING_STRATEGY_UNSPECIFIED = 0;
+  // Distribute messages evenly across consumers.
+  ROUTING_STRATEGY_ROUND_ROBIN = 1;
+  // Select consumers randomly.
+  ROUTING_STRATEGY_RANDOM = 2;
+  // Route based on a hash of message attributes.
+  ROUTING_STRATEGY_HASH = 3;
+  // Send to all available consumers.
+  ROUTING_STRATEGY_BROADCAST = 4;
+}

--- a/pkg/queue/proto/enums/subscription_state.proto
+++ b/pkg/queue/proto/enums/subscription_state.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/enums/subscription_state.proto
-// file: queue/proto/enums/subscription_state.proto
-//
-// Enum definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/enums/subscription_state.proto
+// version: 1.0.0
+// guid: ddd7bd85-a329-4347-be1d-18983916cd3e
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,14 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add enum definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// SubscriptionState describes the lifecycle state of a subscription.
+enum SubscriptionState {
+  // Default state. Server decides behavior.
+  SUBSCRIPTION_STATE_UNSPECIFIED = 0;
+  // Actively receiving messages.
+  SUBSCRIPTION_STATE_ACTIVE = 1;
+  // Temporarily paused from delivering messages.
+  SUBSCRIPTION_STATE_PAUSED = 2;
+  // Permanently closed and cannot be resumed.
+  SUBSCRIPTION_STATE_CLOSED = 3;
+}

--- a/pkg/queue/proto/messages/queue_config.proto
+++ b/pkg/queue/proto/messages/queue_config.proto
@@ -1,18 +1,33 @@
-// filepath: pkg/queue/proto/messages/queue_config.proto
-// file: queue/proto/messages/queue_config.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/queue_config.proto
+// version: 1.0.0
+// guid: c64defde-30d1-41e5-bfac-b415cbf929c6
+
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "pkg/queue/proto/enums/queue_type.proto";
+import "pkg/queue/proto/enums/priority_level.proto";
+import "pkg/queue/proto/messages/retention_policy.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// QueueConfig defines settings for creating a queue instance.
+message QueueConfig {
+  // Name of the queue.
+  string name = 1;
+  // Queue implementation type.
+  QueueType type = 2;
+  // Number of partitions for the queue.
+  int32 partitions = 3;
+  // Retention policy for stored messages.
+  RetentionPolicy retention = 4;
+  // Default priority applied when publishing.
+  PriorityLevel default_priority = 5;
+  // If true, queue persists messages to disk.
+  bool durable = 6;
+  // Whether the queue should be automatically deleted when unused.
+  bool auto_delete = 7;
+}

--- a/pkg/queue/proto/messages/retention_policy.proto
+++ b/pkg/queue/proto/messages/retention_policy.proto
@@ -1,18 +1,23 @@
-// filepath: pkg/queue/proto/messages/retention_policy.proto
-// file: queue/proto/messages/retention_policy.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/retention_policy.proto
+// version: 1.0.0
+// guid: 5a069bb8-66bf-413e-a9e8-a1856f52eb01
+
 edition = "2023";
 
 package gcommon.v1.queue;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// RetentionPolicy controls how long messages are kept before deletion.
+message RetentionPolicy {
+  // Maximum age of a message before it is removed.
+  google.protobuf.Duration max_age = 1;
+  // Maximum total storage size for the queue in bytes.
+  int64 max_size_bytes = 2;
+  // If true, older messages are discarded when limits are reached.
+  bool discard_old = 3;
+}

--- a/pkg/queue/proto/messages/subscription_config.proto
+++ b/pkg/queue/proto/messages/subscription_config.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/messages/subscription_config.proto
-// file: queue/proto/messages/subscription_config.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/subscription_config.proto
+// version: 1.0.0
+// guid: 27b1d56b-2e7b-4003-9ddd-6b30086ff0fb
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,23 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+import "pkg/queue/proto/enums/subscription_state.proto";
+import "pkg/queue/proto/enums/routing_strategy.proto";
+import "pkg/queue/proto/enums/priority_level.proto";
+import "pkg/queue/proto/messages/delivery_options.proto";
+
+// SubscriptionConfig describes how a consumer subscribes to a queue.
+message SubscriptionConfig {
+  // Name of the subscription.
+  string name = 1;
+  // Current state of the subscription.
+  SubscriptionState state = 2;
+  // Message routing strategy for this subscription.
+  RoutingStrategy routing_strategy = 3;
+  // Default priority applied to published messages if unspecified.
+  PriorityLevel default_priority = 4;
+  // Delivery options controlling retries and dead letter handling.
+  DeliveryOptions delivery_options = 5;
+  // Maximum number of unacknowledged messages allowed.
+  int32 max_inflight = 6;
+}

--- a/pkg/queue/proto/messages/validation_config.proto
+++ b/pkg/queue/proto/messages/validation_config.proto
@@ -1,9 +1,7 @@
-// filepath: pkg/queue/proto/messages/validation_config.proto
-// file: queue/proto/messages/validation_config.proto
-//
-// Message definitions for queue module
-// TODO: Implement actual protobuf definitions
-//
+// file: pkg/queue/proto/messages/validation_config.proto
+// version: 1.0.0
+// guid: 50a55c81-98ea-49a5-8d18-c188a48acc5f
+
 edition = "2023";
 
 package gcommon.v1.queue;
@@ -13,6 +11,12 @@ import "google/protobuf/go_features.proto";
 option go_package = "github.com/jdfalk/gcommon/pkg/queue/proto;queuepb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the queue module requirements
+// ValidationConfig defines rules for validating queued messages.
+message ValidationConfig {
+  // Whether to validate message schema.
+  bool validate_schema = 1;
+  // Maximum allowed size of the message body in bytes.
+  int64 max_body_bytes = 2;
+  // If true, reject messages that exceed validation limits.
+  bool reject_invalid = 3;
+}


### PR DESCRIPTION
## Summary
Implemented key configuration messages and enums for the queue module. Added corresponding documentation updates and issue comment.

## Issues Addressed

### feat(queue): add config protobufs and enums
- [`pkg/queue/proto/enums/priority_level.proto`](./pkg/queue/proto/enums/priority_level.proto) - define `PriorityLevel` enum
- [`pkg/queue/proto/enums/routing_strategy.proto`](./pkg/queue/proto/enums/routing_strategy.proto) - define `RoutingStrategy` enum
- [`pkg/queue/proto/enums/subscription_state.proto`](./pkg/queue/proto/enums/subscription_state.proto) - define `SubscriptionState` enum
- [`pkg/queue/proto/enums/queue_type.proto`](./pkg/queue/proto/enums/queue_type.proto) - define `QueueType` enum
- [`pkg/queue/proto/messages/retention_policy.proto`](./pkg/queue/proto/messages/retention_policy.proto) - define `RetentionPolicy` message
- [`pkg/queue/proto/messages/subscription_config.proto`](./pkg/queue/proto/messages/subscription_config.proto) - define `SubscriptionConfig` message
- [`pkg/queue/proto/messages/queue_config.proto`](./pkg/queue/proto/messages/queue_config.proto) - define `QueueConfig` message
- [`pkg/queue/proto/messages/validation_config.proto`](./pkg/queue/proto/messages/validation_config.proto) - define `ValidationConfig` message
- [.github/doc-updates/*.json](./.github/doc-updates/) - changelog, TODO, and plan updates
- [.github/issue-updates/f2aae00d-26ba-4152-b3b5-5854d854e805.json](./.github/issue-updates/f2aae00d-26ba-4152-b3b5-5854d854e805.json) - comment on issue #88

## Testing
- `./scripts/validate-protos.sh` *(failed: Compilation failed for 1102 files)*

------
https://chatgpt.com/codex/tasks/task_e_6886ee81e110832189acd1e0d0fbd408