### PR TITLE
feat: add config provider factory with basic providers

### DIFF
--- a/.github/doc-updates/processed/20250810_025124_412417ff-69ff-4b93-be42-f1d2e3a92b6e.json
+++ b/.github/doc-updates/processed/20250810_025124_412417ff-69ff-4b93-be42-f1d2e3a92b6e.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement remaining components of config module",
+  "guid": "412417ff-69ff-4b93-be42-f1d2e3a92b6e",
+  "created_at": "2025-08-10T02:51:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_025124_fd34b99b-8167-4ae1-81e9-e9159536e7b6.json
+++ b/.github/doc-updates/processed/20250810_025124_fd34b99b-8167-4ae1-81e9-e9159536e7b6.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add initial config provider factory with file and env providers",
+  "guid": "fd34b99b-8167-4ae1-81e9-e9159536e7b6",
+  "created_at": "2025-08-10T02:51:20Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/cbd4a581-8cc3-414b-97a9-68296bc23203.json
+++ b/.github/issue-updates/cbd4a581-8cc3-414b-97a9-68296bc23203.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Config: implement provider factory and basic providers",
+  "body": "Implement initial Config module service layer with provider factory, file and env providers",
+  "labels": ["module:config", "enhancement"],
+  "guid": "cbd4a581-8cc3-414b-97a9-68296bc23203",
+  "legacy_guid": "create-config-implement-provider-factory-and-basic-providers-2025-08-10",
+  "created_at": "2025-08-10T02:50:43.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # GCommon Changelog
 
 <!-- file: CHANGELOG.md -->
+<!-- version: 1.1.1 -->
+<!-- guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d -->
 
 All notable changes to this project will be documented in this file.
 
@@ -14,10 +16,8 @@ and this project adheres to
 
 - Added extensible plugin architecture with security, communication bus, SDK,
   and examples
-
-### Added
-
 - Introduce plugin framework skeleton
+- Add initial config provider factory with file and env providers
 
 ### Added - MAJOR PROTOBUF IMPLEMENTATION MILESTONE (August 2025)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.2.1 -->
 <!-- guid: b2c3d4e5-f6a7-8b9c-def0-1234567890ab -->
 
 # GCommon Project Roadmap & Implementation Plan
@@ -2642,3 +2642,5 @@ module
 Build out plugin SDK and security features
 
 Add more plugin examples and security audits
+
+Implement remaining components of config module

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1,0 +1,19 @@
+<!-- file: pkg/config/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: ae4a9c20-7378-4546-acf1-0bf9d3e6c956 -->
+
+# Config Module
+
+This module provides a pluggable configuration system with a provider factory.
+
+## Quick Start
+
+```go
+p, _ := config.NewProvider("env", nil)
+value, _ := p.Get("EXAMPLE_KEY")
+```
+
+## Providers
+
+- **env**: uses environment variables
+- **file**: reads and writes JSON configuration files

--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -1,0 +1,26 @@
+// file: pkg/config/factory.go
+// version: 1.0.0
+// guid: fe2737c0-4fd4-43e4-8d7d-12cd4f4daaa9
+
+package config
+
+import "fmt"
+
+// ProviderConstructor constructs a Provider from configuration options.
+type ProviderConstructor func(map[string]interface{}) (Provider, error)
+
+var providerRegistry = make(map[string]ProviderConstructor)
+
+// RegisterProvider registers a provider constructor by name.
+func RegisterProvider(name string, constructor ProviderConstructor) {
+	providerRegistry[name] = constructor
+}
+
+// NewProvider creates a Provider based on its registered type.
+func NewProvider(providerType string, cfg map[string]interface{}) (Provider, error) {
+	constructor, exists := providerRegistry[providerType]
+	if !exists {
+		return nil, fmt.Errorf("unknown provider type: %s", providerType)
+	}
+	return constructor(cfg)
+}

--- a/pkg/config/factory_test.go
+++ b/pkg/config/factory_test.go
@@ -1,0 +1,31 @@
+// file: pkg/config/factory_test.go
+// version: 1.0.0
+// guid: 9783f849-cb18-4969-bf72-5d420dcaa31f
+
+package config
+
+import "testing"
+
+type dummyProvider struct{}
+
+func (d *dummyProvider) Get(key string) (interface{}, error)                { return nil, nil }
+func (d *dummyProvider) Set(key string, value interface{}) error            { return nil }
+func (d *dummyProvider) Watch(key string, callback func(interface{})) error { return nil }
+func (d *dummyProvider) Close() error                                       { return nil }
+
+func TestNewProvider_Unknown(t *testing.T) {
+	t.Parallel()
+	if _, err := NewProvider("missing", nil); err == nil {
+		t.Fatalf("expected error for unknown provider")
+	}
+}
+
+func TestRegisterAndCreateProvider(t *testing.T) {
+	t.Parallel()
+	RegisterProvider("dummy", func(cfg map[string]interface{}) (Provider, error) {
+		return &dummyProvider{}, nil
+	})
+	if p, err := NewProvider("dummy", nil); err != nil || p == nil {
+		t.Fatalf("expected provider, got %v", err)
+	}
+}

--- a/pkg/config/interfaces.go
+++ b/pkg/config/interfaces.go
@@ -1,0 +1,26 @@
+// file: pkg/config/interfaces.go
+// version: 1.0.0
+// guid: db2655ec-cb40-404c-ae61-af296e7f636f
+
+package config
+
+import (
+	"context"
+
+	proto "github.com/jdfalk/gcommon/pkg/config/proto"
+)
+
+// Provider defines the configuration provider interface.
+type Provider interface {
+	Get(key string) (interface{}, error)
+	Set(key string, value interface{}) error
+	Watch(key string, callback func(interface{})) error
+	Close() error
+}
+
+// ConfigService defines the main configuration service operations.
+type ConfigService interface {
+	Get(ctx context.Context, req *proto.GetConfigRequest) (*proto.GetConfigResponse, error)
+	Set(ctx context.Context, req *proto.SetConfigRequest) (*proto.SetConfigResponse, error)
+	Watch(req *proto.WatchConfigRequest, stream proto.ConfigService_WatchServer) error
+}

--- a/pkg/config/providers/env.go
+++ b/pkg/config/providers/env.go
@@ -1,0 +1,50 @@
+// file: pkg/config/providers/env.go
+// version: 1.0.0
+// guid: 1782fede-2351-4201-a56d-76073ef4fd87
+
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jdfalk/gcommon/pkg/config"
+)
+
+// EnvProvider reads configuration from environment variables.
+type EnvProvider struct{}
+
+// NewEnvProvider creates a new EnvProvider.
+func NewEnvProvider(cfg map[string]interface{}) (config.Provider, error) {
+	return &EnvProvider{}, nil
+}
+
+// Get retrieves a value by key from environment variables.
+func (p *EnvProvider) Get(key string) (interface{}, error) {
+	if val, ok := os.LookupEnv(key); ok {
+		return val, nil
+	}
+	return nil, fmt.Errorf("key not found: %s", key)
+}
+
+// Set sets an environment variable value.
+func (p *EnvProvider) Set(key string, value interface{}) error {
+	str, ok := value.(string)
+	if !ok {
+		return errors.New("value must be a string")
+	}
+	return os.Setenv(key, str)
+}
+
+// Watch is not supported for environment variables.
+func (p *EnvProvider) Watch(key string, callback func(interface{})) error {
+	return errors.New("watch not supported for env provider")
+}
+
+// Close is a no-op for EnvProvider.
+func (p *EnvProvider) Close() error { return nil }
+
+func init() {
+	config.RegisterProvider("env", NewEnvProvider)
+}

--- a/pkg/config/providers/env_test.go
+++ b/pkg/config/providers/env_test.go
@@ -1,0 +1,30 @@
+// file: pkg/config/providers/env_test.go
+// version: 1.0.0
+// guid: 74e45086-560a-41ab-8605-cacc54926261
+
+package providers
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvProvider_GetSet(t *testing.T) {
+	t.Parallel()
+	pIface, err := NewEnvProvider(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p := pIface.(*EnvProvider)
+	if err := p.Set("TEST_KEY", "VALUE"); err != nil {
+		t.Fatalf("set error: %v", err)
+	}
+	val, err := p.Get("TEST_KEY")
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+	if val != "VALUE" {
+		t.Fatalf("expected VALUE, got %v", val)
+	}
+	os.Unsetenv("TEST_KEY")
+}

--- a/pkg/config/providers/file.go
+++ b/pkg/config/providers/file.go
@@ -1,0 +1,97 @@
+// file: pkg/config/providers/file.go
+// version: 1.0.0
+// guid: 0bf1a8f9-ac21-438a-9f20-bc0d3b237f6a
+
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/jdfalk/gcommon/pkg/config"
+)
+
+// FileProvider stores configuration in a JSON file.
+type FileProvider struct {
+	path     string
+	mu       sync.RWMutex
+	data     map[string]interface{}
+	watchers map[string][]func(interface{})
+}
+
+// NewFileProvider creates a FileProvider from the given config map.
+func NewFileProvider(cfg map[string]interface{}) (config.Provider, error) {
+	path, ok := cfg["path"].(string)
+	if !ok || path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	fp := &FileProvider{path: path, data: map[string]interface{}{}, watchers: map[string][]func(interface{}){}}
+	if err := fp.load(); err != nil {
+		return nil, err
+	}
+	return fp, nil
+}
+
+func (p *FileProvider) load() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	b, err := os.ReadFile(p.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			p.data = map[string]interface{}{}
+			return nil
+		}
+		return err
+	}
+	return json.Unmarshal(b, &p.data)
+}
+
+func (p *FileProvider) save() error {
+	b, err := json.MarshalIndent(p.data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p.path, b, 0o600)
+}
+
+// Get retrieves a value from the file store.
+func (p *FileProvider) Get(key string) (interface{}, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	v, ok := p.data[key]
+	if !ok {
+		return nil, fmt.Errorf("key not found: %s", key)
+	}
+	return v, nil
+}
+
+// Set writes a value to the file store.
+func (p *FileProvider) Set(key string, value interface{}) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.data[key] = value
+	if err := p.save(); err != nil {
+		return err
+	}
+	for _, cb := range p.watchers[key] {
+		cb(value)
+	}
+	return nil
+}
+
+// Watch registers a callback for key changes.
+func (p *FileProvider) Watch(key string, callback func(interface{})) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.watchers[key] = append(p.watchers[key], callback)
+	return nil
+}
+
+// Close is a no-op for FileProvider.
+func (p *FileProvider) Close() error { return nil }
+
+func init() {
+	config.RegisterProvider("file", NewFileProvider)
+}


### PR DESCRIPTION
## Summary
Implemented foundational Config module components including provider interfaces, factory registry, file and environment providers, tests, and documentation.

## Issues Addressed
### feat(config): add provider factory and basic providers
**Description:** Introduced provider interface, factory pattern, env and file providers, and initial module docs and tests.
**Files Modified:**
- `pkg/config/interfaces.go` - define provider and service interfaces
- `pkg/config/factory.go` - add provider registry and constructor pattern
- `pkg/config/providers/env.go` - environment variable provider
- `pkg/config/providers/file.go` - JSON file-based provider with watch support
- `pkg/config/factory_test.go` - factory registration tests
- `pkg/config/providers/env_test.go` - env provider tests
- `pkg/config/README.md` - initial module documentation
- `CHANGELOG.md` - note config provider factory addition
- `TODO.md` - track remaining config module tasks

## Testing
- `go test ./pkg/config/...`

## Breaking Changes
- None

## Additional Notes
- None


------
https://chatgpt.com/codex/tasks/task_e_68980872c27c8321807023f0a4b5d788