### PR TITLE
feat(web): complete web module

### DIFF
--- a/.github/doc-updates/073be225-605c-4a77-b47c-d7b5d176cf8b.json
+++ b/.github/doc-updates/073be225-605c-4a77-b47c-d7b5d176cf8b.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Expanded web module with server factory, middleware, session manager, handlers, routing, gRPC skeleton, and examples",
+  "guid": "073be225-605c-4a77-b47c-d7b5d176cf8b",
+  "created_at": "2025-08-10T12:34:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/726e276e-24d3-4e30-96fb-7ff3fb96ce49.json
+++ b/.github/doc-updates/726e276e-24d3-4e30-96fb-7ff3fb96ce49.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement Redis and database session stores for web module",
+  "guid": "726e276e-24d3-4e30-96fb-7ff3fb96ce49",
+  "created_at": "2025-08-10T12:34:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9603ec6f-e801-4077-8840-e71f0c702558.json
+++ b/.github/doc-updates/9603ec6f-e801-4077-8840-e71f0c702558.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Introduced basic HTTP server, logging middleware, and memory session store for web module",
+  "guid": "9603ec6f-e801-4077-8840-e71f0c702558",
+  "created_at": "2025-08-10T02:57:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/396c0bfe-3f58-49a6-b1e4-5346b77e0101.json
+++ b/.github/issue-updates/396c0bfe-3f58-49a6-b1e4-5346b77e0101.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Web: implement basic service layer",
+  "body": "Add HTTP server, logging middleware, and memory session store for web module.",
+  "labels": ["module:web", "enhancement"],
+  "guid": "396c0bfe-3f58-49a6-b1e4-5346b77e0101",
+  "legacy_guid": "create-web-implement-basic-service-layer-2025-08-10",
+  "created_at": "2025-08-10T02:57:01.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/ef8c163f-c869-410b-89d5-beec01a047a2.json
+++ b/.github/issue-updates/ef8c163f-c869-410b-89d5-beec01a047a2.json
@@ -1,0 +1,13 @@
+{
+  "action": "update",
+  "number": null,
+  "body": "Expand web module with full middleware, session manager, handlers, routing, gRPC skeleton, and examples",
+  "labels": ["module:web", "enhancement"],
+  "guid": "ef8c163f-c869-410b-89d5-beec01a047a2",
+  "legacy_guid": "update-issue-null-2025-08-10",
+  "created_at": "2025-08-10T12:34:45.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.35.0
 	go.opentelemetry.io/otel/metric v1.37.0
-	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/net v0.41.0
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect

--- a/pkg/web/examples/api_server.go
+++ b/pkg/web/examples/api_server.go
@@ -1,0 +1,28 @@
+// file: pkg/web/examples/api_server.go
+// version: 1.1.0
+// guid: 5e7b96e4-00a6-4c4b-bf59-7a86e73bc94e
+
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+	"github.com/jdfalk/gcommon/pkg/web/handlers"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// APIServer example with a single route.
+func main() {
+	cfg := &proto.ServerConfig{}
+	srv := web.NewHTTPServer(cfg)
+	srv.RegisterHandler("/api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.RegisterHandler("/health", handlers.HealthHandler())
+	srv.Start(context.Background())
+	defer srv.Stop(context.Background())
+}

--- a/pkg/web/examples/basic_server.go
+++ b/pkg/web/examples/basic_server.go
@@ -1,0 +1,27 @@
+// file: pkg/web/examples/basic_server.go
+// version: 1.1.0
+// guid: 3d84c605-64d0-4c35-96d9-72c246b193ab
+
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+	"github.com/jdfalk/gcommon/pkg/web/handlers"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// Basic example starting an HTTP server.
+func main() {
+	cfg := &proto.ServerConfig{}
+	srv := web.NewHTTPServer(cfg)
+	srv.RegisterHandler("/health", handlers.HealthHandler())
+	if err := srv.Start(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop(context.Background())
+}

--- a/pkg/web/examples/middleware_chain.go
+++ b/pkg/web/examples/middleware_chain.go
@@ -1,0 +1,25 @@
+// file: pkg/web/examples/middleware_chain.go
+// version: 1.1.0
+// guid: 0ff4e765-181d-4f42-b4a6-cec951f2bf0e
+
+//go:build ignore
+
+package main
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+	"github.com/jdfalk/gcommon/pkg/web/middleware"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// Example showing middleware chaining.
+func main() {
+	cfg := &proto.ServerConfig{}
+	srv := web.NewHTTPServer(cfg)
+	srv.RegisterMiddleware(middleware.Logging())
+	srv.RegisterMiddleware(middleware.RecoveryMiddleware())
+	srv.Start(context.Background())
+	defer srv.Stop(context.Background())
+}

--- a/pkg/web/factory.go
+++ b/pkg/web/factory.go
@@ -1,0 +1,12 @@
+// file: pkg/web/factory.go
+// version: 1.0.0
+// guid: 3e9a918b-9bd2-4c18-9650-e3e2f8f8c1ad
+
+package web
+
+import proto "github.com/jdfalk/gcommon/pkg/web/proto"
+
+// NewServer creates a new Server from the provided configuration.
+func NewServer(cfg *proto.ServerConfig) Server {
+	return NewHTTPServer(cfg)
+}

--- a/pkg/web/grpc/admin_service.go
+++ b/pkg/web/grpc/admin_service.go
@@ -1,0 +1,11 @@
+// file: pkg/web/grpc/admin_service.go
+// version: 1.0.0
+// guid: 4e6ed2bb-7871-4c61-8815-7e71d2342635
+
+package grpc
+
+// AdminService provides placeholder implementation for administrative gRPC service.
+type AdminService struct{}
+
+// NewAdminService creates a new AdminService.
+func NewAdminService() *AdminService { return &AdminService{} }

--- a/pkg/web/grpc/server.go
+++ b/pkg/web/grpc/server.go
@@ -1,0 +1,31 @@
+// file: pkg/web/grpc/server.go
+// version: 1.0.0
+// guid: b9921eb5-3ce3-451f-9f48-8ce274235a8e
+
+package grpc
+
+import (
+	"net"
+
+	"google.golang.org/grpc"
+)
+
+// Server wraps a gRPC server for the web module.
+type Server struct {
+	grpc *grpc.Server
+}
+
+// NewServer creates a new gRPC server with default options.
+func NewServer(opts ...grpc.ServerOption) *Server {
+	return &Server{grpc: grpc.NewServer(opts...)}
+}
+
+// Serve listens on the given address.
+func (s *Server) Serve(l net.Listener) error {
+	return s.grpc.Serve(l)
+}
+
+// GracefulStop gracefully stops the server.
+func (s *Server) GracefulStop() {
+	s.grpc.GracefulStop()
+}

--- a/pkg/web/grpc/web_service.go
+++ b/pkg/web/grpc/web_service.go
@@ -1,0 +1,11 @@
+// file: pkg/web/grpc/web_service.go
+// version: 1.0.0
+// guid: 6f0fd611-6e80-418e-af98-9e8e9a819c9b
+
+package grpc
+
+// WebService provides placeholder implementation for gRPC web service.
+type WebService struct{}
+
+// NewWebService creates a new WebService.
+func NewWebService() *WebService { return &WebService{} }

--- a/pkg/web/handlers/admin.go
+++ b/pkg/web/handlers/admin.go
@@ -1,0 +1,15 @@
+// file: pkg/web/handlers/admin.go
+// version: 1.0.0
+// guid: 5b7fb5a6-d776-4c77-a82a-1192ce140f64
+
+package handlers
+
+import "net/http"
+
+// AdminHandler returns an HTTP handler for administrative endpoints.
+func AdminHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("admin ok"))
+	})
+}

--- a/pkg/web/handlers/health.go
+++ b/pkg/web/handlers/health.go
@@ -1,0 +1,15 @@
+// file: pkg/web/handlers/health.go
+// version: 1.0.0
+// guid: 5aa5bcf9-1f54-4d18-a9f0-154bddc65aca
+
+package handlers
+
+import "net/http"
+
+// HealthHandler returns an HTTP handler that reports service health.
+func HealthHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}

--- a/pkg/web/handlers/health_test.go
+++ b/pkg/web/handlers/health_test.go
@@ -1,0 +1,21 @@
+// file: pkg/web/handlers/health_test.go
+// version: 1.0.0
+// guid: 59ea4d5b-6d6a-4f2e-b861-e8c4589aa01f
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	handler := HealthHandler()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}

--- a/pkg/web/handlers/metrics.go
+++ b/pkg/web/handlers/metrics.go
@@ -1,0 +1,15 @@
+// file: pkg/web/handlers/metrics.go
+// version: 1.0.0
+// guid: 1d7e4c63-bd2d-4bb1-9f65-6cba9b53ae7b
+
+package handlers
+
+import "net/http"
+
+// MetricsHandler returns an HTTP handler that serves metrics data.
+func MetricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("metrics not implemented"))
+	})
+}

--- a/pkg/web/middleware/auth.go
+++ b/pkg/web/middleware/auth.go
@@ -1,0 +1,35 @@
+// file: pkg/web/middleware/auth.go
+// version: 1.0.0
+// guid: 87b40fd0-ef1f-4d8d-b645-13dfb68c5fa0
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+// AuthMiddleware validates bearer tokens in the Authorization header.
+type AuthMiddleware struct {
+	token string
+}
+
+// NewAuthMiddleware creates an AuthMiddleware.
+func NewAuthMiddleware(token string) *AuthMiddleware {
+	return &AuthMiddleware{token: token}
+}
+
+// Handle checks the Authorization header and validates the token.
+func (a *AuthMiddleware) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+a.token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+var _ web.Middleware = (*AuthMiddleware)(nil)

--- a/pkg/web/middleware/cors.go
+++ b/pkg/web/middleware/cors.go
@@ -1,0 +1,26 @@
+// file: pkg/web/middleware/cors.go
+// version: 1.0.0
+// guid: 59da3c2d-2ea8-4a10-bb47-bb9f0e2c2ea2
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+// CORSMiddleware adds basic CORS headers to responses.
+func CORSMiddleware() web.Middleware {
+	return web.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+}

--- a/pkg/web/middleware/logging.go
+++ b/pkg/web/middleware/logging.go
@@ -1,0 +1,24 @@
+// file: pkg/web/middleware/logging.go
+// version: 1.0.0
+// guid: 25c3bbb7-b0b7-4fec-a7f3-8ae731807a2a
+
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+// Logging returns middleware that logs requests.
+func Logging() web.Middleware {
+	return web.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			next.ServeHTTP(w, r)
+			log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+		})
+	})
+}

--- a/pkg/web/middleware/metrics.go
+++ b/pkg/web/middleware/metrics.go
@@ -1,0 +1,24 @@
+// file: pkg/web/middleware/metrics.go
+// version: 1.0.0
+// guid: a0f7f4d1-2d72-4f16-9cde-9e6466d1ff01
+
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+// MetricsMiddleware logs request durations.
+func MetricsMiddleware() web.Middleware {
+	return web.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			next.ServeHTTP(w, r)
+			log.Printf("%s %s took %v", r.Method, r.URL.Path, time.Since(start))
+		})
+	})
+}

--- a/pkg/web/middleware/rate_limit.go
+++ b/pkg/web/middleware/rate_limit.go
@@ -1,0 +1,60 @@
+// file: pkg/web/middleware/rate_limit.go
+// version: 1.0.0
+// guid: 1e4a6a54-ae7c-46b6-9074-f0ac8e2c120e
+
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+type clientCounter struct {
+	count int
+	start time.Time
+}
+
+// RateLimitMiddleware limits requests per client within a window.
+type RateLimitMiddleware struct {
+	limit  int
+	window time.Duration
+	mu     sync.Mutex
+	counts map[string]*clientCounter
+}
+
+// NewRateLimitMiddleware creates a RateLimitMiddleware.
+func NewRateLimitMiddleware(limit int, window time.Duration) *RateLimitMiddleware {
+	return &RateLimitMiddleware{
+		limit:  limit,
+		window: window,
+		counts: make(map[string]*clientCounter),
+	}
+}
+
+// Handle enforces the rate limit per remote IP.
+func (m *RateLimitMiddleware) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+		m.mu.Lock()
+		c, ok := m.counts[ip]
+		now := time.Now()
+		if !ok || now.Sub(c.start) > m.window {
+			c = &clientCounter{start: now}
+			m.counts[ip] = c
+		}
+		if c.count >= m.limit {
+			m.mu.Unlock()
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		c.count++
+		m.mu.Unlock()
+		next.ServeHTTP(w, r)
+	})
+}
+
+var _ web.Middleware = (*RateLimitMiddleware)(nil)

--- a/pkg/web/middleware/recovery.go
+++ b/pkg/web/middleware/recovery.go
@@ -1,0 +1,27 @@
+// file: pkg/web/middleware/recovery.go
+// version: 1.0.0
+// guid: 0f5d0e3a-3cfe-4a27-9ce9-293e2d498dc9
+
+package middleware
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+)
+
+// RecoveryMiddleware recovers from panics in handlers.
+func RecoveryMiddleware() web.Middleware {
+	return web.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					log.Printf("panic: %v", rec)
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	})
+}

--- a/pkg/web/middleware/recovery_test.go
+++ b/pkg/web/middleware/recovery_test.go
@@ -1,0 +1,24 @@
+// file: pkg/web/middleware/recovery_test.go
+// version: 1.0.0
+// guid: 2dfdfd56-6672-4aa7-9c2f-47779fba399a
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecoveryMiddleware(t *testing.T) {
+	m := RecoveryMiddleware()
+	handler := m.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}

--- a/pkg/web/routing/matcher.go
+++ b/pkg/web/routing/matcher.go
@@ -1,0 +1,10 @@
+// file: pkg/web/routing/matcher.go
+// version: 1.0.0
+// guid: 2a88f26d-3f1e-4c8e-91ef-8efba3b9c5cb
+
+package routing
+
+// Match reports whether the path matches the pattern.
+func Match(pattern, path string) bool {
+	return pattern == path
+}

--- a/pkg/web/routing/router.go
+++ b/pkg/web/routing/router.go
@@ -1,0 +1,27 @@
+// file: pkg/web/routing/router.go
+// version: 1.0.0
+// guid: 65c16a06-6734-4b37-8fdd-88aa3ad04e02
+
+package routing
+
+import "net/http"
+
+// Router provides simple pattern-based routing.
+type Router struct {
+	routes map[string]http.Handler
+}
+
+// NewRouter creates an empty Router.
+func NewRouter() *Router {
+	return &Router{routes: make(map[string]http.Handler)}
+}
+
+// Register registers a handler for a pattern.
+func (r *Router) Register(pattern string, h http.Handler) {
+	r.routes[pattern] = h
+}
+
+// Handler returns the handler for the given path or nil.
+func (r *Router) Handler(path string) http.Handler {
+	return r.routes[path]
+}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -1,0 +1,87 @@
+// file: pkg/web/server.go
+// version: 1.1.0
+// guid: 13f51b3e-b522-448a-a499-4b7852262b5c
+
+package web
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"golang.org/x/net/http2"
+
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// HTTPServer implements the Server interface.
+type HTTPServer struct {
+	config      *proto.ServerConfig
+	mux         *http.ServeMux
+	middlewares []Middleware
+	server      *http.Server
+	mu          sync.Mutex
+}
+
+// NewHTTPServer creates a new HTTPServer.
+func NewHTTPServer(config *proto.ServerConfig) *HTTPServer {
+	return &HTTPServer{
+		config: config,
+		mux:    http.NewServeMux(),
+	}
+}
+
+// Start begins serving HTTP requests.
+func (s *HTTPServer) Start(ctx context.Context) error {
+	addr := fmt.Sprintf("%s:%d", s.config.GetHost(), s.config.GetPort())
+	s.mu.Lock()
+	s.server = &http.Server{Addr: addr, Handler: s.mux}
+	if err := http2.ConfigureServer(s.server, &http2.Server{}); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+	go func() {
+		var err error
+		if s.config.GetEnableTls() {
+			err = s.server.ListenAndServeTLS(s.config.GetTlsCertPath(), s.config.GetTlsKeyPath())
+		} else {
+			err = s.server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
+			log.Printf("web server error: %v", err)
+		}
+	}()
+	return nil
+}
+
+// Stop gracefully shuts down the server.
+func (s *HTTPServer) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.server == nil {
+		return nil
+	}
+	return s.server.Shutdown(ctx)
+}
+
+// RegisterHandler registers a handler with the server.
+func (s *HTTPServer) RegisterHandler(pattern string, handler http.Handler) {
+	wrapped := handler
+	for i := len(s.middlewares) - 1; i >= 0; i-- {
+		wrapped = s.middlewares[i].Handle(wrapped)
+	}
+	s.mux.Handle(pattern, wrapped)
+}
+
+// RegisterMiddleware adds middleware to the server.
+func (s *HTTPServer) RegisterMiddleware(m Middleware) {
+	s.middlewares = append(s.middlewares, m)
+}
+
+// GetConfig returns the server configuration.
+func (s *HTTPServer) GetConfig() *proto.ServerConfig {
+	return s.config
+}

--- a/pkg/web/server_test.go
+++ b/pkg/web/server_test.go
@@ -1,0 +1,53 @@
+// file: pkg/web/server_test.go
+// version: 1.0.0
+// guid: 4fce088c-0af6-4f3f-bd3d-148053d0a20f
+
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+func TestRegisterHandlerAndMiddleware(t *testing.T) {
+	cfg := &proto.ServerConfig{}
+	srv := NewHTTPServer(cfg)
+	srv.RegisterMiddleware(MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Test", "1")
+			next.ServeHTTP(w, r)
+		})
+	}))
+	srv.RegisterHandler("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("X-Test") != "1" {
+		t.Fatalf("middleware not applied")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	cfg := &proto.ServerConfig{}
+	cfg.SetHost("127.0.0.1")
+	cfg.SetPort(0)
+	srv := NewHTTPServer(cfg)
+	srv.RegisterHandler("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+}

--- a/pkg/web/session/manager.go
+++ b/pkg/web/session/manager.go
@@ -1,0 +1,40 @@
+// file: pkg/web/session/manager.go
+// version: 1.0.0
+// guid: 9c0de4e5-7f2a-4f9e-9a2c-d5279a2dd1b4
+
+package session
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/web"
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// Manager implements web.SessionManager using a Store.
+type Manager struct {
+	store Store
+}
+
+// NewManager creates a Manager with the provided store.
+func NewManager(store Store) *Manager {
+	return &Manager{store: store}
+}
+
+func (m *Manager) CreateSession(ctx context.Context, userID string) (*proto.SessionData, error) {
+	return m.store.CreateSession(ctx, userID)
+}
+
+func (m *Manager) GetSession(ctx context.Context, sessionID string) (*proto.SessionData, error) {
+	return m.store.GetSession(ctx, sessionID)
+}
+
+func (m *Manager) UpdateSession(ctx context.Context, session *proto.SessionData) error {
+	return m.store.UpdateSession(ctx, session)
+}
+
+func (m *Manager) DeleteSession(ctx context.Context, sessionID string) error {
+	return m.store.DeleteSession(ctx, sessionID)
+}
+
+var _ web.SessionManager = (*Manager)(nil)

--- a/pkg/web/session/manager_test.go
+++ b/pkg/web/session/manager_test.go
@@ -1,0 +1,27 @@
+// file: pkg/web/session/manager_test.go
+// version: 1.0.0
+// guid: d77b31bb-a2b4-41ba-9f2d-6c0d5857a1f4
+
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestManagerDelegatesToStore(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	mgr := NewManager(store)
+	sess, err := mgr.CreateSession(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	got, err := mgr.GetSession(context.Background(), sess.GetSessionId())
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.GetUserId() != "u1" {
+		t.Fatalf("unexpected user id: %s", got.GetUserId())
+	}
+}

--- a/pkg/web/session/memory.go
+++ b/pkg/web/session/memory.go
@@ -1,0 +1,92 @@
+// file: pkg/web/session/memory.go
+// version: 1.1.0
+// guid: 78b88f98-8aec-4cc3-9164-337dfeee1faa
+
+package session
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// MemoryStore implements in-memory session storage.
+type MemoryStore struct {
+	mu       sync.RWMutex
+	sessions map[string]*proto.SessionData
+	ttl      time.Duration
+}
+
+// NewMemoryStore creates a MemoryStore with the given TTL.
+func NewMemoryStore(ttl time.Duration) *MemoryStore {
+	return &MemoryStore{
+		sessions: make(map[string]*proto.SessionData),
+		ttl:      ttl,
+	}
+}
+
+// CreateSession creates a new session for the user.
+func (m *MemoryStore) CreateSession(ctx context.Context, userID string) (*proto.SessionData, error) {
+	id := generateID()
+	now := time.Now()
+	sess := &proto.SessionData{}
+	sess.SetSessionId(id)
+	sess.SetUserId(userID)
+	sess.SetState(proto.SessionState_SESSION_STATE_ACTIVE)
+	sess.SetCreatedAt(timestamppb.New(now))
+	sess.SetLastAccessAt(timestamppb.New(now))
+	sess.SetExpiresAt(timestamppb.New(now.Add(m.ttl)))
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+	return sess, nil
+}
+
+// GetSession retrieves a session by ID.
+func (m *MemoryStore) GetSession(ctx context.Context, sessionID string) (*proto.SessionData, error) {
+	m.mu.RLock()
+	sess, ok := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, errors.New("session not found")
+	}
+	if sess.GetExpiresAt().AsTime().Before(time.Now()) {
+		m.DeleteSession(ctx, sessionID)
+		return nil, errors.New("session expired")
+	}
+	return sess, nil
+}
+
+// UpdateSession updates an existing session.
+func (m *MemoryStore) UpdateSession(ctx context.Context, session *proto.SessionData) error {
+	m.mu.Lock()
+	m.sessions[session.GetSessionId()] = session
+	m.mu.Unlock()
+	return nil
+}
+
+// DeleteSession removes a session.
+func (m *MemoryStore) DeleteSession(ctx context.Context, sessionID string) error {
+	m.mu.Lock()
+	delete(m.sessions, sessionID)
+	m.mu.Unlock()
+	return nil
+}
+
+// generateID creates a random session ID.
+func generateID() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return hex.EncodeToString([]byte(time.Now().Format(time.RFC3339Nano)))
+	}
+	return hex.EncodeToString(b)
+}
+
+var _ Store = (*MemoryStore)(nil)

--- a/pkg/web/session/memory_test.go
+++ b/pkg/web/session/memory_test.go
@@ -1,0 +1,32 @@
+// file: pkg/web/session/memory_test.go
+// version: 1.0.0
+// guid: 9059fbcb-01cc-4e36-9781-8ede9140395a
+
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreSessionLifecycle(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	sess, err := store.CreateSession(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	got, err := store.GetSession(context.Background(), sess.GetSessionId())
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.GetUserId() != "user1" {
+		t.Fatalf("unexpected user id: %s", got.GetUserId())
+	}
+	if err := store.DeleteSession(context.Background(), sess.GetSessionId()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	if _, err := store.GetSession(context.Background(), sess.GetSessionId()); err == nil {
+		t.Fatalf("expected error for deleted session")
+	}
+}

--- a/pkg/web/session/store.go
+++ b/pkg/web/session/store.go
@@ -1,0 +1,19 @@
+// file: pkg/web/session/store.go
+// version: 1.0.0
+// guid: e2f1bbf5-6f0d-4c8c-9d4f-7b026c093894
+
+package session
+
+import (
+	"context"
+
+	proto "github.com/jdfalk/gcommon/pkg/web/proto"
+)
+
+// Store defines persistence for sessions.
+type Store interface {
+	CreateSession(ctx context.Context, userID string) (*proto.SessionData, error)
+	GetSession(ctx context.Context, sessionID string) (*proto.SessionData, error)
+	UpdateSession(ctx context.Context, session *proto.SessionData) error
+	DeleteSession(ctx context.Context, sessionID string) error
+}


### PR DESCRIPTION
## Summary
- implement server factory, middleware suite, session manager and store, routing utilities, handlers, gRPC stubs, and build-ignored examples
- enable HTTP/2 in HTTP server and add tests for middleware, handlers, and session management

## Issues Addressed

### feat(web): complete web module

**Description:** Added comprehensive web capabilities including middleware chain, session management, routing, and example servers while updating HTTP server for HTTP/2.

**Files Modified:**
- [`pkg/web/factory.go`](./pkg/web/factory.go) - create server from config | [[diff]](../../pull/PR_NUMBER/files#diff-factory) [[repo]](../../blob/main/pkg/web/factory.go)
- [`pkg/web/middleware/auth.go`](./pkg/web/middleware/auth.go) - bearer token middleware | [[diff]](../../pull/PR_NUMBER/files#diff-auth) [[repo]](../../blob/main/pkg/web/middleware/auth.go)
- [`pkg/web/middleware/cors.go`](./pkg/web/middleware/cors.go) - CORS headers | [[diff]](../../pull/PR_NUMBER/files#diff-cors) [[repo]](../../blob/main/pkg/web/middleware/cors.go)
- [`pkg/web/middleware/logging.go`](./pkg/web/middleware/logging.go) - request logging | [[diff]](../../pull/PR_NUMBER/files#diff-logging) [[repo]](../../blob/main/pkg/web/middleware/logging.go)
- [`pkg/web/middleware/metrics.go`](./pkg/web/middleware/metrics.go) - request timing | [[diff]](../../pull/PR_NUMBER/files#diff-metrics) [[repo]](../../blob/main/pkg/web/middleware/metrics.go)
- [`pkg/web/middleware/rate_limit.go`](./pkg/web/middleware/rate_limit.go) - client rate limiting | [[diff]](../../pull/PR_NUMBER/files#diff-ratelimit) [[repo]](../../blob/main/pkg/web/middleware/rate_limit.go)
- [`pkg/web/middleware/recovery.go`](./pkg/web/middleware/recovery.go) - panic recovery | [[diff]](../../pull/PR_NUMBER/files#diff-recovery) [[repo]](../../blob/main/pkg/web/middleware/recovery.go)
- [`pkg/web/middleware/recovery_test.go`](./pkg/web/middleware/recovery_test.go) - recovery tests | [[diff]](../../pull/PR_NUMBER/files#diff-recoverytest) [[repo]](../../blob/main/pkg/web/middleware/recovery_test.go)
- [`pkg/web/session/store.go`](./pkg/web/session/store.go) - session store interface | [[diff]](../../pull/PR_NUMBER/files#diff-store) [[repo]](../../blob/main/pkg/web/session/store.go)
- [`pkg/web/session/manager.go`](./pkg/web/session/manager.go) - session manager | [[diff]](../../pull/PR_NUMBER/files#diff-manager) [[repo]](../../blob/main/pkg/web/session/manager.go)
- [`pkg/web/session/manager_test.go`](./pkg/web/session/manager_test.go) - manager tests | [[diff]](../../pull/PR_NUMBER/files#diff-managertest) [[repo]](../../blob/main/pkg/web/session/manager_test.go)
- [`pkg/web/session/memory.go`](./pkg/web/session/memory.go) - implement store | [[diff]](../../pull/PR_NUMBER/files#diff-memory) [[repo]](../../blob/main/pkg/web/session/memory.go)
- [`pkg/web/handlers/health.go`](./pkg/web/handlers/health.go) - health endpoint | [[diff]](../../pull/PR_NUMBER/files#diff-healthhandler) [[repo]](../../blob/main/pkg/web/handlers/health.go)
- [`pkg/web/handlers/metrics.go`](./pkg/web/handlers/metrics.go) - metrics endpoint | [[diff]](../../pull/PR_NUMBER/files#diff-metricshandler) [[repo]](../../blob/main/pkg/web/handlers/metrics.go)
- [`pkg/web/handlers/admin.go`](./pkg/web/handlers/admin.go) - admin endpoint | [[diff]](../../pull/PR_NUMBER/files#diff-adminhandler) [[repo]](../../blob/main/pkg/web/handlers/admin.go)
- [`pkg/web/handlers/health_test.go`](./pkg/web/handlers/health_test.go) - health handler test | [[diff]](../../pull/PR_NUMBER/files#diff-healthtest) [[repo]](../../blob/main/pkg/web/handlers/health_test.go)
- [`pkg/web/routing/router.go`](./pkg/web/routing/router.go) - basic router | [[diff]](../../pull/PR_NUMBER/files#diff-router) [[repo]](../../blob/main/pkg/web/routing/router.go)
- [`pkg/web/routing/matcher.go`](./pkg/web/routing/matcher.go) - path matcher | [[diff]](../../pull/PR_NUMBER/files#diff-matcher) [[repo]](../../blob/main/pkg/web/routing/matcher.go)
- [`pkg/web/grpc/server.go`](./pkg/web/grpc/server.go) - gRPC server wrapper | [[diff]](../../pull/PR_NUMBER/files#diff-grpcserver) [[repo]](../../blob/main/pkg/web/grpc/server.go)
- [`pkg/web/grpc/web_service.go`](./pkg/web/grpc/web_service.go) - web service stub | [[diff]](../../pull/PR_NUMBER/files#diff-webservice) [[repo]](../../blob/main/pkg/web/grpc/web_service.go)
- [`pkg/web/grpc/admin_service.go`](./pkg/web/grpc/admin_service.go) - admin service stub | [[diff]](../../pull/PR_NUMBER/files#diff-adminservice) [[repo]](../../blob/main/pkg/web/grpc/admin_service.go)
- [`pkg/web/examples/basic_server.go`](./pkg/web/examples/basic_server.go) - basic server example | [[diff]](../../pull/PR_NUMBER/files#diff-basicexample) [[repo]](../../blob/main/pkg/web/examples/basic_server.go)
- [`pkg/web/examples/middleware_chain.go`](./pkg/web/examples/middleware_chain.go) - middleware chain example | [[diff]](../../pull/PR_NUMBER/files#diff-middlewareexample) [[repo]](../../blob/main/pkg/web/examples/middleware_chain.go)
- [`pkg/web/examples/api_server.go`](./pkg/web/examples/api_server.go) - API server example | [[diff]](../../pull/PR_NUMBER/files#diff-apiexample) [[repo]](../../blob/main/pkg/web/examples/api_server.go)
- [`pkg/web/server.go`](./pkg/web/server.go) - enable HTTP/2 | [[diff]](../../pull/PR_NUMBER/files#diff-server) [[repo]](../../blob/main/pkg/web/server.go)
- [`go.mod`](./go.mod) - add x/net dependency | [[diff]](../../pull/PR_NUMBER/files#diff-gomod) [[repo]](../../blob/main/go.mod)

## Testing
- `go test ./pkg/web/...`


------
https://chatgpt.com/codex/tasks/task_e_689808bc11508321a09faf8c1120fc4a