### PR TITLE
feat: initial queue service layer

### DIFF
--- a/.github/doc-updates/92c6031e-5b49-445c-b49d-47d31aa3ff74.json
+++ b/.github/doc-updates/92c6031e-5b49-445c-b49d-47d31aa3ff74.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Initial queue service layer with memory and redis providers",
+  "guid": "92c6031e-5b49-445c-b49d-47d31aa3ff74",
+  "created_at": "2025-08-10T03:02:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/95d3effa-b0b1-48ab-bc2c-64d55a53486a.json
+++ b/.github/doc-updates/95d3effa-b0b1-48ab-bc2c-64d55a53486a.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Expand queue providers and gRPC services",
+  "guid": "95d3effa-b0b1-48ab-bc2c-64d55a53486a",
+  "created_at": "2025-08-10T03:02:54Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b140723a-2c43-4414-8c42-92a128d3ddd2.json
+++ b/.github/doc-updates/b140723a-2c43-4414-8c42-92a128d3ddd2.json
@@ -1,0 +1,16 @@
+{
+  "file": "pkg/queue/README.md",
+  "mode": "append",
+  "content": "# Queue Module\\n\\n## Provider Comparison\\n- Memory provider for development\\n- Redis provider for production\\n\\n## Job Scheduling Guide\\nDescribes how to schedule jobs using the Scheduler.\\n\\n## Dead Letter Queue Configuration\\nOverview of handling failed messages.\\n\\n## Performance Tuning\\nNotes on optimizing queue throughput.\\n\\n## Production Deployment\\nRecommendations for deploying queue services.",
+  "guid": "b140723a-2c43-4414-8c42-92a128d3ddd2",
+  "created_at": "2025-08-10T03:03:03Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/8427dc18-3992-4203-a28e-f109a0fe0b3e.json
+++ b/.github/issue-updates/8427dc18-3992-4203-a28e-f109a0fe0b3e.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Implement queue service layer",
+  "body": "Add queue interfaces and providers, scheduler, and docs",
+  "labels": ["module:queue", "type:feature"],
+  "guid": "8427dc18-3992-4203-a28e-f109a0fe0b3e",
+  "legacy_guid": "create-implement-queue-service-layer-2025-08-10",
+  "created_at": "2025-08-10T02:52:52.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/queue/dlq/handler.go
+++ b/pkg/queue/dlq/handler.go
@@ -1,0 +1,33 @@
+// file: pkg/queue/dlq/handler.go
+// version: 1.0.0
+// guid: 5b333253-6466-44fd-9130-ac2e955735c4
+
+package dlq
+
+import (
+	"context"
+	"sync"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type Handler struct {
+	mu       sync.Mutex
+	messages []*queuepb.QueueMessage
+}
+
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+func (h *Handler) Add(_ context.Context, msg *queuepb.QueueMessage) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.messages = append(h.messages, msg)
+}
+
+func (h *Handler) Messages() []*queuepb.QueueMessage {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]*queuepb.QueueMessage(nil), h.messages...)
+}

--- a/pkg/queue/dlq/handler_test.go
+++ b/pkg/queue/dlq/handler_test.go
@@ -1,0 +1,27 @@
+// file: pkg/queue/dlq/handler_test.go
+// version: 1.0.0
+// guid: 69f41a44-0826-4c83-8bf4-963639030c31
+
+package dlq
+
+import (
+	"context"
+	"testing"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+func TestHandler_AddAndRetrieve(t *testing.T) {
+	t.Parallel()
+	h := NewHandler()
+	msg := &queuepb.QueueMessage{}
+	h.Add(context.Background(), msg)
+
+	msgs := h.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0] == nil {
+		t.Fatal("expected message")
+	}
+}

--- a/pkg/queue/dlq/retry.go
+++ b/pkg/queue/dlq/retry.go
@@ -1,0 +1,12 @@
+// file: pkg/queue/dlq/retry.go
+// version: 1.0.0
+// guid: 251099cb-bf0d-43c6-9c96-689119b05d10
+
+package dlq
+
+import "time"
+
+type RetryStrategy struct {
+	Attempts int
+	Delay    time.Duration
+}

--- a/pkg/queue/examples/consumer.go
+++ b/pkg/queue/examples/consumer.go
@@ -1,0 +1,21 @@
+// file: pkg/queue/examples/consumer.go
+// version: 1.0.0
+// guid: 6062c1b4-11e9-4b57-a9c3-822ff7822423
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"github.com/jdfalk/gcommon/pkg/queue/providers"
+)
+
+func ConsumerExample(ctx context.Context) error {
+	q := providers.NewMemoryQueue(10)
+	return q.Subscribe(ctx, func(_ context.Context, m *queuepb.QueueMessage) error {
+		fmt.Println("received message", m)
+		return nil
+	})
+}

--- a/pkg/queue/examples/producer.go
+++ b/pkg/queue/examples/producer.go
@@ -1,0 +1,17 @@
+// file: pkg/queue/examples/producer.go
+// version: 1.0.0
+// guid: d77be7df-8b27-4441-b042-cf83c37c8aec
+
+package examples
+
+import (
+	"context"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"github.com/jdfalk/gcommon/pkg/queue/providers"
+)
+
+func ProducerExample(ctx context.Context) error {
+	q := providers.NewMemoryQueue(10)
+	return q.Publish(ctx, &queuepb.QueueMessage{})
+}

--- a/pkg/queue/examples/scheduler.go
+++ b/pkg/queue/examples/scheduler.go
@@ -1,0 +1,24 @@
+// file: pkg/queue/examples/scheduler.go
+// version: 1.0.0
+// guid: c193225c-7d1c-48af-a02e-0a7896615fa0
+
+package examples
+
+import (
+	"context"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/queue/jobs"
+)
+
+func SchedulerExample(ctx context.Context) error {
+	s := jobs.NewScheduler()
+	job := &jobs.Job{
+		ID:    "example",
+		RunAt: time.Now().Add(10 * time.Millisecond),
+		Handler: func(context.Context, *jobs.Job) error {
+			return nil
+		},
+	}
+	return s.ScheduleJob(ctx, job)
+}

--- a/pkg/queue/factory.go
+++ b/pkg/queue/factory.go
@@ -1,0 +1,33 @@
+// file: pkg/queue/factory.go
+// version: 1.0.0
+// guid: b587cf14-a926-43bf-941b-3a8cf68f9357
+
+package queue
+
+import (
+	"fmt"
+	"sync"
+)
+
+type ProviderFactory func() Queue
+
+var (
+	mu        sync.RWMutex
+	providers = make(map[string]ProviderFactory)
+)
+
+func RegisterProvider(name string, factory ProviderFactory) {
+	mu.Lock()
+	defer mu.Unlock()
+	providers[name] = factory
+}
+
+func CreateProvider(name string) (Queue, error) {
+	mu.RLock()
+	factory, ok := providers[name]
+	mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("provider %s not registered", name)
+	}
+	return factory(), nil
+}

--- a/pkg/queue/grpc/admin_service.go
+++ b/pkg/queue/grpc/admin_service.go
@@ -1,0 +1,21 @@
+// file: pkg/queue/grpc/admin_service.go
+// version: 1.0.0
+// guid: cc47b2b4-b308-48bc-8784-b08495f90dba
+//go:build queue_grpc
+// +build queue_grpc
+
+package grpc
+
+import (
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type AdminService struct {
+	queuepb.UnimplementedQueueAdminServiceServer
+	q queue.Queue
+}
+
+func NewAdminService(q queue.Queue) *AdminService {
+	return &AdminService{q: q}
+}

--- a/pkg/queue/grpc/monitoring_service.go
+++ b/pkg/queue/grpc/monitoring_service.go
@@ -1,0 +1,21 @@
+// file: pkg/queue/grpc/monitoring_service.go
+// version: 1.0.0
+// guid: c59f3164-6838-40da-bbeb-e4f0d1cf676c
+//go:build queue_grpc
+// +build queue_grpc
+
+package grpc
+
+import (
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type MonitoringService struct {
+	queuepb.UnimplementedQueueMonitoringServiceServer
+	q queue.Queue
+}
+
+func NewMonitoringService(q queue.Queue) *MonitoringService {
+	return &MonitoringService{q: q}
+}

--- a/pkg/queue/grpc/queue_service.go
+++ b/pkg/queue/grpc/queue_service.go
@@ -1,0 +1,30 @@
+// file: pkg/queue/grpc/queue_service.go
+// version: 1.0.0
+// guid: d2baf1b8-775f-4232-8a53-cc24003aa217
+//go:build queue_grpc
+// +build queue_grpc
+
+package grpc
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type QueueService struct {
+	queuepb.UnimplementedQueueServiceServer
+	q queue.Queue
+}
+
+func NewQueueService(q queue.Queue) *QueueService {
+	return &QueueService{q: q}
+}
+
+func (s *QueueService) Publish(ctx context.Context, req *queuepb.PublishRequest) (*queuepb.PublishResponse, error) {
+	if err := s.q.Publish(ctx, req.GetMessage()); err != nil {
+		return nil, err
+	}
+	return &queuepb.PublishResponse{MessageId: req.GetMessage().GetId()}, nil
+}

--- a/pkg/queue/grpc/server.go
+++ b/pkg/queue/grpc/server.go
@@ -1,0 +1,20 @@
+// file: pkg/queue/grpc/server.go
+// version: 1.0.0
+// guid: 739634b6-cbd8-471b-b71b-1e2f8c4d3120
+//go:build queue_grpc
+// +build queue_grpc
+
+package grpc
+
+import (
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"google.golang.org/grpc"
+)
+
+// NewServer creates a gRPC server with queue services registered.
+func NewServer(q queue.Queue) *grpc.Server {
+	srv := grpc.NewServer()
+	queuepb.RegisterQueueServiceServer(srv, NewQueueService(q))
+	return srv
+}

--- a/pkg/queue/interfaces.go
+++ b/pkg/queue/interfaces.go
@@ -1,0 +1,28 @@
+// file: pkg/queue/interfaces.go
+// version: 1.0.0
+// guid: 7f091a3a-39fe-439e-a435-e01e561fe5cd
+
+package queue
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/queue/jobs"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type MessageHandler func(ctx context.Context, message *queuepb.QueueMessage) error
+
+type Queue interface {
+	Publish(ctx context.Context, message *queuepb.QueueMessage) error
+	Subscribe(ctx context.Context, handler MessageHandler) error
+	CreateQueue(ctx context.Context, config *queuepb.QueueConfig) error
+	DeleteQueue(ctx context.Context, name string) error
+	GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error)
+}
+
+type Scheduler interface {
+	ScheduleJob(ctx context.Context, job *jobs.Job) error
+	CancelJob(ctx context.Context, jobID string) error
+	GetJobStatus(ctx context.Context, jobID string) (*jobs.JobStatus, error)
+}

--- a/pkg/queue/jobs/processor.go
+++ b/pkg/queue/jobs/processor.go
@@ -1,0 +1,10 @@
+// file: pkg/queue/jobs/processor.go
+// version: 1.0.0
+// guid: 046ecf06-4e0b-4867-9707-67622e1a904e
+
+package jobs
+
+import "context"
+
+// Processor defines job processing logic.
+type Processor func(ctx context.Context, job *Job) error

--- a/pkg/queue/jobs/scheduler.go
+++ b/pkg/queue/jobs/scheduler.go
@@ -1,0 +1,56 @@
+// file: pkg/queue/jobs/scheduler.go
+// version: 1.0.0
+// guid: 617260de-03ba-4067-865d-2c83af7a4049
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Scheduler struct {
+	mu   sync.Mutex
+	jobs map[string]*JobStatus
+}
+
+func NewScheduler() *Scheduler {
+	return &Scheduler{jobs: make(map[string]*JobStatus)}
+}
+
+func (s *Scheduler) ScheduleJob(ctx context.Context, job *Job) error {
+	s.mu.Lock()
+	s.jobs[job.ID] = &JobStatus{ID: job.ID}
+	s.mu.Unlock()
+	time.AfterFunc(time.Until(job.RunAt), func() {
+		err := job.Handler(ctx, job)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		status := s.jobs[job.ID]
+		if err != nil {
+			status.Error = err.Error()
+		} else {
+			status.Completed = true
+		}
+	})
+	return nil
+}
+
+func (s *Scheduler) CancelJob(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	delete(s.jobs, jobID)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Scheduler) GetJobStatus(ctx context.Context, jobID string) (*JobStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, ok := s.jobs[jobID]
+	if !ok {
+		return nil, fmt.Errorf("job %s not found", jobID)
+	}
+	return status, nil
+}

--- a/pkg/queue/jobs/scheduler_test.go
+++ b/pkg/queue/jobs/scheduler_test.go
@@ -1,0 +1,33 @@
+// file: pkg/queue/jobs/scheduler_test.go
+// version: 1.0.0
+// guid: e4f528b7-359e-45b8-83a7-b20b807cfa27
+
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestScheduler_ScheduleJob(t *testing.T) {
+	t.Parallel()
+	s := NewScheduler()
+	done := make(chan struct{})
+	job := &Job{
+		ID:    "test",
+		RunAt: time.Now().Add(10 * time.Millisecond),
+		Handler: func(context.Context, *Job) error {
+			close(done)
+			return nil
+		},
+	}
+	if err := s.ScheduleJob(context.Background(), job); err != nil {
+		t.Fatalf("schedule job: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("job did not run")
+	}
+}

--- a/pkg/queue/jobs/types.go
+++ b/pkg/queue/jobs/types.go
@@ -1,0 +1,25 @@
+// file: pkg/queue/jobs/types.go
+// version: 1.0.0
+// guid: f432e5bb-0162-495f-9b1c-bf26af2ec4ac
+
+package jobs
+
+import (
+	"context"
+	"time"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type Job struct {
+	ID      string
+	Message *queuepb.Message
+	RunAt   time.Time
+	Handler func(context.Context, *Job) error
+}
+
+type JobStatus struct {
+	ID        string
+	Completed bool
+	Error     string
+}

--- a/pkg/queue/jobs/worker.go
+++ b/pkg/queue/jobs/worker.go
@@ -1,0 +1,13 @@
+// file: pkg/queue/jobs/worker.go
+// version: 1.0.0
+// guid: d0a9c07c-518c-4ea5-93d3-cca02f4d31ad
+
+package jobs
+
+// Worker represents a simple job worker placeholder.
+type Worker struct {
+	Scheduler *Scheduler
+}
+
+// Start begins processing jobs. This is a placeholder implementation.
+func (w *Worker) Start() {}

--- a/pkg/queue/providers/memory.go
+++ b/pkg/queue/providers/memory.go
@@ -1,0 +1,55 @@
+// file: pkg/queue/providers/memory.go
+// version: 1.0.0
+// guid: 2295c946-d671-4f1f-8dd4-85f7aa6d56be
+
+package providers
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type MemoryQueue struct {
+	ch chan *queuepb.QueueMessage
+}
+
+func NewMemoryQueue(buffer int) *MemoryQueue {
+	return &MemoryQueue{ch: make(chan *queuepb.QueueMessage, buffer)}
+}
+
+func (m *MemoryQueue) Publish(ctx context.Context, message *queuepb.QueueMessage) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case m.ch <- message:
+		return nil
+	}
+}
+
+func (m *MemoryQueue) Subscribe(ctx context.Context, handler queue.MessageHandler) error {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-m.ch:
+				_ = handler(ctx, msg)
+			}
+		}
+	}()
+	return nil
+}
+
+func (m *MemoryQueue) CreateQueue(ctx context.Context, config *queuepb.QueueConfig) error {
+	return nil
+}
+
+func (m *MemoryQueue) DeleteQueue(ctx context.Context, name string) error {
+	return nil
+}
+
+func (m *MemoryQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
+	return &queuepb.QueueInfo{}, nil
+}

--- a/pkg/queue/providers/memory_test.go
+++ b/pkg/queue/providers/memory_test.go
@@ -1,0 +1,43 @@
+// file: pkg/queue/providers/memory_test.go
+// version: 1.0.0
+// guid: eb1cb3f1-9651-4ffc-b83d-954f0fc32713
+
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	queue "github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+func TestMemoryQueue_PublishSubscribe(t *testing.T) {
+	t.Parallel()
+	q := NewMemoryQueue(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	received := make(chan *queuepb.QueueMessage, 1)
+	if err := q.Subscribe(ctx, queue.MessageHandler(func(_ context.Context, m *queuepb.QueueMessage) error {
+		received <- m
+		return nil
+	})); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	msg := &queuepb.QueueMessage{}
+	if err := q.Publish(ctx, msg); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-received:
+		if got == nil {
+			t.Fatal("expected message")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}

--- a/pkg/queue/providers/redis.go
+++ b/pkg/queue/providers/redis.go
@@ -1,0 +1,37 @@
+// file: pkg/queue/providers/redis.go
+// version: 1.0.0
+// guid: 17ce4e70-7beb-4eea-9b16-69139474add4
+
+package providers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+type RedisQueue struct{}
+
+func NewRedisQueue() *RedisQueue { return &RedisQueue{} }
+
+func (r *RedisQueue) Publish(ctx context.Context, message *queuepb.QueueMessage) error {
+	return errors.New("redis provider not implemented")
+}
+
+func (r *RedisQueue) Subscribe(ctx context.Context, handler queue.MessageHandler) error {
+	return errors.New("redis provider not implemented")
+}
+
+func (r *RedisQueue) CreateQueue(ctx context.Context, config *queuepb.QueueConfig) error {
+	return errors.New("redis provider not implemented")
+}
+
+func (r *RedisQueue) DeleteQueue(ctx context.Context, name string) error {
+	return errors.New("redis provider not implemented")
+}
+
+func (r *RedisQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
+	return nil, errors.New("redis provider not implemented")
+}


### PR DESCRIPTION
## Summary
- add queue interfaces and provider factory
- implement memory queue provider, scheduler, and dead letter handler
- stub gRPC services and redis provider with build tag

## Testing
- `go test ./pkg/queue/...`


------
https://chatgpt.com/codex/tasks/task_e_6898087d6b348321b5f2b7dece2c4e25