### PR TITLE
feat: implement full plugin architecture with SDK and examples

### DIFF
--- a/.github/doc-updates/processed/20250810_025930_19504b67-6a9c-4986-a3c7-3dd66ec2cc5d.json
+++ b/.github/doc-updates/processed/20250810_025930_19504b67-6a9c-4986-a3c7-3dd66ec2cc5d.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "It now supports a plugin architecture for custom integrations.",
+  "guid": "19504b67-6a9c-4986-a3c7-3dd66ec2cc5d",
+  "created_at": "2025-08-10T02:59:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_025930_a43ab29c-844d-4553-8265-3098ba4fe67f.json
+++ b/.github/doc-updates/processed/20250810_025930_a43ab29c-844d-4553-8265-3098ba4fe67f.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Introduce plugin framework skeleton",
+  "guid": "a43ab29c-844d-4553-8265-3098ba4fe67f",
+  "created_at": "2025-08-10T02:58:23Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_025930_f5b4bddf-2407-484e-af2b-776bd7dfba2c.json
+++ b/.github/doc-updates/processed/20250810_025930_f5b4bddf-2407-484e-af2b-776bd7dfba2c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Build out plugin SDK and security features",
+  "guid": "f5b4bddf-2407-484e-af2b-776bd7dfba2c",
+  "created_at": "2025-08-10T02:58:29Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_123954_9404edb3-facf-44a1-aa8f-ee955f3ad4b7.json
+++ b/.github/doc-updates/processed/20250810_123954_9404edb3-facf-44a1-aa8f-ee955f3ad4b7.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Add more plugin examples and security audits",
+  "guid": "9404edb3-facf-44a1-aa8f-ee955f3ad4b7",
+  "created_at": "2025-08-10T12:39:51Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_123954_96b8bb85-44ec-4d06-981b-820573a13720.json
+++ b/.github/doc-updates/processed/20250810_123954_96b8bb85-44ec-4d06-981b-820573a13720.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Provides SDK, security features, and example plugins for extensibility.",
+  "guid": "96b8bb85-44ec-4d06-981b-820573a13720",
+  "created_at": "2025-08-10T12:39:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250810_123954_9d164c51-b2ef-429c-81ce-1b083a3c700f.json
+++ b/.github/doc-updates/processed/20250810_123954_9d164c51-b2ef-429c-81ce-1b083a3c700f.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added extensible plugin architecture with security, communication bus, SDK, and examples",
+  "guid": "9d164c51-b2ef-429c-81ce-1b083a3c700f",
+  "created_at": "2025-08-10T12:39:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/81c59d05-0167-40c8-8da2-fa28093f4e35.json
+++ b/.github/issue-updates/81c59d05-0167-40c8-8da2-fa28093f4e35.json
@@ -1,0 +1,24 @@
+{
+  "action": "create",
+  "title": "Plugin system framework",
+  "body": "Implement plugin management skeleton",
+  "labels": [
+    "module:plugins",
+    "enhancement"
+  ],
+  "guid": "81c59d05-0167-40c8-8da2-fa28093f4e35",
+  "legacy_guid": "create-plugin-system-framework-2025-08-10",
+  "created_at": "2025-08-10T02:55:40.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null,
+  "file_modified_at": "2025-08-10T02:55:40.161615+00:00",
+  "timestamp_extracted_at": "2025-08-10T03:00:14.052928+00:00",
+  "processing_metadata": {
+    "enhanced_at": "2025-08-10T03:00:14.052944+00:00",
+    "source_file": ".github/issue-updates/81c59d05-0167-40c8-8da2-fa28093f4e35.json",
+    "version": "2.0.0"
+  },
+  "has_dependencies": true
+}

--- a/.github/issue-updates/fde9d9c6-b935-4670-912a-2187d92203a4.json
+++ b/.github/issue-updates/fde9d9c6-b935-4670-912a-2187d92203a4.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Complete plugin architecture",
+  "body": "Implement full plugin framework with types, security, sdk, examples",
+  "labels": ["module:plugins", "enhancement"],
+  "guid": "fde9d9c6-b935-4670-912a-2187d92203a4",
+  "legacy_guid": "create-complete-plugin-architecture-2025-08-10",
+  "created_at": "2025-08-10T12:39:37.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added extensible plugin architecture with security, communication bus, SDK, and examples
+
+### Added
+
+- Introduce plugin framework skeleton
+
 ### Added - MAJOR PROTOBUF IMPLEMENTATION MILESTONE (August 2025)
 
 **🚀 MASSIVE PROTOBUF EXPANSION**: Completed comprehensive 1-1-1 pattern

--- a/README.md
+++ b/README.md
@@ -537,3 +537,6 @@ protobuf messages added
 ### July 28, 2025 - Metrics module progress updated: 33 of 97 protobufs implemented
 
 Common module protobufs verified complete (July 28, 2025).
+
+It now supports a plugin architecture for custom integrations.
+Provides SDK, security features, and example plugins for extensibility.

--- a/TODO.md
+++ b/TODO.md
@@ -2638,3 +2638,7 @@ Implemented metrics request and response protobufs
 Verified common module protobufs are fully implemented; no empty files remaining
 Implemented DatabaseStatusCode enum and DatabaseStatus message for database
 module
+
+Build out plugin SDK and security features
+
+Add more plugin examples and security audits

--- a/pkg/plugins/bus_test.go
+++ b/pkg/plugins/bus_test.go
@@ -1,0 +1,18 @@
+// file: pkg/plugins/bus_test.go
+// version: 1.0.0
+// guid: c7d66be5-1e44-4c8e-9ffd-3b7056eeff0c
+
+package plugins
+
+import "testing"
+
+func TestInMemoryBusPublishSubscribe(t *testing.T) {
+	bus := NewInMemoryBus()
+	received := make(chan Message, 1)
+	bus.Subscribe("topic", func(m Message) { received <- m })
+	bus.Publish(Message{Topic: "topic", Data: "hello"})
+	msg := <-received
+	if msg.Data != "hello" {
+		t.Fatalf("unexpected data %v", msg.Data)
+	}
+}

--- a/pkg/plugins/communication.go
+++ b/pkg/plugins/communication.go
@@ -1,0 +1,49 @@
+// file: pkg/plugins/communication.go
+// version: 1.0.0
+// guid: 61ca0091-811b-4a3f-9b5a-76fdc3bfe4db
+
+package plugins
+
+import "sync"
+
+// Message represents a communication payload between plugins.
+type Message struct {
+	Topic string
+	Data  interface{}
+}
+
+// Bus defines plugin messaging operations.
+type Bus interface {
+	Publish(msg Message) error
+	Subscribe(topic string, handler func(Message)) error
+}
+
+// InMemoryBus provides a simple pub/sub message bus for plugins.
+type InMemoryBus struct {
+	mu   sync.RWMutex
+	subs map[string][]func(Message)
+}
+
+// NewInMemoryBus creates an empty message bus.
+func NewInMemoryBus() *InMemoryBus {
+	return &InMemoryBus{subs: make(map[string][]func(Message))}
+}
+
+// Publish sends a message to all subscribers of the topic.
+func (b *InMemoryBus) Publish(msg Message) error {
+	b.mu.RLock()
+	handlers := append([]func(Message){}, b.subs[msg.Topic]...)
+	b.mu.RUnlock()
+	for _, h := range handlers {
+		h(msg)
+	}
+	return nil
+}
+
+// Subscribe registers a handler for a topic.
+func (b *InMemoryBus) Subscribe(topic string, handler func(Message)) error {
+	b.mu.Lock()
+	b.subs[topic] = append(b.subs[topic], handler)
+	b.mu.Unlock()
+	return nil
+}

--- a/pkg/plugins/examples/extension/goodbye/goodbye.go
+++ b/pkg/plugins/examples/extension/goodbye/goodbye.go
@@ -1,0 +1,45 @@
+// file: pkg/plugins/examples/extension/goodbye/goodbye.go
+// version: 1.0.0
+// guid: 2d80bb91-d5b0-476e-9bb4-c7fefb5ea182
+
+package goodbye
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin publishes a goodbye message.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a goodbye extension plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "goodbye",
+		Version:     "0.1.0",
+		Type:        plugins.Extension,
+		Description: "publishes goodbye messages",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Extend publishes a goodbye message via manager bus.
+func (p *Plugin) Extend(m *plugins.Manager) error {
+	return m.Bus().Publish(plugins.Message{Topic: "goodbye", Data: "farewell"})
+}
+
+// Start announces start.
+func (p *Plugin) Start(ctx context.Context) error {
+	fmt.Println("goodbye extension started")
+	return nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/extension/hello/hello.go
+++ b/pkg/plugins/examples/extension/hello/hello.go
@@ -1,0 +1,45 @@
+// file: pkg/plugins/examples/extension/hello/hello.go
+// version: 1.0.0
+// guid: f3e0f4f7-7c45-4d6a-90ab-77bd8bfa9a8e
+
+package hello
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin adds a hello extension.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a hello extension plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "hello",
+		Version:     "0.1.0",
+		Type:        plugins.Extension,
+		Description: "adds hello world extension",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Extend outputs a hello message using the manager's bus.
+func (p *Plugin) Extend(m *plugins.Manager) error {
+	return m.Bus().Publish(plugins.Message{Topic: "hello", Data: "world"})
+}
+
+// Start prints a startup message.
+func (p *Plugin) Start(ctx context.Context) error {
+	fmt.Println("hello extension started")
+	return nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/extension/hello/hello_test.go
+++ b/pkg/plugins/examples/extension/hello/hello_test.go
@@ -1,0 +1,25 @@
+// file: pkg/plugins/examples/extension/hello/hello_test.go
+// version: 1.0.0
+// guid: 8712ad79-36ab-4f70-9de4-e6f8f507b2d7
+
+package hello
+
+import (
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+)
+
+func TestHelloExtend(t *testing.T) {
+	p := New()
+	m := plugins.NewManager(nil, nil, nil)
+	received := make(chan plugins.Message, 1)
+	m.Bus().Subscribe("hello", func(msg plugins.Message) { received <- msg })
+	if err := p.Extend(m); err != nil {
+		t.Fatalf("extend: %v", err)
+	}
+	msg := <-received
+	if msg.Data != "world" {
+		t.Fatalf("unexpected data %v", msg.Data)
+	}
+}

--- a/pkg/plugins/examples/integration/analytics/analytics.go
+++ b/pkg/plugins/examples/integration/analytics/analytics.go
@@ -1,0 +1,41 @@
+// file: pkg/plugins/examples/integration/analytics/analytics.go
+// version: 1.0.0
+// guid: c0d9e7e6-e51d-4dec-8a59-98992bcc12c7
+
+package analytics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin integrates with a dummy analytics service.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates an analytics integration plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "analytics",
+		Version:     "0.1.0",
+		Type:        plugins.Integration,
+		Description: "sends events to a dummy analytics service",
+		Permissions: []plugins.Permission{plugins.PermissionNetwork},
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Connect simulates event reporting.
+func (p *Plugin) Connect(ctx context.Context) error {
+	fmt.Println("sending event to analytics service")
+	return nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/integration/analytics/analytics_test.go
+++ b/pkg/plugins/examples/integration/analytics/analytics_test.go
@@ -1,0 +1,17 @@
+// file: pkg/plugins/examples/integration/analytics/analytics_test.go
+// version: 1.0.0
+// guid: 04a5f24e-973b-4d5a-8320-e82bb00d6bbd
+
+package analytics
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAnalyticsConnect(t *testing.T) {
+	p := New()
+	if err := p.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+}

--- a/pkg/plugins/examples/integration/dummy/dummy.go
+++ b/pkg/plugins/examples/integration/dummy/dummy.go
@@ -1,0 +1,41 @@
+// file: pkg/plugins/examples/integration/dummy/dummy.go
+// version: 1.0.0
+// guid: 1be0aa65-41e6-4bc0-8a94-d541b6b0cb91
+
+package dummy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin integrates with a dummy third-party service.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a dummy integration plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "dummy",
+		Version:     "0.1.0",
+		Type:        plugins.Integration,
+		Description: "connects to a dummy service",
+		Permissions: []plugins.Permission{plugins.PermissionNetwork},
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Connect simulates contacting the third-party service.
+func (p *Plugin) Connect(ctx context.Context) error {
+	fmt.Println("connecting to dummy service")
+	return nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/middleware/logger/logger.go
+++ b/pkg/plugins/examples/middleware/logger/logger.go
@@ -1,0 +1,40 @@
+// file: pkg/plugins/examples/middleware/logger/logger.go
+// version: 1.0.0
+// guid: 452445b8-2d87-4f39-8fbe-eb6e56b51b96
+
+package logger
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin logs messages as middleware.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a logger middleware plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "logger",
+		Version:     "0.1.0",
+		Type:        plugins.Middleware,
+		Description: "logs messages passing through",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Handle logs the message and returns it unchanged.
+func (p *Plugin) Handle(ctx context.Context, msg interface{}) (interface{}, error) {
+	fmt.Printf("logger middleware: %v\n", msg)
+	return msg, nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/middleware/uppercase/uppercase.go
+++ b/pkg/plugins/examples/middleware/uppercase/uppercase.go
@@ -1,0 +1,45 @@
+// file: pkg/plugins/examples/middleware/uppercase/uppercase.go
+// version: 1.0.0
+// guid: 60fc3b21-9436-45b2-b396-975c3b72d8fa
+
+package uppercase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin converts messages to uppercase as middleware.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a new uppercase middleware plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "uppercase",
+		Version:     "0.1.0",
+		Type:        plugins.Middleware,
+		Description: "converts messages to uppercase",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// Handle converts the message to uppercase.
+func (p *Plugin) Handle(ctx context.Context, msg interface{}) (interface{}, error) {
+	if s, ok := msg.(string); ok {
+		u := strings.ToUpper(s)
+		fmt.Printf("uppercase middleware: %s -> %s\n", s, u)
+		return u, nil
+	}
+	return msg, nil
+}
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/middleware/uppercase/uppercase_test.go
+++ b/pkg/plugins/examples/middleware/uppercase/uppercase_test.go
@@ -1,0 +1,21 @@
+// file: pkg/plugins/examples/middleware/uppercase/uppercase_test.go
+// version: 1.0.0
+// guid: 3e3f211e-2587-4ece-9432-2560f5d9e5ce
+
+package uppercase
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUppercaseMiddleware(t *testing.T) {
+	p := New()
+	out, err := p.Handle(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if out != "ABC" {
+		t.Fatalf("expected ABC, got %v", out)
+	}
+}

--- a/pkg/plugins/examples/provider/echo/echo.go
+++ b/pkg/plugins/examples/provider/echo/echo.go
@@ -1,0 +1,41 @@
+// file: pkg/plugins/examples/provider/echo/echo.go
+// version: 1.0.0
+// guid: 0ae6fa8f-760e-4f0c-80ba-623a5a89f721
+
+package echo
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin provides an echo provider.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a new Plugin instance.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "echo",
+		Version:     "0.1.0",
+		Type:        plugins.Provider,
+		Description: "echo provider returns input as output",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// GetProvider returns the echo provider implementation.
+func (p *Plugin) GetProvider() interface{} {
+	return func(s string) string { return s }
+}
+
+// Start announces plugin start via bus.
+func (p *Plugin) Start(ctx context.Context) error { return nil }
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/provider/reverse/reverse.go
+++ b/pkg/plugins/examples/provider/reverse/reverse.go
@@ -1,0 +1,48 @@
+// file: pkg/plugins/examples/provider/reverse/reverse.go
+// version: 1.0.0
+// guid: d295eddd-6e5b-4475-8c55-76fac1a5f477
+
+package reverse
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+	sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// Plugin provides a string reversal provider.
+type Plugin struct {
+	sdk.BasePlugin
+}
+
+// New creates a new reverse plugin.
+func New() *Plugin {
+	md := plugins.Metadata{
+		Name:        "reverse",
+		Version:     "0.1.0",
+		Type:        plugins.Provider,
+		Description: "reverses strings",
+	}
+	return &Plugin{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// GetProvider returns the reverse provider implementation.
+func (p *Plugin) GetProvider() interface{} {
+	return func(s string) string { return reverseString(s) }
+}
+
+func reverseString(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+func (p *Plugin) Start(ctx context.Context) error { return nil }
+
+var Descriptor = plugins.Descriptor{
+	Metadata: New().Metadata,
+	New:      func() plugins.Plugin { return New() },
+}

--- a/pkg/plugins/examples/provider/reverse/reverse_test.go
+++ b/pkg/plugins/examples/provider/reverse/reverse_test.go
@@ -1,0 +1,15 @@
+// file: pkg/plugins/examples/provider/reverse/reverse_test.go
+// version: 1.0.0
+// guid: 2f14309d-a2ae-4d47-b1a7-0c6c5c28b2b5
+
+package reverse
+
+import "testing"
+
+func TestReverseProvider(t *testing.T) {
+	p := New()
+	provider := p.GetProvider().(func(string) string)
+	if got := provider("abc"); got != "cba" {
+		t.Fatalf("expected cba, got %s", got)
+	}
+}

--- a/pkg/plugins/lifecycle.go
+++ b/pkg/plugins/lifecycle.go
@@ -1,0 +1,34 @@
+// file: pkg/plugins/lifecycle.go
+// version: 1.0.0
+// guid: d5b274db-2bd5-4931-8a36-9e47f77581be
+
+package plugins
+
+import "context"
+
+// Initialize configures a plugin before use.
+func Initialize(p Plugin, cfg map[string]interface{}) error {
+	return p.Initialize(cfg)
+}
+
+// Start activates the plugin.
+func Start(ctx context.Context, p Plugin) error {
+	return p.Start(ctx)
+}
+
+// Stop shuts down the plugin.
+func Stop(ctx context.Context, p Plugin) error {
+	return p.Stop(ctx)
+}
+
+// InitializeAll configures all plugins with the provided configs.
+func InitializeAll(reg *Registry, configs map[string]map[string]interface{}) error {
+	for name, p := range reg.plugins {
+		if cfg, ok := configs[name]; ok {
+			if err := Initialize(p, cfg); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -1,0 +1,27 @@
+// file: pkg/plugins/loader.go
+// version: 1.0.0
+// guid: 9108a4e0-b6ed-43bc-8e7b-885394f2255f
+
+package plugins
+
+import (
+	"errors"
+	"plugin"
+)
+
+// Load dynamically loads a plugin descriptor from a shared object file.
+func Load(path string) (Descriptor, error) {
+	p, err := plugin.Open(path)
+	if err != nil {
+		return Descriptor{}, err
+	}
+	sym, err := p.Lookup("Descriptor")
+	if err != nil {
+		return Descriptor{}, err
+	}
+	d, ok := sym.(*Descriptor)
+	if !ok {
+		return Descriptor{}, errors.New("symbol Descriptor has wrong type")
+	}
+	return *d, nil
+}

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -1,0 +1,73 @@
+// file: pkg/plugins/manager.go
+// version: 1.0.0
+// guid: c05997e0-04db-4cb3-a610-103e85fe8eae
+
+package plugins
+
+import "context"
+
+// Manager coordinates plugin lifecycle, security, and communication.
+type Manager struct {
+	registry *Registry
+	bus      Bus
+	checker  Checker
+	policies map[string]Policy
+}
+
+// NewManager creates a plugin manager.
+func NewManager(r *Registry, bus Bus, checker Checker) *Manager {
+	if r == nil {
+		r = NewRegistry()
+	}
+	if bus == nil {
+		bus = NewInMemoryBus()
+	}
+	if checker == nil {
+		checker = DefaultChecker{}
+	}
+	return &Manager{registry: r, bus: bus, checker: checker, policies: make(map[string]Policy)}
+}
+
+// Register adds a plugin and its metadata to the underlying registry.
+func (m *Manager) Register(p Plugin, md Metadata, policy Policy) error {
+	wrapped := WithMetadata(p, md)
+	if err := m.registry.Register(wrapped, md); err != nil {
+		return err
+	}
+	m.policies[p.Name()] = policy
+	return nil
+}
+
+// StartAll initializes and starts all registered plugins with security checks.
+func (m *Manager) StartAll(ctx context.Context) error {
+	for _, p := range m.registry.List() {
+		policy := m.policies[p.Name()]
+		if err := m.checker.Validate(p, policy); err != nil {
+			return err
+		}
+		if err := p.Start(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StopAll stops all registered plugins.
+func (m *Manager) StopAll(ctx context.Context) error {
+	for _, p := range m.registry.List() {
+		if err := p.Stop(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Registry returns the internal registry.
+func (m *Manager) Registry() *Registry {
+	return m.registry
+}
+
+// Bus returns the communication bus.
+func (m *Manager) Bus() Bus {
+	return m.bus
+}

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -1,0 +1,41 @@
+// file: pkg/plugins/manager_test.go
+// version: 1.0.0
+// guid: e7324c9a-331b-4a50-98c8-afb61896c5a5
+
+package plugins
+
+import (
+	"context"
+	"testing"
+)
+
+type simplePlugin struct{ started bool }
+
+func (s *simplePlugin) Name() string                            { return "simple" }
+func (s *simplePlugin) Version() string                         { return "v1" }
+func (s *simplePlugin) Initialize(map[string]interface{}) error { return nil }
+func (s *simplePlugin) Start(ctx context.Context) error         { s.started = true; return nil }
+func (s *simplePlugin) Stop(ctx context.Context) error          { s.started = false; return nil }
+func (s *simplePlugin) Health() HealthStatus                    { return HealthStatus{OK: true} }
+
+func TestManagerStartStop(t *testing.T) {
+	r := NewRegistry()
+	m := NewManager(r, nil, nil)
+	p := &simplePlugin{}
+	md := Metadata{Name: "simple", Type: Provider}
+	if err := m.Register(p, md, Policy{}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := m.StartAll(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !p.started {
+		t.Fatalf("plugin not started")
+	}
+	if err := m.StopAll(context.Background()); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if p.started {
+		t.Fatalf("plugin not stopped")
+	}
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -1,0 +1,93 @@
+// file: pkg/plugins/registry.go
+// version: 1.0.0
+// guid: 81f00222-ba03-4912-9606-6aaa3c836d32
+
+package plugins
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// HealthStatus represents basic plugin health information.
+type HealthStatus struct {
+	OK   bool
+	Info string
+}
+
+// Plugin defines the core behavior for all plugins.
+type Plugin interface {
+	Name() string
+	Version() string
+	Initialize(config map[string]interface{}) error
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	Health() HealthStatus
+}
+
+// ProviderPlugin exposes a provider implementation.
+type ProviderPlugin interface {
+	Plugin
+	GetProvider() interface{}
+}
+
+// Registry manages registered plugins and their metadata.
+type Registry struct {
+	mu       sync.RWMutex
+	plugins  map[string]Plugin
+	metadata map[string]Metadata
+}
+
+// NewRegistry creates a new plugin registry.
+func NewRegistry() *Registry {
+	return &Registry{plugins: make(map[string]Plugin), metadata: make(map[string]Metadata)}
+}
+
+// Register adds a plugin with metadata to the registry.
+func (r *Registry) Register(p Plugin, md Metadata) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.plugins[p.Name()]; exists {
+		return errors.New("plugin already registered")
+	}
+	r.plugins[p.Name()] = p
+	r.metadata[p.Name()] = md
+	return nil
+}
+
+// Get retrieves a plugin by name.
+func (r *Registry) Get(name string) (Plugin, Metadata, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.plugins[name]
+	if !ok {
+		return nil, Metadata{}, false
+	}
+	md := r.metadata[name]
+	return p, md, true
+}
+
+// List returns all registered plugins.
+func (r *Registry) List() []Plugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]Plugin, 0, len(r.plugins))
+	for _, p := range r.plugins {
+		result = append(result, p)
+	}
+	return result
+}
+
+// ListByType returns all plugins matching the specified type.
+func (r *Registry) ListByType(t Type) []Plugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var result []Plugin
+	for name, p := range r.plugins {
+		if md := r.metadata[name]; md.Type == t {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/pkg/plugins/registry_test.go
+++ b/pkg/plugins/registry_test.go
@@ -1,0 +1,49 @@
+// file: pkg/plugins/registry_test.go
+// version: 1.0.0
+// guid: f3354f27-f606-45a2-8867-ac15ea4cd076
+
+package plugins
+
+import (
+	"context"
+	"testing"
+)
+
+type testPlugin struct{ name string }
+
+func (t *testPlugin) Name() string                                   { return t.name }
+func (t *testPlugin) Version() string                                { return "v1" }
+func (t *testPlugin) Initialize(config map[string]interface{}) error { return nil }
+func (t *testPlugin) Start(ctx context.Context) error                { return nil }
+func (t *testPlugin) Stop(ctx context.Context) error                 { return nil }
+func (t *testPlugin) Health() HealthStatus                           { return HealthStatus{OK: true} }
+
+func TestRegistryRegisterGet(t *testing.T) {
+	r := NewRegistry()
+	p := &testPlugin{name: "test"}
+	md := Metadata{Name: "test", Version: "v1", Type: Provider}
+	if err := r.Register(p, md); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	got, gmd, ok := r.Get("test")
+	if !ok {
+		t.Fatalf("plugin not found")
+	}
+	if got != p || gmd.Name != md.Name {
+		t.Fatalf("got %v %v, want %v %v", got, gmd, p, md)
+	}
+}
+
+func TestRegistryListByType(t *testing.T) {
+	r := NewRegistry()
+	p1 := &testPlugin{name: "p1"}
+	r.Register(p1, Metadata{Name: "p1", Version: "v1", Type: Provider})
+	p2 := &testPlugin{name: "p2"}
+	r.Register(p2, Metadata{Name: "p2", Version: "v1", Type: Middleware})
+
+	providers := r.ListByType(Provider)
+	if len(providers) != 1 || providers[0].Name() != "p1" {
+		t.Fatalf("unexpected providers %v", providers)
+	}
+}

--- a/pkg/plugins/sdk/base.go
+++ b/pkg/plugins/sdk/base.go
@@ -1,0 +1,85 @@
+// file: pkg/plugins/sdk/base.go
+// version: 1.0.0
+// guid: 5bb1cce2-b9fa-4e75-8a38-2a1a2e4f5952
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+)
+
+// BasePlugin provides default implementations for common plugin behavior.
+type BasePlugin struct {
+	Metadata plugins.Metadata
+}
+
+// Name returns the plugin name.
+func (b *BasePlugin) Name() string { return b.Metadata.Name }
+
+// Version returns the plugin version.
+func (b *BasePlugin) Version() string { return b.Metadata.Version }
+
+// Initialize sets up plugin configuration. Override for custom behavior.
+func (b *BasePlugin) Initialize(config map[string]interface{}) error { return nil }
+
+// Start activates the plugin. Override for custom behavior.
+func (b *BasePlugin) Start(ctx context.Context) error { return nil }
+
+// Stop deactivates the plugin. Override for custom behavior.
+func (b *BasePlugin) Stop(ctx context.Context) error { return nil }
+
+// Health reports plugin health. Override for custom behavior.
+func (b *BasePlugin) Health() plugins.HealthStatus {
+	return plugins.HealthStatus{OK: true, Info: "healthy"}
+}
+
+// GenerateDocumentation creates a simple documentation string for a plugin.
+func GenerateDocumentation(md plugins.Metadata) string {
+	perms := "none"
+	if len(md.Permissions) > 0 {
+		perms = fmt.Sprint(md.Permissions)
+	}
+	return fmt.Sprintf("%s (v%s) - %s\nPermissions: %s\n", md.Name, md.Version, md.Description, perms)
+}
+
+// ProviderTemplate returns a Go code template for a provider plugin.
+func ProviderTemplate(name string) string {
+	return fmt.Sprintf(`package %s
+
+import (
+        "context"
+
+        "github.com/jdfalk/gcommon/pkg/plugins"
+        sdk "github.com/jdfalk/gcommon/pkg/plugins/sdk"
+)
+
+// %s implements a simple provider plugin.
+type %s struct {
+        sdk.BasePlugin
+}
+
+// New creates a new %s.
+func New() *%s {
+        md := plugins.Metadata{
+                Name:        "%s",
+                Version:     "0.1.0",
+                Type:        plugins.Provider,
+                Description: "%s provider",
+        }
+        return &%s{BasePlugin: sdk.BasePlugin{Metadata: md}}
+}
+
+// GetProvider returns the provider implementation.
+func (p *%s) GetProvider() interface{} {
+        return func() string { return "%s" }
+}
+
+var Descriptor = plugins.Descriptor{
+        Metadata: New().Metadata,
+        New: func() plugins.Plugin { return New() },
+}
+`, name, name, name, name, name, name, name, name, name, name)
+}

--- a/pkg/plugins/sdk/base_test.go
+++ b/pkg/plugins/sdk/base_test.go
@@ -1,0 +1,19 @@
+// file: pkg/plugins/sdk/base_test.go
+// version: 1.0.0
+// guid: 1f38a3c8-5bd6-4e56-b1a2-f3c1c46c7fd4
+
+package sdk
+
+import (
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+)
+
+func TestGenerateDocumentation(t *testing.T) {
+	md := plugins.Metadata{Name: "doc", Version: "1.0", Description: "test", Permissions: []plugins.Permission{plugins.PermissionRead}}
+	doc := GenerateDocumentation(md)
+	if len(doc) == 0 {
+		t.Fatalf("no documentation generated")
+	}
+}

--- a/pkg/plugins/sdk/docgen.go
+++ b/pkg/plugins/sdk/docgen.go
@@ -1,0 +1,17 @@
+// file: pkg/plugins/sdk/docgen.go
+// version: 1.0.0
+// guid: 07c06a88-6c73-4d5e-9fcf-c406f88bb758
+
+package sdk
+
+import (
+	"io"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+)
+
+// GenerateMarkdown writes plugin documentation in Markdown format.
+func GenerateMarkdown(w io.Writer, md plugins.Metadata) error {
+	_, err := io.WriteString(w, GenerateDocumentation(md))
+	return err
+}

--- a/pkg/plugins/sdk/testutil.go
+++ b/pkg/plugins/sdk/testutil.go
@@ -1,0 +1,28 @@
+// file: pkg/plugins/sdk/testutil.go
+// version: 1.0.0
+// guid: e1a1af2d-92bb-4ea1-8f74-52f7593bd84b
+
+package sdk
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/plugins"
+)
+
+// NewTestManager returns a manager suitable for unit tests.
+func NewTestManager() *plugins.Manager {
+	r := plugins.NewRegistry()
+	bus := plugins.NewInMemoryBus()
+	checker := plugins.DefaultChecker{}
+	return plugins.NewManager(r, bus, checker)
+}
+
+// StartPlugin starts a plugin using the test manager.
+func StartPlugin(ctx context.Context, m *plugins.Manager, p plugins.Plugin, md plugins.Metadata) error {
+	policy := plugins.Policy{Permissions: md.Permissions}
+	if err := m.Register(p, md, policy); err != nil {
+		return err
+	}
+	return p.Start(ctx)
+}

--- a/pkg/plugins/security.go
+++ b/pkg/plugins/security.go
@@ -1,0 +1,95 @@
+// file: pkg/plugins/security.go
+// version: 1.0.0
+// guid: 04b518ba-5c55-43fe-9080-78e03d1ddcd4
+
+package plugins
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// Permission represents a security permission granted to a plugin.
+type Permission string
+
+const (
+	// PermissionRead allows read-only operations.
+	PermissionRead Permission = "read"
+	// PermissionWrite allows write operations.
+	PermissionWrite Permission = "write"
+	// PermissionNetwork allows outbound network access.
+	PermissionNetwork Permission = "network"
+)
+
+// Policy defines security constraints for a plugin.
+type Policy struct {
+	Permissions []Permission
+	MaxCPU      int // percentage
+	MaxMemory   int // megabytes
+	Timeout     time.Duration
+}
+
+// Checker validates plugin security requirements.
+type Checker interface {
+	Validate(p Plugin, policy Policy) error
+}
+
+// DefaultChecker implements basic security checks.
+type DefaultChecker struct{}
+
+// Validate ensures the plugin meets the provided policy constraints.
+func (DefaultChecker) Validate(p Plugin, policy Policy) error {
+	md, ok := GetMetadata(p)
+	if !ok {
+		return errors.New("plugin metadata not found")
+	}
+	if err := validatePermissions(md.Permissions, policy.Permissions); err != nil {
+		return fmt.Errorf("permissions: %w", err)
+	}
+	if policy.MaxMemory > 0 {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		used := int(m.Alloc / 1024 / 1024)
+		if used > policy.MaxMemory {
+			return fmt.Errorf("memory limit exceeded: %dMB > %dMB", used, policy.MaxMemory)
+		}
+	}
+	return nil
+}
+
+func validatePermissions(required, allowed []Permission) error {
+	allowedSet := make(map[Permission]struct{}, len(allowed))
+	for _, perm := range allowed {
+		allowedSet[perm] = struct{}{}
+	}
+	for _, need := range required {
+		if _, ok := allowedSet[need]; !ok {
+			return fmt.Errorf("permission %s not granted", need)
+		}
+	}
+	return nil
+}
+
+// metadataKey provides access to plugin metadata when wrapped.
+type metadataKey struct{}
+
+// WithMetadata attaches metadata to a plugin instance.
+func WithMetadata(p Plugin, md Metadata) Plugin {
+	return &metadataWrapper{Plugin: p, metadata: md}
+}
+
+// metadataWrapper exposes metadata for security checks.
+type metadataWrapper struct {
+	Plugin
+	metadata Metadata
+}
+
+// GetMetadata extracts plugin metadata if available.
+func GetMetadata(p Plugin) (Metadata, bool) {
+	if w, ok := p.(*metadataWrapper); ok {
+		return w.metadata, true
+	}
+	return Metadata{}, false
+}

--- a/pkg/plugins/security_test.go
+++ b/pkg/plugins/security_test.go
@@ -1,0 +1,41 @@
+// file: pkg/plugins/security_test.go
+// version: 1.0.0
+// guid: 2c4f8448-5a94-49f1-aea5-c372ac4a3eab
+
+package plugins
+
+import (
+	"context"
+	"testing"
+)
+
+type permPlugin struct{ Base string }
+
+func (p *permPlugin) Name() string                            { return "perm" }
+func (p *permPlugin) Version() string                         { return "v1" }
+func (p *permPlugin) Initialize(map[string]interface{}) error { return nil }
+func (p *permPlugin) Start(context.Context) error             { return nil }
+func (p *permPlugin) Stop(context.Context) error              { return nil }
+func (p *permPlugin) Health() HealthStatus                    { return HealthStatus{OK: true} }
+
+func TestDefaultCheckerValidate(t *testing.T) {
+	p := &permPlugin{}
+	md := Metadata{Name: "perm", Permissions: []Permission{PermissionRead}}
+	wp := WithMetadata(p, md)
+	checker := DefaultChecker{}
+	policy := Policy{Permissions: []Permission{PermissionRead, PermissionWrite}}
+	if err := checker.Validate(wp, policy); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestDefaultCheckerMissingPermission(t *testing.T) {
+	p := &permPlugin{}
+	md := Metadata{Name: "perm", Permissions: []Permission{PermissionWrite}}
+	wp := WithMetadata(p, md)
+	checker := DefaultChecker{}
+	policy := Policy{Permissions: []Permission{PermissionRead}}
+	if err := checker.Validate(wp, policy); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -1,0 +1,73 @@
+// file: pkg/plugins/types.go
+// version: 1.0.0
+// guid: 0c0c287a-7807-4f23-8f35-46a1b465a64f
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+)
+
+// Type identifies the category of a plugin.
+type Type int
+
+const (
+	// Provider implements a concrete service provider.
+	Provider Type = iota
+	// Middleware processes requests or responses.
+	Middleware
+	// Extension adds extra functionality to the host application.
+	Extension
+	// Integration connects third-party services.
+	Integration
+)
+
+// String returns the string representation of the plugin type.
+func (t Type) String() string {
+	switch t {
+	case Provider:
+		return "provider"
+	case Middleware:
+		return "middleware"
+	case Extension:
+		return "extension"
+	case Integration:
+		return "integration"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(t))
+	}
+}
+
+// Metadata describes a plugin's basic information and requirements.
+type Metadata struct {
+	Name        string
+	Version     string
+	Type        Type
+	Description string
+	Permissions []Permission
+}
+
+// Descriptor exposes metadata and a factory for plugin instances.
+type Descriptor struct {
+	Metadata Metadata
+	New      func() Plugin
+}
+
+// MiddlewarePlugin defines middleware behavior for request/response processing.
+type MiddlewarePlugin interface {
+	Plugin
+	Handle(ctx context.Context, msg interface{}) (interface{}, error)
+}
+
+// ExtensionPlugin defines extensions that modify the host system.
+type ExtensionPlugin interface {
+	Plugin
+	Extend(m *Manager) error
+}
+
+// IntegrationPlugin defines plugins that integrate external systems.
+type IntegrationPlugin interface {
+	Plugin
+	Connect(ctx context.Context) error
+}


### PR DESCRIPTION
## Summary
- implement plugin framework with plugin types, registry, manager, loader, communication bus, and security policies
- add plugin development kit and multiple example plugins
- document plugin architecture and track work with issue update

## Testing
- `go test ./pkg/plugins/... -run .`
- `python doc_update_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6898095fe2b883218e7efa21472754fd