### PR TITLE
Add periodic merge conflict labeler

### DIFF
--- a/.github/workflows/merge-conflict-labeler.yml
+++ b/.github/workflows/merge-conflict-labeler.yml
@@ -1,0 +1,55 @@
+# file: .github/workflows/merge-conflict-labeler.yml
+# version: 1.0.0
+# guid: f64f58b4-18ee-4daf-956d-65459064ca63
+
+name: Merge Conflict Labeler
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  file-labeler:
+    name: Standard File Labeling
+    uses: jdfalk/ghcommon/.github/workflows/reusable-labeler.yml@main
+    with:
+      configuration-path: ".github/labeler.yml"
+      sync-labels: true
+      dot: true
+    secrets: inherit
+
+  merge-conflict-check:
+    name: Merge Conflict Detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs with merge conflicts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = 'merge-conflict';
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open' });
+            for (const pr of prs) {
+              let full = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+              if (full.data.mergeable_state === 'unknown') {
+                await new Promise(r => setTimeout(r, 2000));
+                full = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+              }
+              const hasConflict = full.data.mergeable_state === 'dirty';
+              const labels = pr.labels.map(l => l.name);
+              if (hasConflict && !labels.includes(label)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [label] });
+              } else if (!hasConflict && labels.includes(label)) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: label }).catch(e => { if (e.status !== 404) throw e; });
+              }
+            }
+


### PR DESCRIPTION
## Summary

Introduces a new workflow that runs the file‑based labeler on every push, pull request update and on an hourly schedule. The workflow also checks all open PRs for merge conflicts and applies or removes a `merge-conflict` label accordingly.

## Testing

- `make validate` *(failed: missing protobuf files)*
- `make test` *(failed: undefined proto symbols)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688ae8980300832181d61686e32f8fc9