### PR TITLE
Implement initial media protobufs

### DIFF
--- a/.github/doc-updates/67e2c496-4ef3-42d1-ac88-d6e0b2a352bd.json
+++ b/.github/doc-updates/67e2c496-4ef3-42d1-ac88-d6e0b2a352bd.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Create MediaService messages for subtitle-manager integration",
+  "guid": "67e2c496-4ef3-42d1-ac88-d6e0b2a352bd",
+  "created_at": "2025-07-28T03:37:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d6b35842-648f-457a-a13d-9666a6beb90c.json
+++ b/.github/doc-updates/d6b35842-648f-457a-a13d-9666a6beb90c.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added MediaFile and related types for subtitle-manager support",
+  "guid": "d6b35842-648f-457a-a13d-9666a6beb90c",
+  "created_at": "2025-07-28T03:37:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/de0ef2a1-ffed-4c91-90b6-a50fd94f15e9.json
+++ b/.github/doc-updates/de0ef2a1-ffed-4c91-90b6-a50fd94f15e9.json
@@ -1,0 +1,16 @@
+{
+  "file": "PROTOBUF_IMPLEMENTATION_PLAN.md",
+  "mode": "append",
+  "content": "July 31, 2025 - Started implementing Media module protobuf messages",
+  "guid": "de0ef2a1-ffed-4c91-90b6-a50fd94f15e9",
+  "created_at": "2025-07-28T03:37:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/dfa38bce-7be2-4179-8707-caedffe31143.json
+++ b/.github/issue-updates/dfa38bce-7be2-4179-8707-caedffe31143.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Protobuf: Initial Media module",
+  "body": "Implement MediaFile and related messages per subtitle-manager requirements",
+  "labels": ["enhancement", "protobuf"],
+  "guid": "dfa38bce-7be2-4179-8707-caedffe31143",
+  "legacy_guid": "create-protobuf-initial-media-module-2025-07-28",
+  "created_at": "2025-07-28T03:37:53.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/media/proto/enums/media_type.proto
+++ b/pkg/media/proto/enums/media_type.proto
@@ -1,0 +1,21 @@
+// file: pkg/media/proto/enums/media_type.proto
+// version: 1.0.0
+// guid: d13c4939-a91b-4cb8-85e6-09ddda85220e
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Media type classification for library items.
+enum MediaType {
+  MEDIA_TYPE_UNSPECIFIED = 0;
+  MEDIA_TYPE_MOVIE = 1;
+  MEDIA_TYPE_TV_EPISODE = 2;
+  MEDIA_TYPE_DOCUMENTARY = 3;
+  MEDIA_TYPE_ANIME = 4;
+}

--- a/pkg/media/proto/enums/quality_score.proto
+++ b/pkg/media/proto/enums/quality_score.proto
@@ -1,0 +1,21 @@
+// file: pkg/media/proto/enums/quality_score.proto
+// version: 1.0.0
+// guid: 3d37a954-484a-4beb-acc4-7ec2fd05bf7d
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Overall media quality rating.
+enum QualityScore {
+  QUALITY_SCORE_UNSPECIFIED = 0;
+  QUALITY_SCORE_LOW = 1;
+  QUALITY_SCORE_MEDIUM = 2;
+  QUALITY_SCORE_HIGH = 3;
+  QUALITY_SCORE_EXCELLENT = 4;
+}

--- a/pkg/media/proto/enums/resolution.proto
+++ b/pkg/media/proto/enums/resolution.proto
@@ -1,0 +1,21 @@
+// file: pkg/media/proto/enums/resolution.proto
+// version: 1.0.0
+// guid: 2901b257-89ea-43db-8650-a3b6b48acfdb
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Media resolution enumeration.
+enum Resolution {
+  RESOLUTION_UNSPECIFIED = 0;
+  RESOLUTION_480P = 1;
+  RESOLUTION_720P = 2;
+  RESOLUTION_1080P = 3;
+  RESOLUTION_4K = 4;
+}

--- a/pkg/media/proto/messages/audio_track.proto
+++ b/pkg/media/proto/messages/audio_track.proto
@@ -1,0 +1,23 @@
+// file: pkg/media/proto/messages/audio_track.proto
+// version: 1.0.0
+// guid: 55a5a263-fb45-49ae-8090-81d826cc0a5f
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Audio track information.
+message AudioTrack {
+  int32 index = 1;
+  string language = 2;
+  string codec = 3;
+  string title = 4;
+  int32 channels = 5;
+  int32 sample_rate = 6;
+  bool default_track = 7;
+}

--- a/pkg/media/proto/messages/media_file.proto
+++ b/pkg/media/proto/messages/media_file.proto
@@ -1,0 +1,33 @@
+// file: pkg/media/proto/messages/media_file.proto
+// version: 1.0.0
+// guid: e3bc9175-1261-4755-9d32-d991586e723f
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+import "pkg/media/proto/messages/media_metadata.proto";
+import "pkg/media/proto/enums/media_type.proto";
+import "pkg/media/proto/messages/subtitle_track.proto";
+import "pkg/media/proto/messages/audio_track.proto";
+import "pkg/media/proto/messages/media_quality.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Media file representation with associated metadata and tracks.
+message MediaFile {
+  string id = 1;
+  string path = 2;
+  string filename = 3;
+  MediaType type = 4;
+  int64 size_bytes = 5;
+  google.protobuf.Timestamp created_at = 6 [lazy = true];
+  google.protobuf.Timestamp modified_at = 7 [lazy = true];
+  MediaMetadata metadata = 8;
+  repeated SubtitleTrack subtitle_tracks = 9;
+  repeated AudioTrack audio_tracks = 10;
+  MediaQuality quality = 11;
+}

--- a/pkg/media/proto/messages/media_metadata.proto
+++ b/pkg/media/proto/messages/media_metadata.proto
@@ -1,0 +1,31 @@
+// file: pkg/media/proto/messages/media_metadata.proto
+// version: 1.0.0
+// guid: e5b804c2-185f-402f-8edb-b3c390406e52
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+import "pkg/media/proto/messages/series_info.proto";
+import "pkg/media/proto/messages/movie_info.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Metadata information for a media file from external sources.
+message MediaMetadata {
+  string title = 1;
+  string original_title = 2;
+  int32 year = 3;
+  string plot = 4;
+  repeated string genres = 5;
+  string imdb_id = 6;
+  string tmdb_id = 7;
+  float rating = 8;
+  repeated string languages = 9;
+  repeated string actors = 10;
+  repeated string directors = 11;
+  SeriesInfo series_info = 12;
+  MovieInfo movie_info = 13;
+}

--- a/pkg/media/proto/messages/media_quality.proto
+++ b/pkg/media/proto/messages/media_quality.proto
@@ -1,0 +1,23 @@
+// file: pkg/media/proto/messages/media_quality.proto
+// version: 1.0.0
+// guid: 62c527ab-9d69-4c5c-af80-64aa0657f948
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+import "pkg/media/proto/enums/resolution.proto";
+import "pkg/media/proto/enums/quality_score.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Media quality assessment.
+message MediaQuality {
+  Resolution resolution = 1;
+  string video_codec = 2;
+  int32 bitrate_kbps = 3;
+  float duration_seconds = 4;
+  QualityScore quality_score = 5;
+}

--- a/pkg/media/proto/messages/movie_info.proto
+++ b/pkg/media/proto/messages/movie_info.proto
@@ -1,0 +1,21 @@
+// file: pkg/media/proto/messages/movie_info.proto
+// version: 1.0.0
+// guid: fc3b809f-03e7-4446-b355-e7482000e343
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Movie specific information.
+message MovieInfo {
+  google.protobuf.Timestamp release_date = 1;
+  int64 budget = 2;
+  int64 revenue = 3;
+  int32 runtime_minutes = 4;
+}

--- a/pkg/media/proto/messages/series_info.proto
+++ b/pkg/media/proto/messages/series_info.proto
@@ -1,0 +1,22 @@
+// file: pkg/media/proto/messages/series_info.proto
+// version: 1.0.0
+// guid: 1ff30d9b-8171-4cb2-885c-0ae98bd2ad17
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// TV series specific information.
+message SeriesInfo {
+  int32 season = 1;
+  int32 episode = 2;
+  string series_name = 3;
+  string episode_title = 4;
+  google.protobuf.Timestamp air_date = 5;
+}

--- a/pkg/media/proto/messages/subtitle_track.proto
+++ b/pkg/media/proto/messages/subtitle_track.proto
@@ -1,0 +1,23 @@
+// file: pkg/media/proto/messages/subtitle_track.proto
+// version: 1.0.0
+// guid: 2c899982-81d3-43b7-a542-24361cdef856
+
+edition = "2023";
+
+package gcommon.v1.media;
+
+import "google/protobuf/go_features.proto";
+
+option go_package = "github.com/jdfalk/gcommon/pkg/media/proto;mediapb";
+option features.(pb.go).api_level = API_HYBRID;
+
+// Subtitle track information.
+message SubtitleTrack {
+  int32 index = 1;
+  string language = 2;
+  string codec = 3;
+  string title = 4;
+  bool forced = 5;
+  bool hearing_impaired = 6;
+  bool default_track = 7;
+}


### PR DESCRIPTION
## Summary
- start media module for subtitle-manager integration
- add MediaFile and related enum/type definitions
- create docs updates via repo scripts
- open tracking issue for new module

## Testing
- `buf lint --path pkg/media`
- `make proto-compile` *(fails: compilation failed for 1112 files)*

------
https://chatgpt.com/codex/tasks/task_e_6886eef6d20c8321a0749ffc1175d1ef