### PR TITLE
feat(errors): standardize error handling across modules

### DIFF
--- a/.github/doc-updates/3c39cb19-0416-42c7-9d6a-7d29dae94970.json
+++ b/.github/doc-updates/3c39cb19-0416-42c7-9d6a-7d29dae94970.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement comprehensive error handling across modules",
+  "guid": "3c39cb19-0416-42c7-9d6a-7d29dae94970",
+  "created_at": "2025-08-10T02:55:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/3f4ed5ba-5fec-44ee-9bde-49bca2a0def7.json
+++ b/.github/doc-updates/3f4ed5ba-5fec-44ee-9bde-49bca2a0def7.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Error Handling\\n\\nInitial error handling framework with standardized error codes.",
+  "guid": "3f4ed5ba-5fec-44ee-9bde-49bca2a0def7",
+  "created_at": "2025-08-10T02:55:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5ab94410-3640-4c58-aec5-3a11b8b960d1.json
+++ b/.github/doc-updates/5ab94410-3640-4c58-aec5-3a11b8b960d1.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented comprehensive error handling framework across modules",
+  "guid": "5ab94410-3640-4c58-aec5-3a11b8b960d1",
+  "created_at": "2025-08-10T12:39:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/767bd746-6d6a-448c-b639-ef863995f1ba.json
+++ b/.github/doc-updates/767bd746-6d6a-448c-b639-ef863995f1ba.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### Error Handling\\nStandardized errors across modules with codes, wrapping, and monitoring.",
+  "guid": "767bd746-6d6a-448c-b639-ef863995f1ba",
+  "created_at": "2025-08-10T12:39:25Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e5aa4c37-2a33-478e-9f6b-447894e3e60d.json
+++ b/.github/doc-updates/e5aa4c37-2a33-478e-9f6b-447894e3e60d.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add initial error handling framework",
+  "guid": "e5aa4c37-2a33-478e-9f6b-447894e3e60d",
+  "created_at": "2025-08-10T02:55:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/2a40ebc7-e42d-4bca-ad8c-eb2be0d96f7c.json
+++ b/.github/issue-updates/2a40ebc7-e42d-4bca-ad8c-eb2be0d96f7c.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Standardize error handling across modules",
+  "body": "Implement base error framework with common codes and wrapping utilities.",
+  "labels": ["module:common", "type:feature", "enhancement", "codex"],
+  "guid": "2a40ebc7-e42d-4bca-ad8c-eb2be0d96f7c",
+  "legacy_guid": "create-standardize-error-handling-across-modules-2025-08-10",
+  "created_at": "2025-08-10T02:55:38.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/72e0dae2-572f-4485-9329-1b29cb3443c6.json
+++ b/.github/issue-updates/72e0dae2-572f-4485-9329-1b29cb3443c6.json
@@ -1,0 +1,12 @@
+{
+  "action": "comment",
+  "number": null,
+  "body": "Implemented comprehensive error handling framework across modules",
+  "guid": "72e0dae2-572f-4485-9329-1b29cb3443c6",
+  "legacy_guid": "comment-issue--2025-08-10",
+  "created_at": "2025-08-10T12:39:32.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -1,0 +1,75 @@
+// file: pkg/errors/codes.go
+// version: 1.1.0
+// guid: e8950930-ae06-40b9-b3f6-2a64a16af24a
+
+package errors
+
+// ErrorCode represents a standardized gcommon error code.
+type ErrorCode int
+
+const (
+	// General errors
+	ErrCodeUnknown ErrorCode = iota
+	ErrCodeInternal
+	ErrCodeInvalidInput
+	ErrCodeNotFound
+	ErrCodeAlreadyExists
+	ErrCodeTimeout
+	ErrCodeUnavailable
+
+	// Config module errors
+	ErrCodeConfigNotFound
+	ErrCodeConfigInvalid
+	ErrCodeConfigReadOnly
+
+	// Queue module errors
+	ErrCodeQueueNotFound
+	ErrCodeQueueFull
+	ErrCodeMessageTooLarge
+
+	// Auth module errors
+	ErrCodeUnauthorized
+	ErrCodeForbidden
+	ErrCodeTokenExpired
+	ErrCodeTokenInvalid
+
+	// Metrics module errors
+	ErrCodeMetricNotFound
+	ErrCodeMetricInvalid
+	ErrCodeMetricCollectionFailed
+	ErrCodeMetricExportFailed
+	ErrCodeMetricProviderUnavailable
+
+	// Health module errors
+	ErrCodeHealthCheckFailed
+	ErrCodeHealthServiceUnavailable
+	ErrCodeHealthTimeout
+
+	// Cache module errors
+	ErrCodeCacheMiss
+	ErrCodeCacheUnavailable
+	ErrCodeCacheCorrupted
+	ErrCodeCacheSerialization
+	ErrCodeCacheDeserialization
+
+	// Web module errors
+	ErrCodeRouteNotFound
+	ErrCodeRenderFailed
+	ErrCodeSessionExpired
+	ErrCodeBadGateway
+	ErrCodeCSRFDetected
+
+	// Database module errors
+	ErrCodeDBConnection
+	ErrCodeDBQuery
+	ErrCodeDBTransaction
+	ErrCodeDBMigration
+	ErrCodeDBConstraint
+
+	// Logging module errors
+	ErrCodeLogWriteFailed
+	ErrCodeLogConfiguration
+	ErrCodeLogRotationFailed
+	ErrCodeLogPermissionDenied
+	ErrCodeLogUnknownFormat
+)

--- a/pkg/errors/codes_test.go
+++ b/pkg/errors/codes_test.go
@@ -1,0 +1,36 @@
+// file: pkg/errors/codes_test.go
+// version: 1.0.0
+// guid: b1c2d3e4-1516-4f12-f345-1234567890cd
+
+package errors
+
+import "testing"
+
+// TestErrorCodeUniqueness ensures error codes are unique.
+func TestErrorCodeUniqueness(t *testing.T) {
+	seen := map[ErrorCode]bool{}
+	codes := []ErrorCode{
+		ErrCodeUnknown, ErrCodeInternal, ErrCodeInvalidInput, ErrCodeNotFound,
+		ErrCodeAlreadyExists, ErrCodeTimeout, ErrCodeUnavailable,
+		ErrCodeConfigNotFound, ErrCodeConfigInvalid, ErrCodeConfigReadOnly,
+		ErrCodeQueueNotFound, ErrCodeQueueFull, ErrCodeMessageTooLarge,
+		ErrCodeUnauthorized, ErrCodeForbidden, ErrCodeTokenExpired, ErrCodeTokenInvalid,
+		ErrCodeMetricNotFound, ErrCodeMetricInvalid, ErrCodeMetricCollectionFailed,
+		ErrCodeMetricExportFailed, ErrCodeMetricProviderUnavailable,
+		ErrCodeHealthCheckFailed, ErrCodeHealthServiceUnavailable, ErrCodeHealthTimeout,
+		ErrCodeCacheMiss, ErrCodeCacheUnavailable, ErrCodeCacheCorrupted,
+		ErrCodeCacheSerialization, ErrCodeCacheDeserialization,
+		ErrCodeRouteNotFound, ErrCodeRenderFailed, ErrCodeSessionExpired,
+		ErrCodeBadGateway, ErrCodeCSRFDetected,
+		ErrCodeDBConnection, ErrCodeDBQuery, ErrCodeDBTransaction,
+		ErrCodeDBMigration, ErrCodeDBConstraint,
+		ErrCodeLogWriteFailed, ErrCodeLogConfiguration, ErrCodeLogRotationFailed,
+		ErrCodeLogPermissionDenied, ErrCodeLogUnknownFormat,
+	}
+	for _, c := range codes {
+		if seen[c] {
+			t.Fatalf("duplicate code: %v", c)
+		}
+		seen[c] = true
+	}
+}

--- a/pkg/errors/collection.go
+++ b/pkg/errors/collection.go
@@ -1,0 +1,39 @@
+// file: pkg/errors/collection.go
+// version: 1.0.0
+// guid: c4f5aa8b-90d4-4b16-8c5c-f1990e8abcde
+
+package errors
+
+import "strings"
+
+// Collection aggregates multiple Errors.
+type Collection struct {
+	errs []Error
+}
+
+// Add appends an Error to the collection.
+func (c *Collection) Add(err Error) {
+	if err == nil {
+		return
+	}
+	c.errs = append(c.errs, err)
+}
+
+// Error implements the error interface returning a concatenated message.
+func (c *Collection) Error() string {
+	msgs := make([]string, 0, len(c.errs))
+	for _, e := range c.errs {
+		msgs = append(msgs, e.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// Errors returns the underlying slice of Errors.
+func (c *Collection) Errors() []Error {
+	return c.errs
+}
+
+// Len returns the number of errors in the collection.
+func (c *Collection) Len() int {
+	return len(c.errs)
+}

--- a/pkg/errors/collection_test.go
+++ b/pkg/errors/collection_test.go
@@ -1,0 +1,30 @@
+// file: pkg/errors/collection_test.go
+// version: 1.0.0
+// guid: 7d8e9f10-1112-4d0e-ef01-789012345678
+
+package errors
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCollectionAdd verifies that errors can be aggregated.
+func TestCollectionAdd(t *testing.T) {
+	c := &Collection{}
+	c.Add(NewError(context.Background(), ErrCodeInternal, "one"))
+	c.Add(NewError(context.Background(), ErrCodeInternal, "two"))
+	if c.Len() != 2 {
+		t.Fatalf("expected 2 errors, got %d", c.Len())
+	}
+}
+
+// TestCollectionError ensures concatenated error messages are produced.
+func TestCollectionError(t *testing.T) {
+	c := &Collection{}
+	c.Add(NewError(context.Background(), ErrCodeInternal, "one"))
+	c.Add(NewError(context.Background(), ErrCodeInternal, "two"))
+	if c.Error() != "one; two" {
+		t.Fatalf("unexpected error string: %s", c.Error())
+	}
+}

--- a/pkg/errors/context.go
+++ b/pkg/errors/context.go
@@ -1,0 +1,52 @@
+// file: pkg/errors/context.go
+// version: 1.0.0
+// guid: 3a7a7b72-4a0d-4e0e-9f9f-0b276dbe6aa2
+
+package errors
+
+import "context"
+
+// ctxKey is used to store errors within a context.Context.
+type ctxKey struct{}
+
+// NewError creates a new Error with the supplied context and message.
+func NewError(ctx context.Context, code ErrorCode, message string) Error {
+	return NewErrorWithDetails(ctx, code, message, map[string]interface{}{})
+}
+
+// NewErrorWithDetails creates a new Error with additional details.
+func NewErrorWithDetails(ctx context.Context, code ErrorCode, message string, details map[string]interface{}) Error {
+	be := newBaseError(code, componentFromContext(ctx), operationFromContext(ctx), message)
+	if details != nil {
+		be.details = details
+	}
+	return be
+}
+
+// WithError stores an Error in the context.
+func WithError(ctx context.Context, err Error) context.Context {
+	return context.WithValue(ctx, ctxKey{}, err)
+}
+
+// FromContext retrieves an Error from the context if present.
+func FromContext(ctx context.Context) Error {
+	if v := ctx.Value(ctxKey{}); v != nil {
+		if err, ok := v.(Error); ok {
+			return err
+		}
+	}
+	return nil
+}
+
+// componentFromContext extracts a component name from context metadata.
+// In this initial implementation the component is not derived from context,
+// but the hook exists for future extensibility.
+func componentFromContext(ctx context.Context) string {
+	return ""
+}
+
+// operationFromContext extracts an operation name from context metadata.
+// This is a placeholder for future contextual operation tracking.
+func operationFromContext(ctx context.Context) string {
+	return ""
+}

--- a/pkg/errors/context_test.go
+++ b/pkg/errors/context_test.go
@@ -1,0 +1,27 @@
+// file: pkg/errors/context_test.go
+// version: 1.0.0
+// guid: 8e9f1011-1213-4e0f-f012-890123456789
+
+package errors
+
+import (
+	"context"
+	"testing"
+)
+
+// TestContextStorage verifies storing and retrieving errors in context.
+func TestContextStorage(t *testing.T) {
+	err := NewError(context.Background(), ErrCodeInternal, "ctx")
+	ctx := WithError(context.Background(), err)
+	retrieved := FromContext(ctx)
+	if retrieved == nil || retrieved.Error() != "ctx" {
+		t.Fatalf("expected to retrieve error")
+	}
+}
+
+// TestContextStorageMissing verifies retrieval when no error stored.
+func TestContextStorageMissing(t *testing.T) {
+	if FromContext(context.Background()) != nil {
+		t.Fatalf("expected nil error")
+	}
+}

--- a/pkg/errors/examples/basic_errors.go
+++ b/pkg/errors/examples/basic_errors.go
@@ -1,0 +1,20 @@
+// file: pkg/errors/examples/basic_errors.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-4789-abcd-1234567890ef
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	errpkg "github.com/jdfalk/gcommon/pkg/errors"
+)
+
+// ExampleBasic demonstrates basic error creation and formatting.
+func ExampleBasic() {
+	err := errpkg.NewError(context.Background(), errpkg.ErrCodeInternal, "something broke")
+	fmt.Println(errpkg.FormatError(err))
+	// Output:
+	// something broke
+}

--- a/pkg/errors/examples/error_chain.go
+++ b/pkg/errors/examples/error_chain.go
@@ -1,0 +1,21 @@
+// file: pkg/errors/examples/error_chain.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-4901-abcd-3456789023cd
+
+package examples
+
+import (
+	"errors"
+	"fmt"
+
+	errpkg "github.com/jdfalk/gcommon/pkg/errors"
+)
+
+// ExampleErrorChain demonstrates wrapping an existing error.
+func ExampleErrorChain() {
+	base := errors.New("disk failure")
+	wrapped := errpkg.WrapWithCode(base, errpkg.ErrCodeInternal, "storage", "write")
+	fmt.Println(errpkg.FormatError(wrapped))
+	// Output:
+	// disk failure component=storage operation=write
+}

--- a/pkg/errors/examples/grpc_errors.go
+++ b/pkg/errors/examples/grpc_errors.go
@@ -1,0 +1,25 @@
+// file: pkg/errors/examples/grpc_errors.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-4890-abcd-2345678901bc
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	errpkg "github.com/jdfalk/gcommon/pkg/errors"
+	"google.golang.org/grpc/status"
+)
+
+// ExampleGRPC demonstrates converting between internal errors and gRPC statuses.
+func ExampleGRPC() {
+	err := errpkg.NewError(context.Background(), errpkg.ErrCodeInvalidInput, "bad request")
+	st := errpkg.ToGRPCStatus(err)
+	fmt.Println(st.Code())
+	restored := errpkg.FromGRPCStatus(status.New(st.Code(), st.Message()))
+	fmt.Println(restored.Code())
+	// Output:
+	// InvalidArgument
+	// ErrCodeInvalidInput
+}

--- a/pkg/errors/formatting.go
+++ b/pkg/errors/formatting.go
@@ -1,0 +1,41 @@
+// file: pkg/errors/formatting.go
+// version: 1.0.0
+// guid: d6b9a3b4-9c5f-4c18-badf-0ef123456789
+
+package errors
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FormatError returns a human-friendly representation of an Error.
+func FormatError(err Error) string {
+	if err == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(err.Error())
+	if c := err.Component(); c != "" {
+		b.WriteString(fmt.Sprintf(" component=%s", c))
+	}
+	if o := err.Operation(); o != "" {
+		b.WriteString(fmt.Sprintf(" operation=%s", o))
+	}
+	if len(err.Details()) > 0 {
+		keys := make([]string, 0, len(err.Details()))
+		for k := range err.Details() {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		b.WriteString(" details=")
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(fmt.Sprintf("%s=%v", k, err.Details()[k]))
+		}
+	}
+	return b.String()
+}

--- a/pkg/errors/formatting_test.go
+++ b/pkg/errors/formatting_test.go
@@ -1,0 +1,21 @@
+// file: pkg/errors/formatting_test.go
+// version: 1.0.0
+// guid: 9f10a1b2-1314-4e10-f123-901234567890
+
+package errors
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestFormatError ensures formatted output contains key information.
+func TestFormatError(t *testing.T) {
+	err := WrapWithCode(NewError(context.Background(), ErrCodeInternal, "boom"), ErrCodeInternal, "comp", "op")
+	err = WrapWithDetails(err, map[string]interface{}{"k": "v"})
+	out := FormatError(err)
+	if !strings.Contains(out, "comp") || !strings.Contains(out, "k=v") {
+		t.Fatalf("unexpected format: %s", out)
+	}
+}

--- a/pkg/errors/grpc.go
+++ b/pkg/errors/grpc.go
@@ -1,0 +1,94 @@
+// file: pkg/errors/grpc.go
+// version: 1.0.0
+// guid: 0f3e18ec-b74a-4e3f-b54e-6fc5c5abc123
+
+package errors
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	grpcCodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ToGRPCStatus converts an internal Error to a gRPC status.Status.
+func ToGRPCStatus(err Error) *status.Status {
+	if err == nil {
+		return status.New(grpcCodes.OK, "")
+	}
+	code := grpcCodes.Unknown
+	switch err.Code() {
+	case ErrCodeInvalidInput:
+		code = grpcCodes.InvalidArgument
+	case ErrCodeNotFound:
+		code = grpcCodes.NotFound
+	case ErrCodeAlreadyExists:
+		code = grpcCodes.AlreadyExists
+	case ErrCodeTimeout:
+		code = grpcCodes.DeadlineExceeded
+	case ErrCodeUnavailable:
+		code = grpcCodes.Unavailable
+	case ErrCodeUnauthorized:
+		code = grpcCodes.Unauthenticated
+	case ErrCodeForbidden:
+		code = grpcCodes.PermissionDenied
+	default:
+		code = grpcCodes.Unknown
+	}
+	return status.New(code, err.Error())
+}
+
+// FromGRPCStatus converts a gRPC status.Status to an internal Error.
+func FromGRPCStatus(st *status.Status) Error {
+	if st == nil {
+		return nil
+	}
+	var code ErrorCode
+	switch st.Code() {
+	case grpcCodes.InvalidArgument:
+		code = ErrCodeInvalidInput
+	case grpcCodes.NotFound:
+		code = ErrCodeNotFound
+	case grpcCodes.AlreadyExists:
+		code = ErrCodeAlreadyExists
+	case grpcCodes.DeadlineExceeded:
+		code = ErrCodeTimeout
+	case grpcCodes.Unavailable:
+		code = ErrCodeUnavailable
+	case grpcCodes.Unauthenticated:
+		code = ErrCodeUnauthorized
+	case grpcCodes.PermissionDenied:
+		code = ErrCodeForbidden
+	default:
+		code = ErrCodeUnknown
+	}
+	return newBaseError(code, "grpc", "", st.Message())
+}
+
+// ErrorHandlingInterceptor is a unary interceptor converting Errors to gRPC statuses.
+func ErrorHandlingInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		resp, err := handler(ctx, req)
+		if err != nil {
+			if e, ok := err.(Error); ok {
+				return nil, ToGRPCStatus(e).Err()
+			}
+			return nil, err
+		}
+		return resp, nil
+	}
+}
+
+// ErrorHandlingStreamInterceptor is a stream interceptor converting Errors to gRPC statuses.
+func ErrorHandlingStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := handler(srv, ss); err != nil {
+			if e, ok := err.(Error); ok {
+				return ToGRPCStatus(e).Err()
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/errors/grpc_test.go
+++ b/pkg/errors/grpc_test.go
@@ -1,0 +1,25 @@
+// file: pkg/errors/grpc_test.go
+// version: 1.0.0
+// guid: 4a5b6c7d-8e9f-4a0b-bcde-456789012345
+
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+// TestToFromGRPCStatus verifies conversion between Error and gRPC status.
+func TestToFromGRPCStatus(t *testing.T) {
+	err := NewError(context.Background(), ErrCodeInvalidInput, "bad")
+	st := ToGRPCStatus(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	}
+	restored := FromGRPCStatus(st)
+	if restored.Code() != ErrCodeInvalidInput {
+		t.Fatalf("expected ErrCodeInvalidInput, got %v", restored.Code())
+	}
+}

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -1,0 +1,51 @@
+// file: pkg/errors/http.go
+// version: 1.0.0
+// guid: 21b70e69-5e9d-4e40-b9d1-8f89980bba34
+
+package errors
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ToHTTPStatus maps an Error to an HTTP status code.
+func ToHTTPStatus(err Error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	switch err.Code() {
+	case ErrCodeInvalidInput:
+		return http.StatusBadRequest
+	case ErrCodeNotFound:
+		return http.StatusNotFound
+	case ErrCodeAlreadyExists:
+		return http.StatusConflict
+	case ErrCodeTimeout:
+		return http.StatusGatewayTimeout
+	case ErrCodeUnauthorized:
+		return http.StatusUnauthorized
+	case ErrCodeForbidden:
+		return http.StatusForbidden
+	case ErrCodeUnavailable:
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// HTTPErrorResponse is the serialized HTTP error payload.
+type HTTPErrorResponse struct {
+	Code    int                    `json:"code"`
+	Message string                 `json:"message"`
+	Details map[string]interface{} `json:"details,omitempty"`
+}
+
+// WriteHTTPError writes an Error to an http.ResponseWriter as JSON.
+func WriteHTTPError(w http.ResponseWriter, err Error) {
+	status := ToHTTPStatus(err)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	payload := HTTPErrorResponse{Code: int(err.Code()), Message: err.Error(), Details: err.Details()}
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/pkg/errors/http_test.go
+++ b/pkg/errors/http_test.go
@@ -1,0 +1,43 @@
+// file: pkg/errors/http_test.go
+// version: 1.0.0
+// guid: 5b6c7d8e-9f10-4b0c-cdef-567890123456
+
+package errors
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestWriteHTTPError ensures HTTP responses use proper status codes and body.
+func TestWriteHTTPError(t *testing.T) {
+	err := NewError(context.Background(), ErrCodeNotFound, "missing")
+	rec := httptest.NewRecorder()
+	WriteHTTPError(rec, err)
+	if rec.Code != 404 {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestToHTTPStatus verifies mapping between error codes and HTTP statuses.
+func TestToHTTPStatus(t *testing.T) {
+	cases := []struct {
+		code     ErrorCode
+		expected int
+	}{
+		{ErrCodeInvalidInput, 400},
+		{ErrCodeNotFound, 404},
+		{ErrCodeAlreadyExists, 409},
+		{ErrCodeTimeout, 504},
+		{ErrCodeUnauthorized, 401},
+		{ErrCodeForbidden, 403},
+	}
+	for _, c := range cases {
+		err := NewError(context.Background(), c.code, "msg")
+		status := ToHTTPStatus(err)
+		if status != c.expected {
+			t.Fatalf("unexpected status for %v: got %d", c.code, status)
+		}
+	}
+}

--- a/pkg/errors/interceptor_test.go
+++ b/pkg/errors/interceptor_test.go
@@ -1,0 +1,43 @@
+// file: pkg/errors/interceptor_test.go
+// version: 1.0.0
+// guid: a0b1c2d3-1415-4f11-f234-0123456789ab
+
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+// TestErrorHandlingInterceptor ensures unary interceptor converts errors.
+func TestErrorHandlingInterceptor(t *testing.T) {
+	interceptor := ErrorHandlingInterceptor()
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, NewError(ctx, ErrCodeInvalidInput, "bad")
+	}
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, handler)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+// TestErrorHandlingStreamInterceptor ensures stream interceptor converts errors.
+func TestErrorHandlingStreamInterceptor(t *testing.T) {
+	interceptor := ErrorHandlingStreamInterceptor()
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		return NewError(ss.Context(), ErrCodeInvalidInput, "bad")
+	}
+	err := interceptor(nil, &noopServerStream{ctx: context.Background()}, &grpc.StreamServerInfo{}, handler)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+type noopServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (n *noopServerStream) Context() context.Context { return n.ctx }

--- a/pkg/errors/reporter.go
+++ b/pkg/errors/reporter.go
@@ -1,0 +1,83 @@
+// file: pkg/errors/reporter.go
+// version: 1.0.0
+// guid: e2a91c7d-58dc-4dbb-9ae1-1234567890ab
+
+package errors
+
+import (
+	"context"
+	"sync"
+)
+
+// ErrorReporter defines an interface for reporting and tracking errors.
+type ErrorReporter interface {
+	ReportError(ctx context.Context, err Error)
+	ReportErrorWithTags(ctx context.Context, err Error, tags map[string]string)
+	GetErrorStats() *ErrorStats
+	Reset()
+}
+
+// ErrorStats aggregates statistics about reported errors.
+type ErrorStats struct {
+	TotalErrors    int64
+	ErrorsByCode   map[ErrorCode]int64
+	ErrorsByModule map[string]int64
+	RecentErrors   []Error
+}
+
+// MemoryReporter is an in-memory implementation of ErrorReporter.
+type MemoryReporter struct {
+	mu    sync.Mutex
+	stats ErrorStats
+}
+
+// NewMemoryReporter creates a new MemoryReporter.
+func NewMemoryReporter() *MemoryReporter {
+	return &MemoryReporter{
+		stats: ErrorStats{
+			ErrorsByCode:   map[ErrorCode]int64{},
+			ErrorsByModule: map[string]int64{},
+			RecentErrors:   []Error{},
+		},
+	}
+}
+
+// ReportError records an error without additional tags.
+func (r *MemoryReporter) ReportError(ctx context.Context, err Error) {
+	r.ReportErrorWithTags(ctx, err, map[string]string{})
+}
+
+// ReportErrorWithTags records an error and associated tags.
+func (r *MemoryReporter) ReportErrorWithTags(ctx context.Context, err Error, tags map[string]string) {
+	if err == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stats.TotalErrors++
+	r.stats.ErrorsByCode[err.Code()]++
+	r.stats.ErrorsByModule[err.Component()]++
+	if len(r.stats.RecentErrors) >= 10 {
+		r.stats.RecentErrors = r.stats.RecentErrors[1:]
+	}
+	r.stats.RecentErrors = append(r.stats.RecentErrors, err)
+}
+
+// GetErrorStats returns a copy of the current statistics.
+func (r *MemoryReporter) GetErrorStats() *ErrorStats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	stats := r.stats
+	return &stats
+}
+
+// Reset clears all collected statistics.
+func (r *MemoryReporter) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stats = ErrorStats{
+		ErrorsByCode:   map[ErrorCode]int64{},
+		ErrorsByModule: map[string]int64{},
+		RecentErrors:   []Error{},
+	}
+}

--- a/pkg/errors/reporter_test.go
+++ b/pkg/errors/reporter_test.go
@@ -1,0 +1,29 @@
+// file: pkg/errors/reporter_test.go
+// version: 1.0.0
+// guid: 6c7d8e9f-1011-4c0d-def0-678901234567
+
+package errors
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMemoryReporter verifies basic statistics collection.
+func TestMemoryReporter(t *testing.T) {
+	r := NewMemoryReporter()
+	r.ReportError(context.Background(), NewError(context.Background(), ErrCodeInternal, "boom"))
+	r.ReportErrorWithTags(context.Background(), NewError(context.Background(), ErrCodeInternal, "boom2"), map[string]string{"env": "test"})
+	stats := r.GetErrorStats()
+	if stats.TotalErrors != 2 {
+		t.Fatalf("expected 2, got %d", stats.TotalErrors)
+	}
+	if stats.ErrorsByCode[ErrCodeInternal] != 2 {
+		t.Fatalf("expected code count 2")
+	}
+	r.Reset()
+	stats = r.GetErrorStats()
+	if stats.TotalErrors != 0 {
+		t.Fatalf("expected reset stats")
+	}
+}

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -1,0 +1,230 @@
+// file: pkg/errors/types.go
+// version: 1.1.0
+// guid: 37832aac-5f14-4afb-a369-4f83256e11b6
+
+package errors
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Error is the base interface for all gcommon errors with rich context.
+type Error interface {
+	error
+	Code() ErrorCode
+	Component() string
+	Operation() string
+	Details() map[string]interface{}
+	Cause() error
+	Stack() []string
+	Temporary() bool
+	Retryable() bool
+}
+
+// BaseError provides a default implementation of the Error interface.
+type BaseError struct {
+	code      ErrorCode
+	component string
+	operation string
+	message   string
+	details   map[string]interface{}
+	cause     error
+	stack     []string
+	temporary bool
+	retryable bool
+}
+
+// Error implements the error interface.
+func (e *BaseError) Error() string {
+	return e.message
+}
+
+// Code returns the error code.
+func (e *BaseError) Code() ErrorCode {
+	return e.code
+}
+
+// Component returns the component where the error originated.
+func (e *BaseError) Component() string {
+	return e.component
+}
+
+// Operation returns the operation that failed.
+func (e *BaseError) Operation() string {
+	return e.operation
+}
+
+// Details returns additional error details.
+func (e *BaseError) Details() map[string]interface{} {
+	return e.details
+}
+
+// Cause returns the underlying error cause.
+func (e *BaseError) Cause() error {
+	return e.cause
+}
+
+// Stack returns the stack trace at error creation.
+func (e *BaseError) Stack() []string {
+	return e.stack
+}
+
+// Temporary reports whether the error is temporary.
+func (e *BaseError) Temporary() bool {
+	return e.temporary
+}
+
+// Retryable reports whether the operation may be retried.
+func (e *BaseError) Retryable() bool {
+	return e.retryable
+}
+
+// newBaseError creates a BaseError with captured stack information.
+func newBaseError(code ErrorCode, component, operation, message string) *BaseError {
+	return &BaseError{
+		code:      code,
+		component: component,
+		operation: operation,
+		message:   message,
+		details:   map[string]interface{}{},
+		stack:     captureStack(),
+	}
+}
+
+// captureStack records the current call stack as a slice of strings.
+func captureStack() []string {
+	const depth = 32
+	pcs := make([]uintptr, depth)
+	n := runtime.Callers(3, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	stack := make([]string, 0, n)
+	for {
+		frame, more := frames.Next()
+		stack = append(stack, fmt.Sprintf("%s:%d", frame.Function, frame.Line))
+		if !more {
+			break
+		}
+	}
+	return stack
+}
+
+// ConfigError represents configuration-related failures.
+type ConfigError struct {
+	BaseError
+	ConfigKey   string
+	ConfigValue interface{}
+}
+
+// NewConfigError constructs a ConfigError.
+func NewConfigError(code ErrorCode, key string, value interface{}, message string) *ConfigError {
+	return &ConfigError{
+		BaseError:   *newBaseError(code, "config", "", message),
+		ConfigKey:   key,
+		ConfigValue: value,
+	}
+}
+
+// QueueError represents queue processing failures.
+type QueueError struct {
+	BaseError
+	QueueName string
+	MessageID string
+}
+
+// NewQueueError constructs a QueueError.
+func NewQueueError(code ErrorCode, queue, msgID, message string) *QueueError {
+	return &QueueError{
+		BaseError: *newBaseError(code, "queue", "", message),
+		QueueName: queue,
+		MessageID: msgID,
+	}
+}
+
+// AuthError represents authentication and authorization failures.
+type AuthError struct {
+	BaseError
+	UserID   string
+	Resource string
+	Action   string
+}
+
+// NewAuthError constructs an AuthError.
+func NewAuthError(code ErrorCode, userID, resource, action, message string) *AuthError {
+	return &AuthError{
+		BaseError: *newBaseError(code, "auth", "", message),
+		UserID:    userID,
+		Resource:  resource,
+		Action:    action,
+	}
+}
+
+// MetricsError represents metric collection and export failures.
+type MetricsError struct {
+	BaseError
+	MetricName string
+}
+
+// NewMetricsError constructs a MetricsError.
+func NewMetricsError(code ErrorCode, metric, message string) *MetricsError {
+	return &MetricsError{
+		BaseError:  *newBaseError(code, "metrics", "", message),
+		MetricName: metric,
+	}
+}
+
+// CacheError represents cache access failures.
+type CacheError struct {
+	BaseError
+	Key string
+}
+
+// NewCacheError constructs a CacheError.
+func NewCacheError(code ErrorCode, key, message string) *CacheError {
+	return &CacheError{
+		BaseError: *newBaseError(code, "cache", "", message),
+		Key:       key,
+	}
+}
+
+// WebError represents web module failures.
+type WebError struct {
+	BaseError
+	Route string
+}
+
+// NewWebError constructs a WebError.
+func NewWebError(code ErrorCode, route, message string) *WebError {
+	return &WebError{
+		BaseError: *newBaseError(code, "web", "", message),
+		Route:     route,
+	}
+}
+
+// DBError represents database query failures.
+type DBError struct {
+	BaseError
+	Query string
+}
+
+// NewDBError constructs a DBError.
+func NewDBError(code ErrorCode, query, message string) *DBError {
+	return &DBError{
+		BaseError: *newBaseError(code, "db", "", message),
+		Query:     query,
+	}
+}
+
+// LogError represents logging failures.
+type LogError struct {
+	BaseError
+	Logger string
+}
+
+// NewLogError constructs a LogError.
+func NewLogError(code ErrorCode, logger, message string) *LogError {
+	return &LogError{
+		BaseError: *newBaseError(code, "log", "", message),
+		Logger:    logger,
+	}
+}

--- a/pkg/errors/types_test.go
+++ b/pkg/errors/types_test.go
@@ -1,0 +1,86 @@
+// file: pkg/errors/types_test.go
+// version: 1.1.0
+// guid: fb48d36d-d03f-42e1-af17-86e43f1eeef2
+
+package errors
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestNewError verifies that NewError creates an Error with expected fields.
+func TestNewError(t *testing.T) {
+	err := NewError(context.Background(), ErrCodeInternal, "message")
+	e, ok := err.(*BaseError)
+	if !ok {
+		t.Fatalf("expected *BaseError, got %T", err)
+	}
+	if e.Code() != ErrCodeInternal {
+		t.Fatalf("expected code %v, got %v", ErrCodeInternal, e.Code())
+	}
+	if e.Component() != "" || e.Operation() != "" {
+		t.Fatalf("unexpected component or operation")
+	}
+}
+
+// TestWrapWithCode verifies that wrapping preserves the cause and code.
+func TestWrapWithCode(t *testing.T) {
+	base := fmt.Errorf("root cause")
+	wrapped := WrapWithCode(base, ErrCodeTimeout, "comp", "op")
+	if wrapped.Cause() != base {
+		t.Fatalf("expected cause to be preserved")
+	}
+	if wrapped.Code() != ErrCodeTimeout {
+		t.Fatalf("expected code %v, got %v", ErrCodeTimeout, wrapped.Code())
+	}
+	if wrapped.Component() != "comp" || wrapped.Operation() != "op" {
+		t.Fatalf("component or operation not set")
+	}
+}
+
+// TestWrapWithDetails verifies that details are merged into the error.
+func TestWrapWithDetails(t *testing.T) {
+	base := fmt.Errorf("failure")
+	wrapped := WrapWithDetails(base, map[string]interface{}{"k": "v"})
+	if wrapped.Details()["k"] != "v" {
+		t.Fatalf("expected detail to be present")
+	}
+}
+
+// TestSpecificErrors ensures specialized error constructors populate fields.
+func TestSpecificErrors(t *testing.T) {
+	ce := NewConfigError(ErrCodeConfigInvalid, "key", "val", "bad config")
+	if ce.ConfigKey != "key" || ce.ConfigValue != "val" {
+		t.Fatalf("config fields not set")
+	}
+	qe := NewQueueError(ErrCodeQueueFull, "main", "id1", "full")
+	if qe.QueueName != "main" || qe.MessageID != "id1" {
+		t.Fatalf("queue fields not set")
+	}
+	ae := NewAuthError(ErrCodeUnauthorized, "u1", "res", "act", "unauth")
+	if ae.UserID != "u1" || ae.Resource != "res" || ae.Action != "act" {
+		t.Fatalf("auth fields not set")
+	}
+	me := NewMetricsError(ErrCodeMetricInvalid, "cpu", "bad metric")
+	if me.MetricName != "cpu" {
+		t.Fatalf("metric name not set")
+	}
+	cache := NewCacheError(ErrCodeCacheMiss, "k", "miss")
+	if cache.Key != "k" {
+		t.Fatalf("cache key not set")
+	}
+	we := NewWebError(ErrCodeRouteNotFound, "/path", "missing")
+	if we.Route != "/path" {
+		t.Fatalf("web route not set")
+	}
+	de := NewDBError(ErrCodeDBQuery, "SELECT", "db err")
+	if de.Query != "SELECT" {
+		t.Fatalf("db query not set")
+	}
+	le := NewLogError(ErrCodeLogWriteFailed, "main", "log err")
+	if le.Logger != "main" {
+		t.Fatalf("logger not set")
+	}
+}

--- a/pkg/errors/wrapping.go
+++ b/pkg/errors/wrapping.go
@@ -1,0 +1,56 @@
+// file: pkg/errors/wrapping.go
+// version: 1.1.0
+// guid: ebb740ca-1926-4333-94a6-785dbcd3423b
+
+package errors
+
+// Wrap attaches component and operation context to an existing error.
+func Wrap(err error, component, operation string) Error {
+	return WrapWithCode(err, ErrCodeUnknown, component, operation)
+}
+
+// WrapWithCode attaches a code along with component and operation context.
+func WrapWithCode(err error, code ErrorCode, component, operation string) Error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(Error); ok {
+		if component != "" {
+			if be, ok := e.(*BaseError); ok {
+				be.component = component
+			}
+		}
+		if operation != "" {
+			if be, ok := e.(*BaseError); ok {
+				be.operation = operation
+			}
+		}
+		return e
+	}
+	be := newBaseError(code, component, operation, err.Error())
+	be.cause = err
+	return be
+}
+
+// WrapWithDetails attaches additional details to an error.
+func WrapWithDetails(err error, details map[string]interface{}) Error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(Error); ok {
+		be, ok := e.(*BaseError)
+		if ok {
+			if be.details == nil {
+				be.details = map[string]interface{}{}
+			}
+			for k, v := range details {
+				be.details[k] = v
+			}
+		}
+		return e
+	}
+	be := newBaseError(ErrCodeUnknown, "", "", err.Error())
+	be.cause = err
+	be.details = details
+	return be
+}


### PR DESCRIPTION
## Summary
- implement a comprehensive error framework with rich error types, standardized codes, and wrapping helpers
- add gRPC/HTTP conversions, formatting utilities, collection helpers, and in-memory error reporter
- document error handling additions in changelog and README

## Issues Addressed

### feat(errors): standardize error handling across modules

**Description:** Implement extensive error framework: base error types, module-specific errors, context-aware creation, wrapping, collection, reporters, and gRPC/HTTP conversions.

**Files Modified:**
- [`pkg/errors/codes.go`](./pkg/errors/codes.go) - define multi-module error codes | [[diff]](../../pull/PR_NUMBER/files#diff-codes) [[repo]](../../blob/main/pkg/errors/codes.go)
- [`pkg/errors/types.go`](./pkg/errors/types.go) - implement base error interface and specialized error structs | [[diff]](../../pull/PR_NUMBER/files#diff-types) [[repo]](../../blob/main/pkg/errors/types.go)
- [`pkg/errors/context.go`](./pkg/errors/context.go) - add context-aware error creation helpers | [[diff]](../../pull/PR_NUMBER/files#diff-context) [[repo]](../../blob/main/pkg/errors/context.go)
- [`pkg/errors/wrapping.go`](./pkg/errors/wrapping.go) - provide error wrapping with codes and details | [[diff]](../../pull/PR_NUMBER/files#diff-wrapping) [[repo]](../../blob/main/pkg/errors/wrapping.go)
- [`pkg/errors/grpc.go`](./pkg/errors/grpc.go) - convert errors to/from gRPC status and add interceptors | [[diff]](../../pull/PR_NUMBER/files#diff-grpc) [[repo]](../../blob/main/pkg/errors/grpc.go)
- [`pkg/errors/http.go`](./pkg/errors/http.go) - map errors to HTTP responses | [[diff]](../../pull/PR_NUMBER/files#diff-http) [[repo]](../../blob/main/pkg/errors/http.go)
- [`pkg/errors/formatting.go`](./pkg/errors/formatting.go) - human-readable error formatting | [[diff]](../../pull/PR_NUMBER/files#diff-formatting) [[repo]](../../blob/main/pkg/errors/formatting.go)
- [`pkg/errors/collection.go`](./pkg/errors/collection.go) - aggregate multiple errors | [[diff]](../../pull/PR_NUMBER/files#diff-collection) [[repo]](../../blob/main/pkg/errors/collection.go)
- [`pkg/errors/reporter.go`](./pkg/errors/reporter.go) - in-memory error reporting with stats | [[diff]](../../pull/PR_NUMBER/files#diff-reporter) [[repo]](../../blob/main/pkg/errors/reporter.go)
- [`pkg/errors/types_test.go`](./pkg/errors/types_test.go) - expand coverage for new error types and wrappers | [[diff]](../../pull/PR_NUMBER/files#diff-types_test) [[repo]](../../blob/main/pkg/errors/types_test.go)

## Testing
- `go test ./...` *(fails: undefined symbols in pkg/db/grpc)*


------
https://chatgpt.com/codex/tasks/task_e_6898092558708321806123b4fcb6d01f