### PR TITLE
Implement metrics proto requests and responses

### DIFF
--- a/.github/doc-updates/720984ac-fec4-4a2a-8e01-4ae36afb0c87.json
+++ b/.github/doc-updates/720984ac-fec4-4a2a-8e01-4ae36afb0c87.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "### July 28, 2025 - Metrics requests and responses implemented (33 files)",
+  "guid": "720984ac-fec4-4a2a-8e01-4ae36afb0c87",
+  "created_at": "2025-07-28T03:27:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9c538ff0-ff0e-4c7e-aa7a-79f38e0c91b9.json
+++ b/.github/doc-updates/9c538ff0-ff0e-4c7e-aa7a-79f38e0c91b9.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "- Metrics module progress now at 34% with request and response messages implemented",
+  "guid": "9c538ff0-ff0e-4c7e-aa7a-79f38e0c91b9",
+  "created_at": "2025-07-28T03:27:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/af199349-c75d-42d6-adb5-56cee218df33.json
+++ b/.github/doc-updates/af199349-c75d-42d6-adb5-56cee218df33.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented metrics request and response protobufs",
+  "guid": "af199349-c75d-42d6-adb5-56cee218df33",
+  "created_at": "2025-07-28T03:27:31Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b666f2e7-465b-4571-9c32-9f05a8c2fe31.json
+++ b/.github/doc-updates/b666f2e7-465b-4571-9c32-9f05a8c2fe31.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### July 28, 2025 - Metrics module progress updated: 33 of 97 protobufs implemented",
+  "guid": "b666f2e7-465b-4571-9c32-9f05a8c2fe31",
+  "created_at": "2025-07-28T03:27:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/metrics/proto/messages/export_config.proto
+++ b/pkg/metrics/proto/messages/export_config.proto
@@ -1,18 +1,29 @@
 // filepath: pkg/metrics/proto/messages/export_config.proto
 // file: metrics/proto/messages/export_config.proto
 //
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Configuration options for exporting metrics to external systems.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/enums/export_format.proto";
+import "pkg/metrics/proto/enums/compression_type.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ExportConfig defines how metrics are exported.
+ */
+message ExportConfig {
+  // Output format (e.g., prometheus, json)
+  ExportFormat format = 1;
+
+  // Compression algorithm to use
+  CompressionType compression = 2;
+
+  // Destination URL or path
+  string destination = 3;
+}

--- a/pkg/metrics/proto/messages/metric_aggregation.proto
+++ b/pkg/metrics/proto/messages/metric_aggregation.proto
@@ -1,18 +1,28 @@
 // filepath: pkg/metrics/proto/messages/metric_aggregation.proto
 // file: metrics/proto/messages/metric_aggregation.proto
 //
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Definition of aggregation results for metrics queries.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/enums/aggregation_type.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * MetricAggregation represents aggregated metric value.
+ */
+message MetricAggregation {
+  // Aggregation type performed
+  AggregationType type = 1;
+
+  // Value produced by aggregation
+  double value = 2;
+
+  // Number of samples aggregated
+  int64 sample_count = 3;
+}

--- a/pkg/metrics/proto/messages/metric_family.proto
+++ b/pkg/metrics/proto/messages/metric_family.proto
@@ -1,18 +1,35 @@
 // filepath: pkg/metrics/proto/messages/metric_family.proto
 // file: metrics/proto/messages/metric_family.proto
 //
-// Message definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// MetricFamily groups related metrics together.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/metrics/proto/enums/metric_type.proto";
+import "pkg/metrics/proto/messages/metric_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add message definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * MetricFamily groups metrics of the same name and type.
+ */
+message MetricFamily {
+  // Family name (e.g., http_requests)
+  string name = 1;
+
+  // Family description
+  string description = 2;
+
+  // Metric type for this family
+  MetricType type = 3;
+
+  // Unit of measurement
+  string unit = 4;
+
+  // Metrics in this family
+  repeated MetricData metrics = 5;
+}

--- a/pkg/metrics/proto/requests/create_metric_request.proto
+++ b/pkg/metrics/proto/requests/create_metric_request.proto
@@ -2,17 +2,25 @@
 // file: metrics/proto/requests/create_metric_request.proto
 //
 // Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/metric_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * CreateMetricRequest creates a new metric definition.
+ */
+message CreateMetricRequest {
+  // Metric to create
+  MetricData metric = 1;
+
+  // Request metadata for tracing
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/delete_metric_request.proto
+++ b/pkg/metrics/proto/requests/delete_metric_request.proto
@@ -1,18 +1,28 @@
 // filepath: pkg/metrics/proto/requests/delete_metric_request.proto
 // file: metrics/proto/requests/delete_metric_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request to delete an existing metric definition.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * DeleteMetricRequest removes a metric by ID.
+ */
+message DeleteMetricRequest {
+  // Unique identifier of the metric
+  string metric_id = 1;
+
+  // Optional namespace
+  string namespace = 2;
+
+  // Request metadata for auditing
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/get_alerting_rules_request.proto
+++ b/pkg/metrics/proto/requests/get_alerting_rules_request.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/requests/get_alerting_rules_request.proto
 // file: metrics/proto/requests/get_alerting_rules_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for retrieving alerting rules associated with a metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetAlertingRulesRequest fetches alerting rules for a metric.
+ */
+message GetAlertingRulesRequest {
+  // Metric identifier
+  string metric_id = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/get_metric_config_request.proto
+++ b/pkg/metrics/proto/requests/get_metric_config_request.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/requests/get_metric_config_request.proto
 // file: metrics/proto/requests/get_metric_config_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message to retrieve metric configuration.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetMetricConfigRequest returns configuration for a metric.
+ */
+message GetMetricConfigRequest {
+  // Metric identifier
+  string metric_id = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/get_metric_request.proto
+++ b/pkg/metrics/proto/requests/get_metric_request.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/requests/get_metric_request.proto
 // file: metrics/proto/requests/get_metric_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for retrieving a metric by ID.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetMetricRequest fetches a metric definition and data.
+ */
+message GetMetricRequest {
+  // Unique metric identifier
+  string metric_id = 1;
+
+  // Request metadata for tracing
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/get_scrape_config_request.proto
+++ b/pkg/metrics/proto/requests/get_scrape_config_request.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/requests/get_scrape_config_request.proto
 // file: metrics/proto/requests/get_scrape_config_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for retrieving scrape configuration.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetScrapeConfigRequest retrieves the scrape configuration for a provider.
+ */
+message GetScrapeConfigRequest {
+  // Provider identifier
+  string provider_id = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/get_stats_request.proto
+++ b/pkg/metrics/proto/requests/get_stats_request.proto
@@ -1,18 +1,29 @@
 // filepath: pkg/metrics/proto/requests/get_stats_request.proto
 // file: metrics/proto/requests/get_stats_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request for retrieving metric statistics over a time range.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/types/timestamp_range.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetStatsRequest fetches statistics for a metric.
+ */
+message GetStatsRequest {
+  // Metric name or ID to query
+  string metric = 1;
+
+  // Time range for stats
+  TimestampRange range = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/import_metrics_request.proto
+++ b/pkg/metrics/proto/requests/import_metrics_request.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/requests/import_metrics_request.proto
 // file: metrics/proto/requests/import_metrics_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for importing multiple metrics.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/metric_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ImportMetricsRequest uploads a batch of metrics.
+ */
+message ImportMetricsRequest {
+  // Metrics to import
+  repeated MetricData metrics = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/record_summary_request.proto
+++ b/pkg/metrics/proto/requests/record_summary_request.proto
@@ -1,18 +1,30 @@
 // filepath: pkg/metrics/proto/requests/record_summary_request.proto
 // file: metrics/proto/requests/record_summary_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for recording a summary metric observation.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "google/protobuf/timestamp.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/summary_metric.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * RecordSummaryRequest records a summary observation.
+ */
+message RecordSummaryRequest {
+  // Summary metric data
+  SummaryMetric metric = 1;
+
+  // Optional timestamp for the observation
+  google.protobuf.Timestamp observed_at = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/reset_metrics_request.proto
+++ b/pkg/metrics/proto/requests/reset_metrics_request.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/requests/reset_metrics_request.proto
 // file: metrics/proto/requests/reset_metrics_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for resetting stored metric data.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ResetMetricsRequest clears metric data or statistics.
+ */
+message ResetMetricsRequest {
+  // Metric name or ID to reset
+  string metric = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/set_alerting_rules_request.proto
+++ b/pkg/metrics/proto/requests/set_alerting_rules_request.proto
@@ -1,18 +1,29 @@
 // filepath: pkg/metrics/proto/requests/set_alerting_rules_request.proto
 // file: metrics/proto/requests/set_alerting_rules_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for configuring alerting rules for a metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/alerting_rule.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetAlertingRulesRequest sets alerting rules for a metric.
+ */
+message SetAlertingRulesRequest {
+  // Metric identifier
+  string metric_id = 1;
+
+  // Rules to set
+  repeated AlertingRule rules = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/set_metric_metadata_request.proto
+++ b/pkg/metrics/proto/requests/set_metric_metadata_request.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/requests/set_metric_metadata_request.proto
 // file: metrics/proto/requests/set_metric_metadata_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message for updating metric metadata.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/metric_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetMetricMetadataRequest updates metadata for a metric.
+ */
+message SetMetricMetadataRequest {
+  // Metric metadata to apply
+  MetricMetadata metadata = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata request_meta = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/set_scrape_config_request.proto
+++ b/pkg/metrics/proto/requests/set_scrape_config_request.proto
@@ -1,18 +1,29 @@
 // filepath: pkg/metrics/proto/requests/set_scrape_config_request.proto
 // file: metrics/proto/requests/set_scrape_config_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message to set scraping configuration for a provider.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/scrape_config.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetScrapeConfigRequest updates scrape configuration.
+ */
+message SetScrapeConfigRequest {
+  // Provider identifier
+  string provider_id = 1;
+
+  // New scrape configuration
+  ScrapeConfig config = 2;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 3 [lazy = true];
+}

--- a/pkg/metrics/proto/requests/update_metric_request.proto
+++ b/pkg/metrics/proto/requests/update_metric_request.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/requests/update_metric_request.proto
 // file: metrics/proto/requests/update_metric_request.proto
 //
-// Request definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Request message to update an existing metric definition.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/request_metadata.proto";
+import "pkg/metrics/proto/messages/metric_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add request definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * UpdateMetricRequest modifies a metric definition.
+ */
+message UpdateMetricRequest {
+  // Updated metric data
+  MetricData metric = 1;
+
+  // Request metadata
+  gcommon.v1.common.RequestMetadata metadata = 2 [lazy = true];
+}

--- a/pkg/metrics/proto/responses/create_metric_response.proto
+++ b/pkg/metrics/proto/responses/create_metric_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/create_metric_response.proto
 // file: metrics/proto/responses/create_metric_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response returned after creating a metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/metric_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * CreateMetricResponse contains the result of a metric creation.
+ */
+message CreateMetricResponse {
+  // Created metric metadata
+  MetricMetadata metadata = 1;
+
+  // Operation error details if any
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/delete_metric_response.proto
+++ b/pkg/metrics/proto/responses/delete_metric_response.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/responses/delete_metric_response.proto
 // file: metrics/proto/responses/delete_metric_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response returned after deleting a metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * DeleteMetricResponse confirms metric deletion.
+ */
+message DeleteMetricResponse {
+  // Whether the delete succeeded
+  bool success = 1;
+
+  // Error details if the operation failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/get_alerting_rules_response.proto
+++ b/pkg/metrics/proto/responses/get_alerting_rules_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/get_alerting_rules_response.proto
 // file: metrics/proto/responses/get_alerting_rules_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response message containing alerting rules for a metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/alerting_rule.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetAlertingRulesResponse returns configured alerting rules.
+ */
+message GetAlertingRulesResponse {
+  // Alerting rules for the metric
+  repeated AlertingRule rules = 1;
+
+  // Error information if retrieval failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/get_metric_response.proto
+++ b/pkg/metrics/proto/responses/get_metric_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/get_metric_response.proto
 // file: metrics/proto/responses/get_metric_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response containing a metric definition and data.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/metric_data.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetMetricResponse returns metric data.
+ */
+message GetMetricResponse {
+  // Metric data requested
+  MetricData metric = 1;
+
+  // Error information if retrieval failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/get_scrape_config_response.proto
+++ b/pkg/metrics/proto/responses/get_scrape_config_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/get_scrape_config_response.proto
 // file: metrics/proto/responses/get_scrape_config_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response containing scraping configuration for a provider.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/scrape_config.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetScrapeConfigResponse returns provider scrape configuration.
+ */
+message GetScrapeConfigResponse {
+  // Current scrape configuration
+  ScrapeConfig config = 1;
+
+  // Error information if retrieval failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/get_stats_response.proto
+++ b/pkg/metrics/proto/responses/get_stats_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/get_stats_response.proto
 // file: metrics/proto/responses/get_stats_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response containing metric statistics over a time range.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/types/query_stats.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * GetStatsResponse returns statistics for a metric.
+ */
+message GetStatsResponse {
+  // Statistics for the query
+  QueryStats stats = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/import_metrics_response.proto
+++ b/pkg/metrics/proto/responses/import_metrics_response.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/responses/import_metrics_response.proto
 // file: metrics/proto/responses/import_metrics_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response returned after importing metrics.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ImportMetricsResponse reports the result of a batch import.
+ */
+message ImportMetricsResponse {
+  // Number of metrics successfully imported
+  int32 imported_count = 1;
+
+  // Error information if the import failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/list_metrics_response.proto
+++ b/pkg/metrics/proto/responses/list_metrics_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/list_metrics_response.proto
 // file: metrics/proto/responses/list_metrics_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response containing a list of metric metadata.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/metric_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ListMetricsResponse lists available metrics.
+ */
+message ListMetricsResponse {
+  // Available metrics
+  repeated MetricMetadata metrics = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/record_summary_response.proto
+++ b/pkg/metrics/proto/responses/record_summary_response.proto
@@ -1,18 +1,30 @@
 // filepath: pkg/metrics/proto/responses/record_summary_response.proto
 // file: metrics/proto/responses/record_summary_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response after recording a summary metric.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/summary_metric.proto";
+import "pkg/metrics/proto/types/recording_stats.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * RecordSummaryResponse returns updated summary stats.
+ */
+message RecordSummaryResponse {
+  // Updated summary metric
+  SummaryMetric metric = 1;
+
+  // Processing stats
+  RecordingStats stats = 2;
+
+  // Error information
+  gcommon.v1.common.Error error = 3;
+}

--- a/pkg/metrics/proto/responses/reset_metrics_response.proto
+++ b/pkg/metrics/proto/responses/reset_metrics_response.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/responses/reset_metrics_response.proto
 // file: metrics/proto/responses/reset_metrics_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response after resetting metric data.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * ResetMetricsResponse reports reset status.
+ */
+message ResetMetricsResponse {
+  // Whether the reset succeeded
+  bool success = 1;
+
+  // Error information if reset failed
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/set_alerting_rules_response.proto
+++ b/pkg/metrics/proto/responses/set_alerting_rules_response.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/responses/set_alerting_rules_response.proto
 // file: metrics/proto/responses/set_alerting_rules_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response after setting alerting rules.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetAlertingRulesResponse confirms alert rule configuration.
+ */
+message SetAlertingRulesResponse {
+  // Whether the operation succeeded
+  bool success = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/set_metric_metadata_response.proto
+++ b/pkg/metrics/proto/responses/set_metric_metadata_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/set_metric_metadata_response.proto
 // file: metrics/proto/responses/set_metric_metadata_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response after updating metric metadata.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/metric_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetMetricMetadataResponse returns updated metadata.
+ */
+message SetMetricMetadataResponse {
+  // Updated metadata
+  MetricMetadata metadata = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/set_scrape_config_response.proto
+++ b/pkg/metrics/proto/responses/set_scrape_config_response.proto
@@ -1,18 +1,25 @@
 // filepath: pkg/metrics/proto/responses/set_scrape_config_response.proto
 // file: metrics/proto/responses/set_scrape_config_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response after updating scrape configuration.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * SetScrapeConfigResponse confirms new configuration.
+ */
+message SetScrapeConfigResponse {
+  // Whether the update succeeded
+  bool success = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}

--- a/pkg/metrics/proto/responses/update_metric_response.proto
+++ b/pkg/metrics/proto/responses/update_metric_response.proto
@@ -1,18 +1,26 @@
 // filepath: pkg/metrics/proto/responses/update_metric_response.proto
 // file: metrics/proto/responses/update_metric_response.proto
 //
-// Response definitions for metrics module
-// TODO: Implement actual protobuf definitions
+// Response returned after updating a metric definition.
 //
 edition = "2023";
 
 package gcommon.v1.metrics;
 
 import "google/protobuf/go_features.proto";
+import "pkg/common/proto/messages/error.proto";
+import "pkg/metrics/proto/messages/metric_metadata.proto";
 
 option go_package = "github.com/jdfalk/gcommon/pkg/metrics/proto;metricspb";
 option features.(pb.go).api_level = API_HYBRID;
 
-// TODO: Add response definitions here
-// This is a placeholder file created during 1-1-1 migration
-// Implement the actual protobuf definitions according to the metrics module requirements
+/**
+ * UpdateMetricResponse returns updated metadata.
+ */
+message UpdateMetricResponse {
+  // Updated metric metadata
+  MetricMetadata metadata = 1;
+
+  // Error information
+  gcommon.v1.common.Error error = 2;
+}


### PR DESCRIPTION
## Summary
- add remaining Metrics request and response protobufs
- implement MetricFamily, MetricAggregation and ExportConfig messages
- log progress in PROTOBUF_IMPLEMENTATION_PLAN, README, and TODO
- document new feature in CHANGELOG

## Testing
- `make proto-compile` *(fails: Compilation failed for 1098 files)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea9149cc83218c541afb4efbcbe0