### PR TITLE
feat(organization): add organization service layer

### DIFF
--- a/.github/doc-updates/4a03be98-ffe7-4dc0-954b-b6f110a499c3.json
+++ b/.github/doc-updates/4a03be98-ffe7-4dc0-954b-b6f110a499c3.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "  - Implemented initial organization service layer",
+  "guid": "4a03be98-ffe7-4dc0-954b-b6f110a499c3",
+  "created_at": "2025-08-10T02:58:54Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/54d8cc84-2b78-4622-9a02-d829b5814c72.json
+++ b/.github/doc-updates/54d8cc84-2b78-4622-9a02-d829b5814c72.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Add organization service layer with in-memory tenant management",
+  "guid": "54d8cc84-2b78-4622-9a02-d829b5814c72",
+  "created_at": "2025-08-10T02:58:48Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/organization/examples/multi_tenant.go
+++ b/pkg/organization/examples/multi_tenant.go
@@ -1,0 +1,8 @@
+// file: pkg/organization/examples/multi_tenant.go
+// version: 1.0.0
+// guid: 51e90824-0beb-4d35-bd8d-cd3c8c8385f2
+
+package examples
+
+// This package will contain examples for using the organization module.
+// multi_tenant.go demonstrates multi-tenant setup (placeholder).

--- a/pkg/organization/factory.go
+++ b/pkg/organization/factory.go
@@ -1,0 +1,25 @@
+// file: pkg/organization/factory.go
+// version: 1.0.0
+// guid: 2b80b967-fa14-4400-8c4e-cd7d63efd1bd
+
+// Package organization exposes constructors for service implementations.
+package organization
+
+import (
+	"github.com/jdfalk/gcommon/pkg/organization/hierarchy"
+	"github.com/jdfalk/gcommon/pkg/organization/tenant"
+)
+
+// Services groups organization service implementations.
+type Services struct {
+	Tenant    TenantManager
+	Hierarchy HierarchyManager
+}
+
+// NewServices returns initialized organization service implementations.
+func NewServices() *Services {
+	return &Services{
+		Tenant:    tenant.NewManager(),
+		Hierarchy: hierarchy.NewTree(),
+	}
+}

--- a/pkg/organization/grpc/server.go
+++ b/pkg/organization/grpc/server.go
@@ -1,0 +1,15 @@
+// file: pkg/organization/grpc/server.go
+// version: 1.0.0
+// guid: 7a6b4ad3-d481-47d1-9ba2-fa0a391e287b
+
+package grpc
+
+import (
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	"google.golang.org/grpc"
+)
+
+// Register registers organization gRPC services with the server.
+func Register(s *grpc.Server, ts orgpb.TenantServiceServer) {
+	orgpb.RegisterTenantServiceServer(s, ts)
+}

--- a/pkg/organization/grpc/tenant_service.go
+++ b/pkg/organization/grpc/tenant_service.go
@@ -1,0 +1,99 @@
+// file: pkg/organization/grpc/tenant_service.go
+// version: 1.1.0
+// guid: e6c8dd36-ef60-4f63-b41d-7e29b84b86e4
+
+// Package grpc provides gRPC service implementations for the organization module.
+package grpc
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/organization"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// TenantService implements the generated gRPC server for tenant operations.
+type TenantService struct {
+	orgpb.UnimplementedTenantServiceServer
+	tm organization.TenantManager
+}
+
+// NewTenantService returns a TenantService with the provided manager.
+func NewTenantService(tm organization.TenantManager) *TenantService {
+	return &TenantService{tm: tm}
+}
+
+// CreateTenant handles tenant creation.
+func (s *TenantService) CreateTenant(ctx context.Context, req *orgpb.CreateTenantRequest) (*orgpb.CreateTenantResponse, error) {
+	t := req.GetTenant()
+	if t == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing tenant")
+	}
+	if err := s.tm.CreateTenant(ctx, t); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.CreateTenantResponse_builder{Tenant: t, Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+// GetTenant retrieves a tenant by ID.
+func (s *TenantService) GetTenant(ctx context.Context, req *orgpb.GetTenantRequest) (*orgpb.GetTenantResponse, error) {
+	tenant, err := s.tm.GetTenant(ctx, req.GetTenantId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.GetTenantResponse_builder{Tenant: tenant, Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+// UpdateTenant updates an existing tenant.
+func (s *TenantService) UpdateTenant(ctx context.Context, req *orgpb.UpdateTenantRequest) (*orgpb.UpdateTenantResponse, error) {
+	t := req.GetTenant()
+	if t == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing tenant")
+	}
+	if err := s.tm.UpdateTenant(ctx, t); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.UpdateTenantResponse_builder{Tenant: t, Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+// DeleteTenant removes a tenant.
+func (s *TenantService) DeleteTenant(ctx context.Context, req *orgpb.DeleteTenantRequest) (*orgpb.DeleteTenantResponse, error) {
+	if err := s.tm.DeleteTenant(ctx, req.GetTenantId()); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.DeleteTenantResponse_builder{Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+// ListTenants returns all tenants.
+func (s *TenantService) ListTenants(ctx context.Context, req *orgpb.ListTenantsRequest) (*orgpb.ListTenantsResponse, error) {
+	tenants, err := s.tm.ListTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.ListTenantsResponse_builder{Tenants: tenants}).Build()
+	return resp, nil
+}
+
+// Remaining RPCs are unimplemented.
+func (s *TenantService) ConfigureTenantIsolation(context.Context, *orgpb.ConfigureTenantIsolationRequest) (*orgpb.ConfigureTenantIsolationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (s *TenantService) GetTenantIsolation(context.Context, *orgpb.GetTenantIsolationRequest) (*orgpb.GetTenantIsolationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (s *TenantService) UpdateTenantQuota(context.Context, *orgpb.UpdateTenantQuotaRequest) (*orgpb.UpdateTenantQuotaResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (s *TenantService) GetTenantUsage(context.Context, *orgpb.GetTenantUsageRequest) (*orgpb.GetTenantUsageResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}

--- a/pkg/organization/hierarchy/tree.go
+++ b/pkg/organization/hierarchy/tree.go
@@ -1,0 +1,82 @@
+// file: pkg/organization/hierarchy/tree.go
+// version: 1.1.0
+// guid: c4744bfd-7318-4c57-bef7-cb6265d69569
+
+// Package hierarchy provides simple organization hierarchy management.
+package hierarchy
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// Tree manages a collection of hierarchy nodes in memory.
+type Tree struct {
+	mu    sync.RWMutex
+	nodes map[string]*orgpb.HierarchyNode
+}
+
+// NewTree creates an empty hierarchy tree.
+func NewTree() *Tree {
+	return &Tree{nodes: make(map[string]*orgpb.HierarchyNode)}
+}
+
+// CreateNode adds a node to the hierarchy.
+func (t *Tree) CreateNode(ctx context.Context, node *orgpb.HierarchyNode) error {
+	id := node.GetId()
+	if id == "" {
+		return errors.New("missing node id")
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.nodes[id]; exists {
+		return errors.New("node exists")
+	}
+	t.nodes[id] = node
+	return nil
+}
+
+// GetNode retrieves a node by ID.
+func (t *Tree) GetNode(ctx context.Context, nodeID string) (*orgpb.HierarchyNode, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	n, ok := t.nodes[nodeID]
+	if !ok {
+		return nil, errors.New("node not found")
+	}
+	return n, nil
+}
+
+// GetChildren returns children of a given parent ID.
+func (t *Tree) GetChildren(ctx context.Context, parentID string) ([]*orgpb.HierarchyNode, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var children []*orgpb.HierarchyNode
+	for _, n := range t.nodes {
+		if n.GetParentId() == parentID {
+			children = append(children, n)
+		}
+	}
+	return children, nil
+}
+
+// MoveNode changes a node's parent.
+func (t *Tree) MoveNode(ctx context.Context, nodeID, newParentID string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n, ok := t.nodes[nodeID]
+	if !ok {
+		return errors.New("node not found")
+	}
+	// Note: HierarchyNode uses builder pattern for updates; create a new node with updated parent.
+	updated := (&orgpb.HierarchyNode_builder{
+		Id:       gproto.String(n.GetId()),
+		ParentId: gproto.String(newParentID),
+	}).Build()
+	t.nodes[nodeID] = updated
+	return nil
+}

--- a/pkg/organization/interfaces.go
+++ b/pkg/organization/interfaces.go
@@ -1,0 +1,29 @@
+// file: pkg/organization/interfaces.go
+// version: 1.0.0
+// guid: 674239c9-d92a-4b83-9ec8-c88c1b3dd040
+
+// Package organization provides service interfaces for managing organizations.
+package organization
+
+import (
+	"context"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+)
+
+// TenantManager defines operations for tenant lifecycle management.
+type TenantManager interface {
+	CreateTenant(ctx context.Context, tenant *orgpb.Tenant) error
+	GetTenant(ctx context.Context, tenantID string) (*orgpb.Tenant, error)
+	UpdateTenant(ctx context.Context, tenant *orgpb.Tenant) error
+	DeleteTenant(ctx context.Context, tenantID string) error
+	ListTenants(ctx context.Context) ([]*orgpb.Tenant, error)
+}
+
+// HierarchyManager defines operations for organization hierarchy management.
+type HierarchyManager interface {
+	CreateNode(ctx context.Context, node *orgpb.HierarchyNode) error
+	GetNode(ctx context.Context, nodeID string) (*orgpb.HierarchyNode, error)
+	GetChildren(ctx context.Context, parentID string) ([]*orgpb.HierarchyNode, error)
+	MoveNode(ctx context.Context, nodeID, newParentID string) error
+}

--- a/pkg/organization/policies/access.go
+++ b/pkg/organization/policies/access.go
@@ -1,0 +1,9 @@
+// file: pkg/organization/policies/access.go
+// version: 1.0.0
+// guid: da6d4a3e-7766-4206-9ee5-ec87a9fa6717
+
+// Package policies contains organization access policy placeholders.
+package policies
+
+// AccessPolicy represents a stub for future access policy rules.
+type AccessPolicy struct{}

--- a/pkg/organization/teams/manager.go
+++ b/pkg/organization/teams/manager.go
@@ -1,0 +1,9 @@
+// file: pkg/organization/teams/manager.go
+// version: 1.0.0
+// guid: 06c314f0-0e40-4ac7-8c2e-ce2577b0905a
+
+// Package teams provides placeholders for team management functionality.
+package teams
+
+// This file intentionally left minimal; full team management is pending
+// future implementation.

--- a/pkg/organization/tenant/manager.go
+++ b/pkg/organization/tenant/manager.go
@@ -1,0 +1,88 @@
+// file: pkg/organization/tenant/manager.go
+// version: 1.1.0
+// guid: 8974f08a-188a-467d-8849-aede36294cbb
+
+// Package tenant implements tenant lifecycle management.
+package tenant
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+)
+
+// Manager provides in-memory tenant management.
+type Manager struct {
+	mu      sync.RWMutex
+	tenants map[string]*orgpb.Tenant
+}
+
+// NewManager returns a new Manager instance.
+func NewManager() *Manager {
+	return &Manager{tenants: make(map[string]*orgpb.Tenant)}
+}
+
+// CreateTenant stores a new tenant if it does not already exist.
+func (m *Manager) CreateTenant(ctx context.Context, tenant *orgpb.Tenant) error {
+	id := tenant.GetId()
+	if id == "" {
+		return errors.New("missing tenant id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.tenants[id]; exists {
+		return errors.New("tenant already exists")
+	}
+	m.tenants[id] = tenant
+	return nil
+}
+
+// GetTenant retrieves a tenant by ID.
+func (m *Manager) GetTenant(ctx context.Context, tenantID string) (*orgpb.Tenant, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.tenants[tenantID]
+	if !ok {
+		return nil, errors.New("tenant not found")
+	}
+	return t, nil
+}
+
+// UpdateTenant replaces an existing tenant entry.
+func (m *Manager) UpdateTenant(ctx context.Context, tenant *orgpb.Tenant) error {
+	id := tenant.GetId()
+	if id == "" {
+		return errors.New("missing tenant id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.tenants[id]; !exists {
+		return errors.New("tenant not found")
+	}
+	m.tenants[id] = tenant
+	return nil
+}
+
+// DeleteTenant removes a tenant by ID.
+func (m *Manager) DeleteTenant(ctx context.Context, tenantID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.tenants[tenantID]; !exists {
+		return errors.New("tenant not found")
+	}
+	delete(m.tenants, tenantID)
+	return nil
+}
+
+// ListTenants returns all stored tenants.
+func (m *Manager) ListTenants(ctx context.Context) ([]*orgpb.Tenant, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*orgpb.Tenant, 0, len(m.tenants))
+	for _, t := range m.tenants {
+		result = append(result, t)
+	}
+	return result, nil
+}

--- a/pkg/organization/tenant/manager_test.go
+++ b/pkg/organization/tenant/manager_test.go
@@ -1,0 +1,60 @@
+// file: pkg/organization/tenant/manager_test.go
+// version: 1.1.0
+// guid: 0c9b693c-edf2-444e-ba17-50a0bf2ea8dc
+
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// TestManager_TenantLifecycle verifies basic tenant operations.
+func TestManager_TenantLifecycle(t *testing.T) {
+	// Setup
+	m := NewManager()
+	ctx := context.Background()
+	tenant := (&orgpb.Tenant_builder{Id: gproto.String("t1"), Name: gproto.String("TenantOne")}).Build()
+
+	// Exercise: Create
+	if err := m.CreateTenant(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+
+	// Verify: Get
+	got, err := m.GetTenant(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get tenant: %v", err)
+	}
+	if got.GetName() != "TenantOne" {
+		t.Fatalf("expected name TenantOne, got %s", got.GetName())
+	}
+
+	// Exercise: Update
+	updated := (&orgpb.Tenant_builder{Id: gproto.String("t1"), Name: gproto.String("TenantUno")}).Build()
+	if err := m.UpdateTenant(ctx, updated); err != nil {
+		t.Fatalf("update tenant: %v", err)
+	}
+
+	// Verify: List
+	list, err := m.ListTenants(ctx)
+	if err != nil {
+		t.Fatalf("list tenants: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 tenant, got %d", len(list))
+	}
+
+	// Exercise: Delete
+	if err := m.DeleteTenant(ctx, "t1"); err != nil {
+		t.Fatalf("delete tenant: %v", err)
+	}
+
+	// Verify: Get after delete
+	if _, err := m.GetTenant(ctx, "t1"); err == nil {
+		t.Fatalf("expected error for missing tenant")
+	}
+}


### PR DESCRIPTION
## Summary
- add core organization interfaces and factory
- implement in-memory tenant and hierarchy managers with gRPC service
- add placeholders for teams, policies, and examples

## Testing
- `go fmt ./pkg/organization/...`
- `go test ./pkg/organization/...`


------
https://chatgpt.com/codex/tasks/task_e_689808eb4b3c832191b7e245708c0dd1