### PR TITLE
feat(perf): expand performance testing framework skeleton

### DIFF
--- a/.github/doc-updates/0fa7c920-68b6-4ec4-8682-5ec3c1d34cd8.json
+++ b/.github/doc-updates/0fa7c920-68b6-4ec4-8682-5ec3c1d34cd8.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Implement full performance testing framework",
+  "guid": "0fa7c920-68b6-4ec4-8682-5ec3c1d34cd8",
+  "created_at": "2025-08-10T02:54:43Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7e4d1fa7-ada5-41e2-aad6-decb1db78211.json
+++ b/.github/doc-updates/7e4d1fa7-ada5-41e2-aad6-decb1db78211.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add initial performance testing framework skeleton",
+  "guid": "7e4d1fa7-ada5-41e2-aad6-decb1db78211",
+  "created_at": "2025-08-10T02:54:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8005288e-2b4f-4c00-810a-c0dc813e286b.json
+++ b/.github/doc-updates/8005288e-2b4f-4c00-810a-c0dc813e286b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "- **[Performance Testing Framework](perf/)** - Benchmarks and performance tools",
+  "guid": "8005288e-2b4f-4c00-810a-c0dc813e286b",
+  "created_at": "2025-08-10T12:34:34Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d02bff65-4384-462e-aab8-ee0a9c25faec.json
+++ b/.github/doc-updates/d02bff65-4384-462e-aab8-ee0a9c25faec.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n\\n- Expand performance testing framework with runner, benchmarks, load, stress, and regression modules",
+  "guid": "d02bff65-4384-462e-aab8-ee0a9c25faec",
+  "created_at": "2025-08-10T12:34:31Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/64e47491-d5e0-48c4-8aa7-bf0332d459bc.json
+++ b/.github/issue-updates/64e47491-d5e0-48c4-8aa7-bf0332d459bc.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Performance testing framework skeleton",
+  "body": "Add initial performance testing framework with metrics structures",
+  "labels": ["type:feature", "performance", "testing"],
+  "guid": "64e47491-d5e0-48c4-8aa7-bf0332d459bc",
+  "legacy_guid": "create-performance-testing-framework-skeleton-2025-08-10",
+  "created_at": "2025-08-10T02:54:02.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/e9c4b4a9-a380-4c9d-b045-932d397f69fd.json
+++ b/.github/issue-updates/e9c4b4a9-a380-4c9d-b045-932d397f69fd.json
@@ -1,0 +1,13 @@
+{
+  "action": "update",
+  "number": null,
+  "body": "Expanded performance testing framework with runner, benchmarks, load, stress, and regression components",
+  "labels": ["type:feature", "performance", "testing"],
+  "guid": "e9c4b4a9-a380-4c9d-b045-932d397f69fd",
+  "legacy_guid": "update-issue-null-2025-08-10",
+  "created_at": "2025-08-10T12:34:38.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/perf/benchmarks/auth_bench.go
+++ b/perf/benchmarks/auth_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/auth_bench.go
+// version: 1.0.0
+// guid: fd0f1fb4-c2b0-4ffe-877a-3ec930f5fa3c
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkTokenValidation measures token validation speed.
+func BenchmarkTokenValidation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement token validation
+	}
+}
+
+// BenchmarkAuthDecision measures authorization decision latency.
+func BenchmarkAuthDecision(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement authorization decision
+	}
+}
+
+// BenchmarkConcurrentAuthRequests measures concurrent authentication requests.
+func BenchmarkConcurrentAuthRequests(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent auth request
+		}
+	})
+}
+
+// BenchmarkPolicyEvaluation measures policy evaluation performance.
+func BenchmarkPolicyEvaluation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement policy evaluation
+	}
+}

--- a/perf/benchmarks/cache_bench.go
+++ b/perf/benchmarks/cache_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/cache_bench.go
+// version: 1.0.0
+// guid: dbd85aa4-ce87-4d30-9b6f-4881edd6cb12
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkCacheLatency measures cache hit/miss latency.
+func BenchmarkCacheLatency(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement cache latency benchmark
+	}
+}
+
+// BenchmarkCacheThroughput measures cache throughput.
+func BenchmarkCacheThroughput(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement cache throughput benchmark
+	}
+}
+
+// BenchmarkCacheEviction measures eviction policy performance.
+func BenchmarkCacheEviction(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement cache eviction benchmark
+	}
+}
+
+// BenchmarkConcurrentCacheAccess measures concurrent cache access.
+func BenchmarkConcurrentCacheAccess(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent cache access
+		}
+	})
+}

--- a/perf/benchmarks/config_bench.go
+++ b/perf/benchmarks/config_bench.go
@@ -1,0 +1,38 @@
+// file: perf/benchmarks/config_bench.go
+// version: 1.0.0
+// guid: 311a5d69-2fc9-48e2-adeb-6490a46ab222
+
+// Package benchmarks provides module benchmark stubs.
+package benchmarks
+
+import "testing"
+
+// BenchmarkConfigRetrieval measures configuration retrieval performance.
+func BenchmarkConfigRetrieval(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement configuration retrieval benchmark
+	}
+}
+
+// BenchmarkConfigParsing measures configuration parsing speed.
+func BenchmarkConfigParsing(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement configuration parsing benchmark
+	}
+}
+
+// BenchmarkConfigConcurrentAccess measures concurrent configuration access.
+func BenchmarkConfigConcurrentAccess(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent access benchmark
+		}
+	})
+}
+
+// BenchmarkConfigWatchingOverhead measures configuration watching overhead.
+func BenchmarkConfigWatchingOverhead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement config watching overhead benchmark
+	}
+}

--- a/perf/benchmarks/metrics_bench.go
+++ b/perf/benchmarks/metrics_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/metrics_bench.go
+// version: 1.0.0
+// guid: ada49c78-cfee-48e9-8940-19fa6aba772b
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkMetricCollection measures metric collection overhead.
+func BenchmarkMetricCollection(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement metric collection
+	}
+}
+
+// BenchmarkMetricAggregation measures metric aggregation performance.
+func BenchmarkMetricAggregation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement metric aggregation
+	}
+}
+
+// BenchmarkMetricExport measures export performance.
+func BenchmarkMetricExport(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement metric export
+	}
+}
+
+// BenchmarkConcurrentMetricRecording measures concurrent metric recording.
+func BenchmarkConcurrentMetricRecording(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent metric recording
+		}
+	})
+}

--- a/perf/benchmarks/notification_bench.go
+++ b/perf/benchmarks/notification_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/notification_bench.go
+// version: 1.0.0
+// guid: 76f64712-9442-44d5-9f74-360028e0b6e0
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkNotificationSend measures notification send throughput.
+func BenchmarkNotificationSend(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement notification send benchmark
+	}
+}
+
+// BenchmarkNotificationDelivery measures delivery latency.
+func BenchmarkNotificationDelivery(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement notification delivery benchmark
+	}
+}
+
+// BenchmarkNotificationQueueDepth measures queue depth handling.
+func BenchmarkNotificationQueueDepth(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement notification queue depth benchmark
+	}
+}
+
+// BenchmarkConcurrentNotifications measures concurrent notification handling.
+func BenchmarkConcurrentNotifications(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent notification handling
+		}
+	})
+}

--- a/perf/benchmarks/organization_bench.go
+++ b/perf/benchmarks/organization_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/organization_bench.go
+// version: 1.0.0
+// guid: 73ce7a17-d28d-40bb-acef-0b8343cc2c9d
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkOrgCreation measures organization creation performance.
+func BenchmarkOrgCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement organization creation benchmark
+	}
+}
+
+// BenchmarkOrgLookup measures organization lookup speed.
+func BenchmarkOrgLookup(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement organization lookup benchmark
+	}
+}
+
+// BenchmarkOrgListing measures organization listing throughput.
+func BenchmarkOrgListing(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement organization listing benchmark
+	}
+}
+
+// BenchmarkOrgConcurrentOps measures concurrent organization operations.
+func BenchmarkOrgConcurrentOps(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent organization operations
+		}
+	})
+}

--- a/perf/benchmarks/queue_bench.go
+++ b/perf/benchmarks/queue_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/queue_bench.go
+// version: 1.0.0
+// guid: b40d8fa6-78a7-4405-a2bb-94865f4c5a36
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkQueuePublishing measures message publishing throughput.
+func BenchmarkQueuePublishing(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement message publishing
+	}
+}
+
+// BenchmarkQueueConsumption measures message consumption latency.
+func BenchmarkQueueConsumption(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement message consumption
+	}
+}
+
+// BenchmarkQueueDepthHandling measures queue depth handling.
+func BenchmarkQueueDepthHandling(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement queue depth handling
+	}
+}
+
+// BenchmarkQueueConcurrent measures concurrent producer/consumer performance.
+func BenchmarkQueueConcurrent(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent producer/consumer
+		}
+	})
+}

--- a/perf/benchmarks/web_bench.go
+++ b/perf/benchmarks/web_bench.go
@@ -1,0 +1,37 @@
+// file: perf/benchmarks/web_bench.go
+// version: 1.0.0
+// guid: 0e03a6a3-7b39-4696-ab4f-bbffb0c789c9
+
+package benchmarks
+
+import "testing"
+
+// BenchmarkHTTPThroughput measures HTTP request handling throughput.
+func BenchmarkHTTPThroughput(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement HTTP throughput benchmark
+	}
+}
+
+// BenchmarkMiddlewareOverhead measures middleware chain overhead.
+func BenchmarkMiddlewareOverhead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement middleware overhead benchmark
+	}
+}
+
+// BenchmarkSessionManagement measures session management performance.
+func BenchmarkSessionManagement(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// TODO: implement session management benchmark
+	}
+}
+
+// BenchmarkConcurrentConnections measures concurrent connection handling.
+func BenchmarkConcurrentConnections(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// TODO: implement concurrent connection benchmark
+		}
+	})
+}

--- a/perf/framework/metrics.go
+++ b/perf/framework/metrics.go
@@ -1,0 +1,55 @@
+// file: perf/framework/metrics.go
+// version: 1.0.0
+// guid: 4e9b2dc2-9853-459b-9c81-a190eaf138a8
+
+// Package framework provides utilities for performance testing.
+package framework
+
+import "time"
+
+// PerformanceMetrics captures collected metrics for a benchmark run.
+type PerformanceMetrics struct {
+	Latency       LatencyMetrics
+	Throughput    ThroughputMetrics
+	MemoryUsage   MemoryMetrics
+	CPUUsage      CPUMetrics
+	ErrorRate     ErrorRateMetrics
+	ResourceUsage ResourceMetrics
+}
+
+// LatencyMetrics represents latency distribution metrics.
+type LatencyMetrics struct {
+	P50, P95, P99, P999 time.Duration
+	Mean, Max, Min      time.Duration
+}
+
+// ThroughputMetrics represents throughput measurements.
+type ThroughputMetrics struct {
+	RequestsPerSecond   float64
+	OperationsPerSecond float64
+	BytesPerSecond      float64
+}
+
+// MemoryMetrics reports memory usage statistics.
+type MemoryMetrics struct {
+	AllocatedBytes uint64
+	TotalBytes     uint64
+}
+
+// CPUMetrics reports CPU usage percentages.
+type CPUMetrics struct {
+	UserPercent   float64
+	SystemPercent float64
+}
+
+// ErrorRateMetrics captures error counts and rate.
+type ErrorRateMetrics struct {
+	Errors    int64
+	ErrorRate float64
+}
+
+// ResourceMetrics tracks system resource utilization.
+type ResourceMetrics struct {
+	OpenFiles  int
+	Goroutines int
+}

--- a/perf/framework/profiling.go
+++ b/perf/framework/profiling.go
@@ -1,0 +1,41 @@
+// file: perf/framework/profiling.go
+// version: 1.0.0
+// guid: ab4d72d9-fc62-4f07-8051-55df394207c0
+
+package framework
+
+import (
+	"os"
+	"runtime"
+	"runtime/pprof"
+)
+
+// StartCPUProfile begins CPU profiling and writes to the given path.
+func StartCPUProfile(path string) (*os.File, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// StopCPUProfile stops the CPU profile and closes the file.
+func StopCPUProfile(f *os.File) {
+	pprof.StopCPUProfile()
+	_ = f.Close()
+}
+
+// WriteMemProfile writes a heap profile to the specified path.
+func WriteMemProfile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	runtime.GC()
+	return pprof.WriteHeapProfile(f)
+}

--- a/perf/framework/reporting.go
+++ b/perf/framework/reporting.go
@@ -1,0 +1,18 @@
+// file: perf/framework/reporting.go
+// version: 1.0.0
+// guid: cae403f2-401c-4d19-b1de-b6e9cd16df1e
+
+package framework
+
+import "encoding/json"
+
+// Report wraps performance metrics for output.
+type Report struct {
+	Metrics PerformanceMetrics `json:"metrics"`
+}
+
+// GenerateReport returns metrics as formatted JSON.
+func GenerateReport(m PerformanceMetrics) ([]byte, error) {
+	r := Report{Metrics: m}
+	return json.MarshalIndent(r, "", "  ")
+}

--- a/perf/framework/runner.go
+++ b/perf/framework/runner.go
@@ -1,0 +1,16 @@
+// file: perf/framework/runner.go
+// version: 1.0.0
+// guid: b6ba8daf-d498-45da-8fbc-92f4bddfc1c0
+
+// Package framework provides utilities for performance testing.
+package framework
+
+import "testing"
+
+// Runner executes benchmarks and collects metrics.
+type Runner struct{}
+
+// Run executes a benchmark and returns collected metrics.
+func (r *Runner) Run(b *testing.B, fn func(b *testing.B) PerformanceMetrics) PerformanceMetrics {
+	return fn(b)
+}

--- a/perf/load/analyzers/analyzers.go
+++ b/perf/load/analyzers/analyzers.go
@@ -1,0 +1,11 @@
+// file: perf/load/analyzers/analyzers.go
+// version: 1.0.0
+// guid: 377b1d5b-a9ef-4ddc-b2f6-cbabcae4845e
+
+// Package analyzers evaluates load test results.
+package analyzers
+
+// Analyzer processes load test metrics.
+type Analyzer interface {
+	Analyze() error
+}

--- a/perf/load/generators/generators.go
+++ b/perf/load/generators/generators.go
@@ -1,0 +1,12 @@
+// file: perf/load/generators/generators.go
+// version: 1.0.0
+// guid: 9e819fd0-172f-46fd-9a3c-1ff30221fceb
+
+// Package generators provides load generators.
+package generators
+
+// Generator produces load against the system under test.
+type Generator interface {
+	Start() error
+	Stop() error
+}

--- a/perf/load/scenarios/scenarios.go
+++ b/perf/load/scenarios/scenarios.go
@@ -1,0 +1,11 @@
+// file: perf/load/scenarios/scenarios.go
+// version: 1.0.0
+// guid: f80b7f6b-0bdc-4c33-96f2-0d226ae78c62
+
+// Package scenarios defines load test scenarios.
+package scenarios
+
+// Scenario defines a load test scenario.
+type Scenario struct {
+	Name string
+}

--- a/perf/regression/baseline.go
+++ b/perf/regression/baseline.go
@@ -1,0 +1,13 @@
+// file: perf/regression/baseline.go
+// version: 1.0.0
+// guid: c5fa1a50-68cd-4820-9956-aa7757ccc010
+
+// Package regression provides performance regression detection.
+package regression
+
+import "github.com/jdfalk/gcommon/perf/framework"
+
+// Baseline represents stored performance metrics for comparison.
+type Baseline struct {
+	Metrics framework.PerformanceMetrics
+}

--- a/perf/regression/comparison.go
+++ b/perf/regression/comparison.go
@@ -1,0 +1,10 @@
+// file: perf/regression/comparison.go
+// version: 1.0.0
+// guid: 40ae2f0e-0dda-4c37-85a9-41710f07aa51
+
+package regression
+
+// CompareMetrics compares current metrics with baseline.
+func CompareMetrics(current, baseline float64) float64 {
+	return current - baseline
+}

--- a/perf/regression/detection.go
+++ b/perf/regression/detection.go
@@ -1,0 +1,10 @@
+// file: perf/regression/detection.go
+// version: 1.0.0
+// guid: 610f86d8-1b34-41e3-b20c-86161c182f6d
+
+package regression
+
+// DetectRegression returns true if a regression is detected.
+func DetectRegression(diff float64, threshold float64) bool {
+	return diff > threshold
+}

--- a/perf/stress/concurrent_stress.go
+++ b/perf/stress/concurrent_stress.go
@@ -1,0 +1,20 @@
+// file: perf/stress/concurrent_stress.go
+// version: 1.0.0
+// guid: fe674fd3-b43c-406f-ba93-854dfac52654
+
+package stress
+
+import "sync"
+
+// SpawnWorkers launches goroutines to test concurrency limits.
+func SpawnWorkers(workers int, work func()) {
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			work()
+		}()
+	}
+	wg.Wait()
+}

--- a/perf/stress/cpu_stress.go
+++ b/perf/stress/cpu_stress.go
@@ -1,0 +1,14 @@
+// file: perf/stress/cpu_stress.go
+// version: 1.0.0
+// guid: c0de16cc-49e1-4959-9b4f-9f9c52a67c78
+
+package stress
+
+// BurnCPU performs a compute-heavy loop to stress CPU.
+func BurnCPU(iterations int) int {
+	x := 0
+	for i := 0; i < iterations; i++ {
+		x += i
+	}
+	return x
+}

--- a/perf/stress/memory_stress.go
+++ b/perf/stress/memory_stress.go
@@ -1,0 +1,15 @@
+// file: perf/stress/memory_stress.go
+// version: 1.0.0
+// guid: 24e5b2ef-d78e-4714-a6c6-64c5581116f7
+
+// Package stress contains stress test helpers.
+package stress
+
+// AllocateMemory repeatedly allocates blocks to test memory limits.
+func AllocateMemory(blocks int, size int) [][]byte {
+	data := make([][]byte, 0, blocks)
+	for i := 0; i < blocks; i++ {
+		data = append(data, make([]byte, size))
+	}
+	return data
+}


### PR DESCRIPTION
## Summary
- scaffold runner, profiling, and reporting utilities for performance metrics
- add benchmark stubs, load testing scaffolding, stress helpers, and regression detectors
- document framework expansion in changelog and README; update tracking issue

## Testing
- `go test ./perf/...`
- `go test ./...` *(hangs after auth mock; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68980916e8f08321a43c7f99bc989e87