### PR TITLE
feat(deploy): add Docker, Kubernetes, and Helm deployment stack

### DIFF
--- a/.github/doc-updates/2869658b-3a2c-4c63-8b0b-3233e450081f.json
+++ b/.github/doc-updates/2869658b-3a2c-4c63-8b0b-3233e450081f.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Deployment\n\n- **Docker**: Multi-stage build example in [deploy/docker](deploy/docker)\n- **Kubernetes**: Example manifest in [deploy/kubernetes](deploy/kubernetes)",
+  "guid": "2869658b-3a2c-4c63-8b0b-3233e450081f",
+  "created_at": "2025-08-10T02:55:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/3a2c56fa-cf61-4faa-9416-c01601867922.json
+++ b/.github/doc-updates/3a2c56fa-cf61-4faa-9416-c01601867922.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "### Advanced Deployment\\n\\n- **Helm Charts**: Configurable Helm chart in [deploy/helm](deploy/helm)\\n- **Automation**: GitOps and CI/CD templates in [deploy/automation](deploy/automation)\\n- **Monitoring**: Prometheus, logging, and tracing configs in [deploy/kubernetes/monitoring](deploy/kubernetes/monitoring)",
+  "guid": "3a2c56fa-cf61-4faa-9416-c01601867922",
+  "created_at": "2025-08-10T12:35:24Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5f3361f9-4956-47a4-9e38-a5e5d2b84ca5.json
+++ b/.github/doc-updates/5f3361f9-4956-47a4-9e38-a5e5d2b84ca5.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement automated rollbacks and canary analysis tooling",
+  "guid": "5f3361f9-4956-47a4-9e38-a5e5d2b84ca5",
+  "created_at": "2025-08-10T12:35:32Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7739ed06-0a32-4c75-b2b6-b0aa129f753b.json
+++ b/.github/doc-updates/7739ed06-0a32-4c75-b2b6-b0aa129f753b.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add comprehensive deployment stack with Docker, Kubernetes, Helm, automation, and monitoring",
+  "guid": "7739ed06-0a32-4c75-b2b6-b0aa129f753b",
+  "created_at": "2025-08-10T12:35:29Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9ed93c3a-e8e7-453b-b3fa-51b927926b09.json
+++ b/.github/doc-updates/9ed93c3a-e8e7-453b-b3fa-51b927926b09.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Implement Helm charts and deployment automation",
+  "guid": "9ed93c3a-e8e7-453b-b3fa-51b927926b09",
+  "created_at": "2025-08-10T02:55:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b29dcbc3-5bbe-4a55-b1f7-7287b3465c8e.json
+++ b/.github/doc-updates/b29dcbc3-5bbe-4a55-b1f7-7287b3465c8e.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add Dockerfile and Kubernetes deployment templates",
+  "guid": "b29dcbc3-5bbe-4a55-b1f7-7287b3465c8e",
+  "created_at": "2025-08-10T02:55:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/4f89924f-b503-4efe-b489-8492f0ac62be.json
+++ b/.github/issue-updates/4f89924f-b503-4efe-b489-8492f0ac62be.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Implement comprehensive deployment stack",
+  "body": "Provide full containerization, Helm charts, automation, and monitoring for gcommon apps.",
+  "labels": ["module:deployment", "type:enhancement"],
+  "guid": "4f89924f-b503-4efe-b489-8492f0ac62be",
+  "legacy_guid": "create-implement-comprehensive-deployment-stack-2025-08-10",
+  "created_at": "2025-08-10T12:35:11.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/ee5ddf44-c3b5-41b7-bb6a-eefdac3d63b5.json
+++ b/.github/issue-updates/ee5ddf44-c3b5-41b7-bb6a-eefdac3d63b5.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Add containerization templates",
+  "body": "Add Dockerfile and Kubernetes deployment manifests for gcommon apps.",
+  "labels": ["module:deployment", "type:enhancement"],
+  "guid": "ee5ddf44-c3b5-41b7-bb6a-eefdac3d63b5",
+  "legacy_guid": "create-add-containerization-templates-2025-08-10",
+  "created_at": "2025-08-10T02:55:25.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+# file: .github/workflows/deploy.yml
+# version: 1.0.0
+# guid: 4416f373-2a10-4053-bf39-ef7e8efe9742
+
+name: Deploy GCommon App
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'deploy/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build Docker image
+        run: |
+          docker build -f deploy/docker/Dockerfile -t ghcr.io/jdfalk/gcommon-app:latest .
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        run: docker push ghcr.io/jdfalk/gcommon-app:latest
+
+  deploy:
+    name: Deploy to Kubernetes
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
+
+      - name: Configure kubeconfig
+        run: echo "$KUBECONFIG_DATA" | base64 -d > $HOME/.kube/config
+        env:
+          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_DATA }}
+
+      - name: Deploy via Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm upgrade
+        run: |
+          helm upgrade --install gcommon-app deploy/helm/gcommon-app \
+            --namespace gcommon --create-namespace

--- a/deploy/automation/argocd-app.yaml
+++ b/deploy/automation/argocd-app.yaml
@@ -1,0 +1,28 @@
+# file: deploy/automation/argocd-app.yaml
+# version: 1.0.0
+# guid: 9dcc7e6d-aa01-4543-80c9-0ea53520d69d
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gcommon-app
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/jdfalk/gcommon
+    path: deploy/helm/gcommon-app
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gcommon
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/automation/blue-green.yaml
+++ b/deploy/automation/blue-green.yaml
@@ -1,0 +1,55 @@
+# file: deploy/automation/blue-green.yaml
+# version: 1.0.0
+# guid: 6220b6a1-b157-45cd-bad3-4caf0c9e196e
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcommon-app-blue
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: gcommon-app
+      color: blue
+  template:
+    metadata:
+      labels:
+        app: gcommon-app
+        color: blue
+    spec:
+      containers:
+        - name: app
+          image: gcommon/app:blue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcommon-app-green
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: gcommon-app
+      color: green
+  template:
+    metadata:
+      labels:
+        app: gcommon-app
+        color: green
+    spec:
+      containers:
+        - name: app
+          image: gcommon/app:green
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcommon-app
+spec:
+  selector:
+    app: gcommon-app
+    color: blue
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/deploy/automation/canary.yaml
+++ b/deploy/automation/canary.yaml
@@ -1,0 +1,27 @@
+# file: deploy/automation/canary.yaml
+# version: 1.0.0
+# guid: a446d96e-6519-469c-9a6c-1a8e780f07aa
+
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: gcommon-app
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gcommon-app
+  service:
+    port: 80
+  analysis:
+    interval: 1m
+    threshold: 5
+    maxWeight: 50
+    stepWeight: 5
+    metrics:
+      - name: request-success-rate
+        threshold: 99
+        interval: 1m
+      - name: request-duration
+        threshold: 500
+        interval: 1m

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,70 @@
+# file: deploy/docker/Dockerfile
+# version: 1.1.0
+# guid: 33c96dd2-4630-4780-859d-f6ba16ec9719
+
+# ------------------------------------------------------------
+# Multi-stage Dockerfile for gcommon-based applications
+# Provides build, development, and production stages with
+# security hardening and optional debugging tools.
+# ------------------------------------------------------------
+
+# ---------- Base Build Stage ----------
+FROM golang:1.22-alpine AS builder
+
+# Enable modules and configure work directory
+ENV CGO_ENABLED=0 \
+    GO111MODULE=on \
+    GOPROXY=https://proxy.golang.org,direct
+
+WORKDIR /app
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source
+COPY . .
+
+# Build main application; override CMD_PATH for specific binaries
+ARG CMD_PATH=./cmd/examples
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /gcommon-app ${CMD_PATH}
+
+# ---------- Development Stage ----------
+FROM golang:1.22-alpine AS development
+
+WORKDIR /workspace
+
+# Install debugging tools
+RUN apk add --no-cache bash curl git && \
+    adduser -D devuser
+USER devuser
+
+COPY --from=builder /app /workspace
+
+CMD ["go", "test", "./..."]
+
+# ---------- Production Stage ----------
+FROM alpine:3.19 AS runtime
+
+LABEL maintainer="gcommon maintainers"
+
+# Install CA certificates and minimal utilities
+RUN apk add --no-cache ca-certificates tzdata && \
+    adduser -D -u 10001 appuser
+
+WORKDIR /home/appuser
+
+# Copy built binary
+COPY --from=builder /gcommon-app /usr/local/bin/app
+
+# Drop privileges
+USER appuser
+
+# Expose port and define health check command placeholder
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+  CMD wget -qO- http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/deploy/docker/Dockerfile.dev
+++ b/deploy/docker/Dockerfile.dev
@@ -1,0 +1,23 @@
+# file: deploy/docker/Dockerfile.dev
+# version: 1.0.0
+# guid: fc1aaf72-5cb9-459c-9c50-acafd9634b17
+
+# Development image with hot-reload and debugger support
+FROM golang:1.22-alpine
+
+WORKDIR /app
+
+# Install development tools
+RUN apk add --no-cache bash git curl delve && \
+    go install github.com/cosmtrek/air@latest
+
+# Copy go modules and download dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source for live development
+COPY . .
+
+# Default command runs Air for hot reload
+CMD ["air", "-c", ".air.toml"]

--- a/deploy/docker/Dockerfile.prod
+++ b/deploy/docker/Dockerfile.prod
@@ -1,0 +1,17 @@
+# file: deploy/docker/Dockerfile.prod
+# version: 1.0.0
+# guid: db00b1d3-7c18-4b5b-a58a-ee15bb7a3bff
+
+# Minimal production image based on distroless
+FROM golang:1.22 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app ./cmd/examples
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /app /app
+USER nonroot
+EXPOSE 8080
+ENTRYPOINT ["/app"]

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -1,0 +1,75 @@
+# file: deploy/docker/docker-compose.yaml
+# version: 1.0.0
+# guid: 7f83576f-4c6b-41fa-ba0c-e853a07c9674
+
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: gcommon/app:dev
+    ports:
+      - "8080:8080"
+    environment:
+      - APP_ENV=development
+    depends_on:
+      - db
+      - cache
+    volumes:
+      - ../:/workspace
+
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=gcommon
+      - POSTGRES_PASSWORD=gcommon
+      - POSTGRES_DB=gcommon
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  cache:
+    image: redis:7-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - cache-data:/data
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.58
+    ports:
+      - "16686:16686"
+      - "14250:14250"
+
+  fluent-bit:
+    image: fluent/fluent-bit:3.0
+    volumes:
+      - ./monitoring/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+    depends_on:
+      - app
+
+volumes:
+  db-data:
+  cache-data:
+  grafana-data:

--- a/deploy/docker/monitoring/fluent-bit.conf
+++ b/deploy/docker/monitoring/fluent-bit.conf
@@ -1,0 +1,18 @@
+# file: deploy/docker/monitoring/fluent-bit.conf
+# version: 1.0.0
+# guid: 2984389f-e573-4e28-b37a-a4f8ab956c96
+
+[SERVICE]
+    Flush        1
+    Daemon       Off
+    Log_Level    info
+
+[INPUT]
+    Name         tail
+    Path         /workspace/logs/*.log
+    Parser       docker
+    Tag          app.*
+
+[OUTPUT]
+    Name         stdout
+    Match        *

--- a/deploy/docker/monitoring/prometheus.yml
+++ b/deploy/docker/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+# file: deploy/docker/monitoring/prometheus.yml
+# version: 1.0.0
+# guid: 2d7324e3-e84e-4892-96f6-b4d2b67c509d
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'gcommon-app'
+    static_configs:
+      - targets: ['app:8080']
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']

--- a/deploy/helm/gcommon-app/Chart.yaml
+++ b/deploy/helm/gcommon-app/Chart.yaml
@@ -1,0 +1,9 @@
+# file: deploy/helm/gcommon-app/Chart.yaml
+# version: 1.0.0
+# guid: bf3632fb-c949-407e-bd0d-cddb505132ad
+
+apiVersion: v2
+name: gcommon-app
+description: Helm chart for deploying gcommon-based applications
+version: 0.1.0
+appVersion: "1.0"

--- a/deploy/helm/gcommon-app/templates/configmap.yaml
+++ b/deploy/helm/gcommon-app/templates/configmap.yaml
@@ -1,0 +1,14 @@
+# file: deploy/helm/gcommon-app/templates/configmap.yaml
+# version: 1.0.0
+# guid: bcb3191e-a6c8-4069-be7b-21c7b325898a
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}-config
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: "{{ $value }}"
+  {{- end }}

--- a/deploy/helm/gcommon-app/templates/deployment.yaml
+++ b/deploy/helm/gcommon-app/templates/deployment.yaml
@@ -1,0 +1,50 @@
+# file: deploy/helm/gcommon-app/templates/deployment.yaml
+# version: 1.0.0
+# guid: ffb9fd11-e836-456d-b75f-1a555d47d422
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.autoscaling.minReplicas }}
+  selector:
+    matchLabels:
+      {{- include "gcommon-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gcommon-app.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "gcommon-app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            {{- range $key, $value := .Values.config }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gcommon-app.fullname" . }}-secret
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/deploy/helm/gcommon-app/templates/hpa.yaml
+++ b/deploy/helm/gcommon-app/templates/hpa.yaml
@@ -1,0 +1,21 @@
+# file: deploy/helm/gcommon-app/templates/hpa.yaml
+# version: 1.0.0
+# guid: 20dbbac2-96d6-419e-a14f-eeb578b03c03
+
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gcommon-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.hpaMetrics | nindent 4 }}
+{{- end }}

--- a/deploy/helm/gcommon-app/templates/ingress.yaml
+++ b/deploy/helm/gcommon-app/templates/ingress.yaml
@@ -1,0 +1,33 @@
+# file: deploy/helm/gcommon-app/templates/ingress.yaml
+# version: 1.0.0
+# guid: 7a15aa83-cbff-493f-83b7-dd81fd3808f9
+
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "gcommon-app.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}

--- a/deploy/helm/gcommon-app/templates/monitoring.yaml
+++ b/deploy/helm/gcommon-app/templates/monitoring.yaml
@@ -1,0 +1,19 @@
+# file: deploy/helm/gcommon-app/templates/monitoring.yaml
+# version: 1.0.0
+# guid: 9e237279-8b48-4100-bc5e-30a0d8439df7
+
+{{- if .Values.monitoring.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "gcommon-app.selectorLabels" . | nindent 8 }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.monitoring.prometheus.scrapeInterval }}
+{{- end }}

--- a/deploy/helm/gcommon-app/templates/secret.yaml
+++ b/deploy/helm/gcommon-app/templates/secret.yaml
@@ -1,0 +1,15 @@
+# file: deploy/helm/gcommon-app/templates/secret.yaml
+# version: 1.0.0
+# guid: 53e23f07-9ba6-467d-94a3-8808c9f7907a
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}-secret
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secret.data }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}

--- a/deploy/helm/gcommon-app/templates/service.yaml
+++ b/deploy/helm/gcommon-app/templates/service.yaml
@@ -1,0 +1,21 @@
+# file: deploy/helm/gcommon-app/templates/service.yaml
+# version: 1.0.0
+# guid: eecf5791-309d-4734-87d5-6955da057831
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gcommon-app.fullname" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gcommon-app.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/gcommon-app/templates/serviceaccount.yaml
+++ b/deploy/helm/gcommon-app/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# file: deploy/helm/gcommon-app/templates/serviceaccount.yaml
+# version: 1.0.0
+# guid: f65ed845-62f3-4282-a8c8-21ddab546e70
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gcommon-app.serviceAccountName" . }}
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/deploy/helm/gcommon-app/templates/tests/test-connection.yaml
+++ b/deploy/helm/gcommon-app/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+# file: deploy/helm/gcommon-app/templates/tests/test-connection.yaml
+# version: 1.0.0
+# guid: 2612d62a-2dbf-4643-b35d-3fa9a4ddcd41
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include \"gcommon-app.fullname\" . }}-test"
+  labels:
+    {{- include "gcommon-app.labels" . | nindent 4 }}
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "gcommon-app.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/helm/gcommon-app/values.yaml
+++ b/deploy/helm/gcommon-app/values.yaml
@@ -1,0 +1,156 @@
+# file: deploy/helm/gcommon-app/values.yaml
+# version: 1.0.0
+# guid: 9b745489-a895-4886-a4aa-771f457615bb
+
+# Default values for gcommon-app.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: gcommon/app
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+  targetMemoryUtilizationPercentage: 80
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  hosts:
+    - host: gcommon.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+config:
+  APP_ENV: production
+  LOG_LEVEL: info
+
+secret:
+  create: true
+  data:
+    DATABASE_URL: ""
+
+monitoring:
+  prometheus:
+    enabled: true
+    scrapeInterval: 15s
+  logging:
+    fluentBit:
+      enabled: true
+  tracing:
+    jaeger:
+      enabled: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Additional environment variables
+extraEnv: []
+
+# Extra volumes and mounts
+extraVolumes: []
+extraVolumeMounts: []
+
+# Liveness and readiness probe settings
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# Sidecars
+sidecars: []
+
+# Metrics service for Prometheus
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+
+# HPA Metrics
+hpaMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 75
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+
+# Deployment strategy
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+# Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# Extra labels
+labels: {}
+
+# Volume claim template for stateful workloads
+persistence:
+  enabled: false
+  size: 1Gi
+  storageClass: ""

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,14 @@
+# file: deploy/kubernetes/configmap.yaml
+# version: 1.0.0
+# guid: a1f6a8ea-d933-4942-96fd-0eee848cf67a
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcommon-config
+  labels:
+    app: gcommon-app
+
+data:
+  APP_ENV: "production"
+  LOG_LEVEL: "info"

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,69 @@
+# file: deploy/kubernetes/deployment.yaml
+# version: 1.1.0
+# guid: 926a31d3-7442-4af8-ac1e-9ce8be445493
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+spec:
+  replicas: 3
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: gcommon-app
+  template:
+    metadata:
+      labels:
+        app: gcommon-app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      serviceAccountName: gcommon-app
+      containers:
+        - name: app
+          image: gcommon/app:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: gcommon-config
+                  key: APP_ENV
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: gcommon-secrets
+                  key: DATABASE_URL
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: config
+              mountPath: /etc/gcommon
+      volumes:
+        - name: config
+          configMap:
+            name: gcommon-config

--- a/deploy/kubernetes/hpa.yaml
+++ b/deploy/kubernetes/hpa.yaml
@@ -1,0 +1,24 @@
+# file: deploy/kubernetes/hpa.yaml
+# version: 1.0.0
+# guid: 93a48dd0-5bd8-4f43-a1d6-fe46df829700
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gcommon-app
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -1,0 +1,25 @@
+# file: deploy/kubernetes/ingress.yaml
+# version: 1.0.0
+# guid: 25eb45cf-59cb-4fb0-bbb3-a514dd2a57f9
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gcommon-ingress
+  labels:
+    app: gcommon-app
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: gcommon.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gcommon-app
+                port:
+                  number: 80

--- a/deploy/kubernetes/monitoring/fluent-bit.yaml
+++ b/deploy/kubernetes/monitoring/fluent-bit.yaml
@@ -1,0 +1,57 @@
+# file: deploy/kubernetes/monitoring/fluent-bit.yaml
+# version: 1.0.0
+# guid: af1c544d-50a4-4535-b693-61964f08253d
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  labels:
+    app: gcommon-app
+  namespace: default
+
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush        1
+        Daemon       Off
+        Log_Level    info
+    [INPUT]
+        Name         tail
+        Path         /var/log/containers/*.log
+        Parser       docker
+    [OUTPUT]
+        Name         stdout
+        Match        *
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  labels:
+    app: gcommon-app
+spec:
+  selector:
+    matchLabels:
+      app: fluent-bit
+  template:
+    metadata:
+      labels:
+        app: fluent-bit
+    spec:
+      serviceAccountName: gcommon-app
+      containers:
+        - name: fluent-bit
+          image: fluent/fluent-bit:3.0
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: cfg
+              mountPath: /fluent-bit/etc
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: cfg
+          configMap:
+            name: fluent-bit-config

--- a/deploy/kubernetes/monitoring/jaeger.yaml
+++ b/deploy/kubernetes/monitoring/jaeger.yaml
@@ -1,0 +1,16 @@
+# file: deploy/kubernetes/monitoring/jaeger.yaml
+# version: 1.0.0
+# guid: af5bb18e-3ee9-4f87-a200-b8263297e776
+
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simple-prod
+spec:
+  strategy: allInOne
+  allInOne:
+    options:
+      query:
+        base-path: /
+  storage:
+    type: memory

--- a/deploy/kubernetes/monitoring/prometheus.yaml
+++ b/deploy/kubernetes/monitoring/prometheus.yaml
@@ -1,0 +1,17 @@
+# file: deploy/kubernetes/monitoring/prometheus.yaml
+# version: 1.0.0
+# guid: cd9944ca-5175-44bb-bcbd-2b6cbf8e2737
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+spec:
+  selector:
+    matchLabels:
+      app: gcommon-app
+  endpoints:
+    - port: http
+      interval: 15s

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -1,0 +1,28 @@
+# file: deploy/kubernetes/rbac.yaml
+# version: 1.0.0
+# guid: 50c28eed-d52f-41a8-ba45-962fb32b069e
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+subjects:
+  - kind: ServiceAccount
+    name: gcommon-app
+roleRef:
+  kind: Role
+  name: gcommon-app
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,0 +1,14 @@
+# file: deploy/kubernetes/secret.yaml
+# version: 1.0.0
+# guid: 3c1a2a9d-0ff8-436e-9c2b-4f3934c905ac
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcommon-secrets
+  labels:
+    app: gcommon-app
+
+type: Opaque
+data:
+  DATABASE_URL: ZGJuOi8vZ2NvbW1vbjpncGFzc0Bwb3N0Z3Jlczo1NDMyL2djb21tb24=

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,19 @@
+# file: deploy/kubernetes/service.yaml
+# version: 1.0.0
+# guid: 8bc1696b-a5c2-45b1-9fc1-9987bf2022d4
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app
+spec:
+  selector:
+    app: gcommon-app
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/deploy/kubernetes/serviceaccount.yaml
+++ b/deploy/kubernetes/serviceaccount.yaml
@@ -1,0 +1,10 @@
+# file: deploy/kubernetes/serviceaccount.yaml
+# version: 1.0.0
+# guid: 2fdd2aef-5841-4672-a70b-df8c2cdc3736
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcommon-app
+  labels:
+    app: gcommon-app


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles, docker-compose stack, and monitoring configs
- expand Kubernetes manifests with configmaps, secrets, ingress, RBAC, HPA, and monitoring
- introduce parameterized Helm chart and templates for gcommon apps
- provide deployment automation via GitHub Actions, Argo CD, blue-green, and canary examples
- record documentation updates and tracking issue

## Issues Addressed

### feat(deploy): implement comprehensive deployment stack

**Description:** establish standardized containerization, orchestration, and automation templates for gcommon applications.

**Files Modified:**
- `deploy/docker/Dockerfile` - multi-stage build with dev and prod stages
- `deploy/kubernetes/deployment.yaml` - production-ready deployment manifest
- `deploy/helm/gcommon-app/values.yaml` - default chart values and options
- `deploy/automation/argocd-app.yaml` - GitOps application definition
- `.github/workflows/deploy.yml` - CI/CD pipeline for build and deploy
- `deploy/kubernetes/monitoring/fluent-bit.yaml` - logging DaemonSet configuration

## Testing
- `go test ./...` *(fails: undefined types in db and metrics packages)*

## Breaking Changes
- none

## Additional Notes
- documentation updates stored in `.github/doc-updates/`
- issue tracking file created in `.github/issue-updates/`

------
https://chatgpt.com/codex/tasks/task_e_689809553038832186945a9c227e1b8e