### PR TITLE
feat(buf): scaffold multi-language SDK generation

### DIFF
--- a/.github/doc-updates/50776edc-deef-4ff6-b7b4-b3ebadee0b6c.json
+++ b/.github/doc-updates/50776edc-deef-4ff6-b7b4-b3ebadee0b6c.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add buf plugins for generating multi-language SDKs",
+  "guid": "50776edc-deef-4ff6-b7b4-b3ebadee0b6c",
+  "created_at": "2025-08-10T02:55:54Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/7fe54475-1f9b-49dc-a598-fb02fb4870d2.json
+++ b/.github/issue-updates/7fe54475-1f9b-49dc-a598-fb02fb4870d2.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Add multi-language SDK generation",
+  "body": "Add protobuf generation plugins for Python, TypeScript, Java, and C# in buf.gen.yaml",
+  "labels": ["enhancement"],
+  "guid": "7fe54475-1f9b-49dc-a598-fb02fb4870d2",
+  "legacy_guid": "create-add-multi-language-sdk-generation-2025-08-10",
+  "created_at": "2025-08-10T02:55:18.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -19,3 +19,33 @@ plugins:
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
+  - remote: buf.build/protocolbuffers/python
+    out: sdks/python
+    opt:
+      - paths=source_relative
+  - remote: buf.build/grpc/python
+    out: sdks/python
+    opt:
+      - paths=source_relative
+  - remote: buf.build/protocolbuffers/js
+    out: sdks/ts
+    opt:
+      - import_style=commonjs
+      - binary
+  - remote: buf.build/grpc/web
+    out: sdks/ts
+    opt:
+      - import_style=typescript
+      - mode=grpcweb
+  - remote: buf.build/protocolbuffers/java
+    out: sdks/java
+    opt:
+      - lite
+  - remote: buf.build/grpc/java
+    out: sdks/java
+    opt:
+      - lite
+  - remote: buf.build/protocolbuffers/csharp
+    out: sdks/csharp
+  - remote: buf.build/grpc/csharp
+    out: sdks/csharp

--- a/sdks/.gitignore
+++ b/sdks/.gitignore
@@ -1,0 +1,7 @@
+# file: sdks/.gitignore
+# version: 1.0.0
+# guid: 1b8d87e0-2c93-4a74-b5f2-1d594de2fc80
+
+# Ignore all generated SDK files
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- configure Buf to emit client SDKs for Python, TypeScript, Java, and C#
- ignore generated SDK artifacts to keep repo clean

## Issues Addressed
### feat(buf): scaffold multi-language SDK generation
**Description:** Configure Buf for multi-language client SDK generation and track the change with issue and changelog updates.

**Files Modified:**
- [`buf.gen.yaml`](./buf.gen.yaml) - add language-specific plugins | [[diff]](../../pull/PR_NUMBER/files#diff-?) [[repo]](./buf.gen.yaml)
- [`sdks/.gitignore`](./sdks/.gitignore) - ignore generated SDK artifacts | [[diff]](../../pull/PR_NUMBER/files#diff-?) [[repo]](./sdks/.gitignore)
- [`.github/issue-updates/7fe54475-1f9b-49dc-a598-fb02fb4870d2.json`](./.github/issue-updates/7fe54475-1f9b-49dc-a598-fb02fb4870d2.json) - record issue creation | [[diff]](../../pull/PR_NUMBER/files#diff-?) [[repo]](./.github/issue-updates/7fe54475-1f9b-49dc-a598-fb02fb4870d2.json)
- [`.github/doc-updates/50776edc-deef-4ff6-b7b4-b3ebadee0b6c.json`](./.github/doc-updates/50776edc-deef-4ff6-b7b4-b3ebadee0b6c.json) - add changelog entry | [[diff]](../../pull/PR_NUMBER/files#diff-?) [[repo]](./.github/doc-updates/50776edc-deef-4ff6-b7b4-b3ebadee0b6c.json)

## Testing
- `go test ./...`
- `buf generate` (command not found; attempted `go install github.com/bufbuild/buf/cmd/buf@latest` but installation requires Go 1.24)

## Breaking Changes
- None

## Additional Notes
- Attempted to install `buf` to verify generation but environment lacks required Go version.

## Related Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_6898095952588321b6c4044e12692d33