### PR TITLE
feat: implement database migration system

### DIFF
--- a/.github/doc-updates/06719804-b2f6-49e6-89ba-d8c0b41736e4.json
+++ b/.github/doc-updates/06719804-b2f6-49e6-89ba-d8c0b41736e4.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "A powerful migration framework enables schema versioning, rollback, and multi-database support.",
+  "guid": "06719804-b2f6-49e6-89ba-d8c0b41736e4",
+  "created_at": "2025-08-10T12:41:06Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8cd5927a-5d8e-4867-b144-06e42dbd6380.json
+++ b/.github/doc-updates/8cd5927a-5d8e-4867-b144-06e42dbd6380.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] Add CLI utilities for managing database migrations",
+  "guid": "8cd5927a-5d8e-4867-b144-06e42dbd6380",
+  "created_at": "2025-08-10T12:41:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bbdd987c-8fcf-41cc-9b32-876909e7da31.json
+++ b/.github/doc-updates/bbdd987c-8fcf-41cc-9b32-876909e7da31.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n\\n- Implement comprehensive database migration system with versioning, rollback, and multi-database support",
+  "guid": "bbdd987c-8fcf-41cc-9b32-876909e7da31",
+  "created_at": "2025-08-10T12:41:02Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d3f688ad-0828-45ef-beaf-4345bba74c01.json
+++ b/.github/doc-updates/d3f688ad-0828-45ef-beaf-4345bba74c01.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Complete database migration system features",
+  "guid": "d3f688ad-0828-45ef-beaf-4345bba74c01",
+  "created_at": "2025-08-10T02:56:12Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f5208c38-223c-49e1-9f2f-d7472a246cc7.json
+++ b/.github/doc-updates/f5208c38-223c-49e1-9f2f-d7472a246cc7.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add skeleton database migration framework",
+  "guid": "f5208c38-223c-49e1-9f2f-d7472a246cc7",
+  "created_at": "2025-08-10T02:56:06Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/fe1fb534-2189-4aff-9d16-73d3aade63fc.json
+++ b/.github/doc-updates/fe1fb534-2189-4aff-9d16-73d3aade63fc.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "- Added initial database migration framework for schema management",
+  "guid": "fe1fb534-2189-4aff-9d16-73d3aade63fc",
+  "created_at": "2025-08-10T02:56:09Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/146d6bf3-c888-4708-8097-3c33632c173e.json
+++ b/.github/issue-updates/146d6bf3-c888-4708-8097-3c33632c173e.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Database: implement migration system",
+  "body": "Implement full migration system with versioning, rollback, multi-db support.",
+  "labels": ["module:db", "type:feature"],
+  "guid": "146d6bf3-c888-4708-8097-3c33632c173e",
+  "legacy_guid": "create-database-implement-migration-system-2025-08-10",
+  "created_at": "2025-08-10T12:34:40.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/865418e6-3577-44dc-bad1-820d447952d9.json
+++ b/.github/issue-updates/865418e6-3577-44dc-bad1-820d447952d9.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Database: add migration framework",
+  "body": "Introduce skeleton database migration system for managing schema changes.",
+  "labels": ["module:db", "type:feature"],
+  "guid": "865418e6-3577-44dc-bad1-820d447952d9",
+  "legacy_guid": "create-database-add-migration-framework-2025-08-10",
+  "created_at": "2025-08-10T02:56:03.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/db/migration/executor.go
+++ b/pkg/db/migration/executor.go
@@ -1,0 +1,14 @@
+// file: pkg/db/migration/executor.go
+// version: 1.0.0
+// guid: 2a4c11fb-61d6-4a5e-8c5f-b9425e75fd0b
+
+package migration
+
+import "context"
+
+// Executor runs and lists migrations.
+type Executor interface {
+	Execute(context.Context, Migration) error
+	Rollback(context.Context, Migration) error
+	List(context.Context) ([]Migration, error)
+}

--- a/pkg/db/migration/executor_cockroach.go
+++ b/pkg/db/migration/executor_cockroach.go
@@ -1,0 +1,37 @@
+// file: pkg/db/migration/executor_cockroach.go
+// version: 1.0.0
+// guid: d3e4f5a6-b7c8-49d0-1e2f-3a4b5c6d7e8f
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// CockroachExecutor runs migrations against CockroachDB.
+type CockroachExecutor struct {
+	SQLExecutor
+}
+
+// NewCockroachExecutor creates an executor for CockroachDB.
+func NewCockroachExecutor(db *sql.DB) CockroachExecutor {
+	return CockroachExecutor{SQLExecutor{DB: db}}
+}
+
+// Execute ensures the migration is for CockroachDB before running.
+func (e CockroachExecutor) Execute(ctx context.Context, m Migration) error {
+	if m.DB != Cockroach {
+		return fmt.Errorf("migration %s not for CockroachDB", m)
+	}
+	return e.SQLExecutor.Execute(ctx, m)
+}
+
+// Rollback ensures the migration is for CockroachDB before running.
+func (e CockroachExecutor) Rollback(ctx context.Context, m Migration) error {
+	if m.DB != Cockroach {
+		return fmt.Errorf("migration %s not for CockroachDB", m)
+	}
+	return e.SQLExecutor.Rollback(ctx, m)
+}

--- a/pkg/db/migration/executor_mysql.go
+++ b/pkg/db/migration/executor_mysql.go
@@ -1,0 +1,37 @@
+// file: pkg/db/migration/executor_mysql.go
+// version: 1.0.0
+// guid: e4f5a6b7-c8d9-40e1-f2a3-b4c5d6e7f8a9
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// MySQLExecutor runs migrations against MySQL databases.
+type MySQLExecutor struct {
+	SQLExecutor
+}
+
+// NewMySQLExecutor creates an executor for MySQL.
+func NewMySQLExecutor(db *sql.DB) MySQLExecutor {
+	return MySQLExecutor{SQLExecutor{DB: db}}
+}
+
+// Execute ensures the migration is for MySQL before running.
+func (e MySQLExecutor) Execute(ctx context.Context, m Migration) error {
+	if m.DB != MySQL {
+		return fmt.Errorf("migration %s not for MySQL", m)
+	}
+	return e.SQLExecutor.Execute(ctx, m)
+}
+
+// Rollback ensures the migration is for MySQL before running.
+func (e MySQLExecutor) Rollback(ctx context.Context, m Migration) error {
+	if m.DB != MySQL {
+		return fmt.Errorf("migration %s not for MySQL", m)
+	}
+	return e.SQLExecutor.Rollback(ctx, m)
+}

--- a/pkg/db/migration/executor_postgres.go
+++ b/pkg/db/migration/executor_postgres.go
@@ -1,0 +1,37 @@
+// file: pkg/db/migration/executor_postgres.go
+// version: 1.0.0
+// guid: b1c2d3e4-f5a6-47b8-90c1-d2e3f4a5b6c7
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// PostgresExecutor runs migrations against PostgreSQL.
+type PostgresExecutor struct {
+	SQLExecutor
+}
+
+// NewPostgresExecutor creates an executor for Postgres.
+func NewPostgresExecutor(db *sql.DB) PostgresExecutor {
+	return PostgresExecutor{SQLExecutor{DB: db}}
+}
+
+// Execute wraps SQLExecutor.Execute with Postgres specific checks.
+func (e PostgresExecutor) Execute(ctx context.Context, m Migration) error {
+	if m.DB != Postgres {
+		return fmt.Errorf("migration %s not for Postgres", m)
+	}
+	return e.SQLExecutor.Execute(ctx, m)
+}
+
+// Rollback wraps SQLExecutor.Rollback with Postgres specific checks.
+func (e PostgresExecutor) Rollback(ctx context.Context, m Migration) error {
+	if m.DB != Postgres {
+		return fmt.Errorf("migration %s not for Postgres", m)
+	}
+	return e.SQLExecutor.Rollback(ctx, m)
+}

--- a/pkg/db/migration/executor_sql.go
+++ b/pkg/db/migration/executor_sql.go
@@ -1,0 +1,58 @@
+// file: pkg/db/migration/executor_sql.go
+// version: 1.0.0
+// guid: a7b8c9d0-e1f2-4a3b-b4c5-d6e7f8a9b0c1
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// SQLExecutor executes SQL statements using a sql.DB connection.
+type SQLExecutor struct {
+	DB *sql.DB
+}
+
+// Execute runs the migration's Up statements in order.
+func (e SQLExecutor) Execute(ctx context.Context, m Migration) error {
+	tx, err := e.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	for i, stmt := range m.Up {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("exec up %d: %w", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// Rollback executes the Down statements in reverse order.
+func (e SQLExecutor) Rollback(ctx context.Context, m Migration) error {
+	tx, err := e.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	for i := len(m.Down) - 1; i >= 0; i-- {
+		if _, err := tx.ExecContext(ctx, m.Down[i]); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("exec down %d: %w", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// List is not supported for SQLExecutor directly; use Source instead.
+func (e SQLExecutor) List(ctx context.Context) ([]Migration, error) {
+	_ = ctx
+	return nil, fmt.Errorf("list unsupported; use migration source")
+}

--- a/pkg/db/migration/executor_sqlite.go
+++ b/pkg/db/migration/executor_sqlite.go
@@ -1,0 +1,37 @@
+// file: pkg/db/migration/executor_sqlite.go
+// version: 1.0.0
+// guid: c2d3e4f5-a6b7-48c9-0d1e-2f3a4b5c6d7e
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// SQLiteExecutor runs migrations against SQLite databases.
+type SQLiteExecutor struct {
+	SQLExecutor
+}
+
+// NewSQLiteExecutor creates an executor for SQLite.
+func NewSQLiteExecutor(db *sql.DB) SQLiteExecutor {
+	return SQLiteExecutor{SQLExecutor{DB: db}}
+}
+
+// Execute ensures the migration is for SQLite before running.
+func (e SQLiteExecutor) Execute(ctx context.Context, m Migration) error {
+	if m.DB != SQLite {
+		return fmt.Errorf("migration %s not for SQLite", m)
+	}
+	return e.SQLExecutor.Execute(ctx, m)
+}
+
+// Rollback ensures the migration is for SQLite before running.
+func (e SQLiteExecutor) Rollback(ctx context.Context, m Migration) error {
+	if m.DB != SQLite {
+		return fmt.Errorf("migration %s not for SQLite", m)
+	}
+	return e.SQLExecutor.Rollback(ctx, m)
+}

--- a/pkg/db/migration/manager.go
+++ b/pkg/db/migration/manager.go
@@ -1,0 +1,135 @@
+// file: pkg/db/migration/manager.go
+// version: 1.0.0
+// guid: 5cbe9eaa-9ad5-4e74-9e0d-5fd26e9dd98a
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Manager coordinates database migrations, validation, and version tracking.
+type Manager struct {
+	Exec      Executor
+	Validator Validator
+	Tracker   VersionTracker
+	Sources   []Source
+	Parallel  bool
+}
+
+// NewManager creates a new Manager.
+func NewManager(exec Executor, validator Validator, tracker VersionTracker) *Manager {
+	return &Manager{Exec: exec, Validator: validator, Tracker: tracker}
+}
+
+// AddSource registers a migration source.
+func (m *Manager) AddSource(src Source) {
+	m.Sources = append(m.Sources, src)
+}
+
+// Migrate loads migrations from all sources and applies any that have not yet been run.
+func (m *Manager) Migrate(ctx context.Context) error {
+	if err := m.ensureTracker(ctx); err != nil {
+		return err
+	}
+	migrations, err := m.loadMigrations(ctx)
+	if err != nil {
+		return err
+	}
+	current, err := m.Tracker.Current(ctx)
+	if err != nil {
+		return fmt.Errorf("current version: %w", err)
+	}
+	var pending []Migration
+	for _, mg := range migrations {
+		if mg.Version > current {
+			pending = append(pending, mg)
+		}
+	}
+	SortMigrations(pending)
+	if m.Parallel {
+		return m.migrateParallel(ctx, pending)
+	}
+	for _, mg := range pending {
+		if err := m.applyOne(ctx, mg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Rollback reverses the last n migrations (n defaults to 1 if <=0).
+func (m *Manager) Rollback(ctx context.Context, n int) error {
+	if n <= 0 {
+		n = 1
+	}
+	rb := SimpleRollback{Exec: m.Exec, Tracker: m.Tracker}
+	for i := 0; i < n; i++ {
+		if err := rb.Rollback(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// loadMigrations aggregates migrations from all sources.
+func (m *Manager) loadMigrations(ctx context.Context) ([]Migration, error) {
+	var all []Migration
+	for _, src := range m.Sources {
+		migs, err := src.Load(ctx)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, migs...)
+	}
+	SortMigrations(all)
+	return all, nil
+}
+
+// ensureTracker ensures version tracking table exists when supported.
+func (m *Manager) ensureTracker(ctx context.Context) error {
+	if t, ok := m.Tracker.(interface{ EnsureTable(context.Context) error }); ok {
+		return t.EnsureTable(ctx)
+	}
+	return nil
+}
+
+// applyOne validates and executes a single migration.
+func (m *Manager) applyOne(ctx context.Context, mg Migration) error {
+	if err := m.Validator.Validate(mg); err != nil {
+		return fmt.Errorf("validate %s: %w", mg, err)
+	}
+	if err := m.Exec.Execute(ctx, mg); err != nil {
+		return fmt.Errorf("execute %s: %w", mg, err)
+	}
+	if err := m.Tracker.SetVersion(ctx, mg.Version, mg.Name); err != nil {
+		return fmt.Errorf("set version %s: %w", mg, err)
+	}
+	return nil
+}
+
+// migrateParallel runs pending migrations concurrently.
+func (m *Manager) migrateParallel(ctx context.Context, migs []Migration) error {
+	errCh := make(chan error, len(migs))
+	var wg sync.WaitGroup
+	for _, mg := range migs {
+		mg := mg
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := m.applyOne(ctx, mg); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/db/migration/manager_test.go
+++ b/pkg/db/migration/manager_test.go
@@ -1,0 +1,116 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// dummyExecutor records executed migrations.
+type dummyExecutor struct {
+	applied  []Migration
+	rolled   []Migration
+	failExec bool
+	failRoll bool
+}
+
+func (d *dummyExecutor) Execute(_ context.Context, m Migration) error {
+	if d.failExec {
+		return fmt.Errorf("exec fail")
+	}
+	d.applied = append(d.applied, m)
+	return nil
+}
+
+func (d *dummyExecutor) Rollback(_ context.Context, m Migration) error {
+	if d.failRoll {
+		return fmt.Errorf("rollback fail")
+	}
+	d.rolled = append(d.rolled, m)
+	return nil
+}
+
+func (d *dummyExecutor) List(_ context.Context) ([]Migration, error) { return d.applied, nil }
+
+// dummyTracker tracks versions in memory.
+type dummyTracker struct {
+	versions []Migration
+}
+
+func (t *dummyTracker) Current(context.Context) (int, error) {
+	if len(t.versions) == 0 {
+		return 0, nil
+	}
+	return t.versions[len(t.versions)-1].Version, nil
+}
+
+func (t *dummyTracker) SetVersion(_ context.Context, v int, name string) error {
+	t.versions = append(t.versions, Migration{Version: v, Name: name})
+	return nil
+}
+
+func (t *dummyTracker) Last(context.Context) (Migration, error) {
+	if len(t.versions) == 0 {
+		return Migration{}, nil
+	}
+	return t.versions[len(t.versions)-1], nil
+}
+
+func (t *dummyTracker) RemoveVersion(_ context.Context, v int) error {
+	for i, m := range t.versions {
+		if m.Version == v {
+			t.versions = append(t.versions[:i], t.versions[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// TestManager_MigrateApplyPending verifies migrations are executed and tracked.
+func TestManager_MigrateApplyPending(t *testing.T) {
+	dir := t.TempDir()
+	up1 := filepath.Join(dir, "001_init.up.sql")
+	down1 := filepath.Join(dir, "001_init.down.sql")
+	os.WriteFile(up1, []byte("CREATE TABLE t1();"), 0644)
+	os.WriteFile(down1, []byte("DROP TABLE t1;"), 0644)
+
+	up2 := filepath.Join(dir, "002_add.up.sql")
+	down2 := filepath.Join(dir, "002_add.down.sql")
+	os.WriteFile(up2, []byte("ALTER TABLE t1 ADD COLUMN c1 INT;"), 0644)
+	os.WriteFile(down2, []byte("ALTER TABLE t1 DROP COLUMN c1;"), 0644)
+
+	src := FileSource{Dir: dir, DB: Postgres}
+	exec := &dummyExecutor{}
+	tracker := &dummyTracker{}
+	mgr := NewManager(exec, BasicValidator{}, tracker)
+	mgr.AddSource(src)
+	if err := mgr.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(exec.applied) != 2 {
+		t.Fatalf("expected 2 applied, got %d", len(exec.applied))
+	}
+	if v, _ := tracker.Current(context.Background()); v != 2 {
+		t.Fatalf("expected version 2, got %d", v)
+	}
+}
+
+// TestManager_Rollback reverses last migration.
+func TestManager_Rollback(t *testing.T) {
+	exec := &dummyExecutor{}
+	tracker := &dummyTracker{versions: []Migration{{Version: 1, Name: "init"}}}
+	mgr := NewManager(exec, BasicValidator{}, tracker)
+	mgr.Exec = exec
+	mgr.Tracker = tracker
+	if err := mgr.Rollback(context.Background(), 1); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if len(exec.rolled) != 1 {
+		t.Fatalf("expected 1 rolled, got %d", len(exec.rolled))
+	}
+	if v, _ := tracker.Current(context.Background()); v != 0 {
+		t.Fatalf("expected version 0, got %d", v)
+	}
+}

--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -1,0 +1,146 @@
+// file: pkg/db/migration/migration.go
+// version: 1.0.0
+// guid: 8f0c2d7e-3c31-4db2-8e5e-73a7aefd1f1c
+
+package migration
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DBType represents a supported database engine.
+type DBType string
+
+const (
+	// Postgres represents PostgreSQL database.
+	Postgres DBType = "postgres"
+	// SQLite represents SQLite database.
+	SQLite DBType = "sqlite"
+	// Cockroach represents CockroachDB database.
+	Cockroach DBType = "cockroach"
+	// MySQL represents MySQL database.
+	MySQL DBType = "mysql"
+)
+
+// Migration defines a single database migration step.
+// Each migration consists of a set of SQL statements for moving forward (Up)
+// and backward (Down) through schema versions.
+type Migration struct {
+	Version int
+	Name    string
+	DB      DBType
+	Up      []string
+	Down    []string
+	Source  string
+}
+
+// SortMigrations orders migrations by version.
+func SortMigrations(migs []Migration) {
+	sort.Slice(migs, func(i, j int) bool {
+		return migs[i].Version < migs[j].Version
+	})
+}
+
+// ParseSQLFile reads a SQL file and splits statements by semicolon.
+// Empty lines and comments starting with "--" are ignored.
+func ParseSQLFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open sql file: %w", err)
+	}
+	defer f.Close()
+
+	return readSQLStatements(f)
+}
+
+// readSQLStatements reads SQL statements from r.
+func readSQLStatements(r io.Reader) ([]string, error) {
+	var stmts []string
+	var b strings.Builder
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "--") {
+			continue
+		}
+		b.WriteString(line)
+		if strings.HasSuffix(line, ";") {
+			stmts = append(stmts, strings.TrimSuffix(b.String(), ";"))
+			b.Reset()
+		} else {
+			b.WriteRune(' ')
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan sql: %w", err)
+	}
+	if b.Len() > 0 {
+		stmts = append(stmts, strings.TrimSpace(b.String()))
+	}
+	return stmts, nil
+}
+
+// LoadMigrationFromDir loads a migration given a base path and version/name.
+// It expects files in format `<version>_<name>.up.sql` and `<version>_<name>.down.sql`.
+func LoadMigrationFromDir(dir string, version int, name string, db DBType) (Migration, error) {
+	base := fmt.Sprintf("%03d_%s", version, name)
+	upPath := filepath.Join(dir, base+".up.sql")
+	downPath := filepath.Join(dir, base+".down.sql")
+
+	upStmts, err := ParseSQLFile(upPath)
+	if err != nil {
+		return Migration{}, err
+	}
+	downStmts, err := ParseSQLFile(downPath)
+	if err != nil {
+		return Migration{}, err
+	}
+	return Migration{
+		Version: version,
+		Name:    name,
+		DB:      db,
+		Up:      upStmts,
+		Down:    downStmts,
+		Source:  dir,
+	}, nil
+}
+
+// String returns a human-readable representation of the migration.
+func (m Migration) String() string {
+	return fmt.Sprintf("%d_%s", m.Version, m.Name)
+}
+
+// Validate ensures migration has required fields.
+func (m Migration) Validate() error {
+	if m.Version <= 0 {
+		return fmt.Errorf("version must be positive")
+	}
+	if m.Name == "" {
+		return fmt.Errorf("name required")
+	}
+	if len(m.Up) == 0 {
+		return fmt.Errorf("up statements required")
+	}
+	if len(m.Down) == 0 {
+		return fmt.Errorf("down statements required")
+	}
+	return nil
+}
+
+// Reverse returns a copy of the migration with Up and Down swapped.
+func (m Migration) Reverse() Migration {
+	return Migration{
+		Version: m.Version,
+		Name:    m.Name,
+		DB:      m.DB,
+		Up:      append([]string{}, m.Down...),
+		Down:    append([]string{}, m.Up...),
+		Source:  m.Source,
+	}
+}

--- a/pkg/db/migration/rollback.go
+++ b/pkg/db/migration/rollback.go
@@ -1,0 +1,34 @@
+// file: pkg/db/migration/rollback.go
+// version: 1.0.0
+// guid: a3b4c5d6-e7f8-40a9-b0c1-d2e3f4a5b6c7
+
+package migration
+
+import (
+	"context"
+	"fmt"
+)
+
+// SimpleRollback provides rollback utilities.
+type SimpleRollback struct {
+	Exec    Executor
+	Tracker VersionTracker
+}
+
+// Rollback reverses the most recent migration.
+func (r *SimpleRollback) Rollback(ctx context.Context) error {
+	last, err := r.Tracker.Last(ctx)
+	if err != nil {
+		return fmt.Errorf("get last: %w", err)
+	}
+	if last.Version == 0 {
+		return nil
+	}
+	if err := r.Exec.Rollback(ctx, last); err != nil {
+		return fmt.Errorf("rollback: %w", err)
+	}
+	if err := r.Tracker.RemoveVersion(ctx, last.Version); err != nil {
+		return fmt.Errorf("remove version: %w", err)
+	}
+	return nil
+}

--- a/pkg/db/migration/source.go
+++ b/pkg/db/migration/source.go
@@ -1,0 +1,12 @@
+// file: pkg/db/migration/source.go
+// version: 1.0.0
+// guid: b2f4f5a6-7e8d-4c9b-8c1d-0e0f1a2b3c4d
+
+package migration
+
+import "context"
+
+// Source provides migrations from a storage mechanism.
+type Source interface {
+	Load(context.Context) ([]Migration, error)
+}

--- a/pkg/db/migration/source_db.go
+++ b/pkg/db/migration/source_db.go
@@ -1,0 +1,50 @@
+// file: pkg/db/migration/source_db.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-4e1f-a2b3-c4567890def1
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// DatabaseSource loads migrations stored in a database table.
+// The table schema:
+//
+//	CREATE TABLE migrations (version INTEGER PRIMARY KEY, name TEXT, up TEXT, down TEXT);
+type DatabaseSource struct {
+	DB     *sql.DB
+	Table  string
+	DBType DBType
+}
+
+// Load retrieves migrations from the database.
+func (s DatabaseSource) Load(ctx context.Context) ([]Migration, error) {
+	query := fmt.Sprintf("SELECT version, name, up, down FROM %s ORDER BY version", s.Table)
+	rows, err := s.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query migrations: %w", err)
+	}
+	defer rows.Close()
+
+	var migrations []Migration
+	for rows.Next() {
+		var m Migration
+		var up, down string
+		if err := rows.Scan(&m.Version, &m.Name, &up, &down); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		m.DB = s.DBType
+		m.Up = strings.Split(up, "\n--statement--\n")
+		m.Down = strings.Split(down, "\n--statement--\n")
+		m.Source = s.Table
+		migrations = append(migrations, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return migrations, nil
+}

--- a/pkg/db/migration/source_embed.go
+++ b/pkg/db/migration/source_embed.go
@@ -1,0 +1,87 @@
+// file: pkg/db/migration/source_embed.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-4d0e-af01-b23456789cde
+
+package migration
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+// EmbedSource loads migrations from an embedded filesystem.
+type EmbedSource struct {
+	FS  embed.FS
+	Dir string
+	DB  DBType
+}
+
+// Load reads migrations from the embedded filesystem.
+func (s EmbedSource) Load(ctx context.Context) ([]Migration, error) {
+	_ = ctx
+	entries, err := fs.ReadDir(s.FS, s.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("readdir: %w", err)
+	}
+	type pair struct{ up, down string }
+	files := map[int]*pair{}
+	for _, e := range entries {
+		name := e.Name()
+		matches := filePattern.FindStringSubmatch(name)
+		if len(matches) != 4 {
+			continue
+		}
+		version := atoi(matches[1])
+		mig, ok := files[version]
+		if !ok {
+			mig = &pair{}
+			files[version] = mig
+		}
+		path := filepath.Join(s.Dir, name)
+		if matches[3] == "up" {
+			mig.up = path
+		} else {
+			mig.down = path
+		}
+	}
+	var migrations []Migration
+	for v, p := range files {
+		name := extractName(p.up, v)
+		if p.up == "" || p.down == "" {
+			return nil, fmt.Errorf("migration %d missing up or down file", v)
+		}
+		upFile, err := s.FS.Open(p.up)
+		if err != nil {
+			return nil, err
+		}
+		upStmts, err := readSQLStatements(upFile)
+		upFile.Close()
+		if err != nil {
+			return nil, err
+		}
+		downFile, err := s.FS.Open(p.down)
+		if err != nil {
+			return nil, err
+		}
+		downStmts, err := readSQLStatements(downFile)
+		downFile.Close()
+		if err != nil {
+			return nil, err
+		}
+		migrations = append(migrations, Migration{
+			Version: v,
+			Name:    name,
+			DB:      s.DB,
+			Up:      upStmts,
+			Down:    downStmts,
+			Source:  s.Dir,
+		})
+	}
+	SortMigrations(migrations)
+	return migrations, nil
+}
+
+// No additional helpers required; reuse atoi and extractName from file source.

--- a/pkg/db/migration/source_file.go
+++ b/pkg/db/migration/source_file.go
@@ -1,0 +1,103 @@
+// file: pkg/db/migration/source_file.go
+// version: 1.0.0
+// guid: c1d2e3f4-5678-4abc-90de-f123456789ab
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var filePattern = regexp.MustCompile(`^(\d+)_([a-zA-Z0-9_]+)\.(up|down)\.sql$`)
+
+// FileSource loads migrations from a directory on disk.
+type FileSource struct {
+	Dir string
+	DB  DBType
+}
+
+// Load reads all migrations from the directory.
+func (s FileSource) Load(ctx context.Context) ([]Migration, error) {
+	_ = ctx
+	entries, err := os.ReadDir(s.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+
+	type pair struct {
+		up   string
+		down string
+	}
+
+	files := map[int]*pair{}
+
+	for _, e := range entries {
+		name := e.Name()
+		matches := filePattern.FindStringSubmatch(name)
+		if len(matches) != 4 {
+			continue
+		}
+		version := atoi(matches[1])
+		mig, ok := files[version]
+		if !ok {
+			mig = &pair{}
+			files[version] = mig
+		}
+		path := filepath.Join(s.Dir, name)
+		if matches[3] == "up" {
+			mig.up = path
+		} else {
+			mig.down = path
+		}
+	}
+
+	var migrations []Migration
+	for v, p := range files {
+		name := extractName(p.up, v)
+		if p.up == "" || p.down == "" {
+			return nil, fmt.Errorf("migration %d missing up or down file", v)
+		}
+		upStmts, err := ParseSQLFile(p.up)
+		if err != nil {
+			return nil, err
+		}
+		downStmts, err := ParseSQLFile(p.down)
+		if err != nil {
+			return nil, err
+		}
+		migrations = append(migrations, Migration{
+			Version: v,
+			Name:    name,
+			DB:      s.DB,
+			Up:      upStmts,
+			Down:    downStmts,
+			Source:  s.Dir,
+		})
+	}
+
+	SortMigrations(migrations)
+	return migrations, nil
+}
+
+// atoi converts string to int ignoring errors.
+func atoi(s string) int {
+	var n int
+	for _, r := range s {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// extractName infers migration name from path.
+func extractName(path string, version int) string {
+	base := filepath.Base(path)
+	matches := filePattern.FindStringSubmatch(base)
+	if len(matches) == 4 {
+		return matches[2]
+	}
+	return fmt.Sprintf("migration_%d", version)
+}

--- a/pkg/db/migration/source_remote.go
+++ b/pkg/db/migration/source_remote.go
@@ -1,0 +1,58 @@
+// file: pkg/db/migration/source_remote.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-4f2a-b3c4-d567890e1f23
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// RemoteSource fetches migrations from a remote HTTP endpoint.
+// The endpoint should return JSON array of objects {version,name,up,down,db}.
+type RemoteSource struct {
+	Client *http.Client
+	URL    string
+}
+
+// Load retrieves migrations from the remote server.
+func (s RemoteSource) Load(ctx context.Context) ([]Migration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var data []struct {
+		Version int      `json:"version"`
+		Name    string   `json:"name"`
+		DB      DBType   `json:"db"`
+		Up      []string `json:"up"`
+		Down    []string `json:"down"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	var migrations []Migration
+	for _, d := range data {
+		migrations = append(migrations, Migration{
+			Version: d.Version,
+			Name:    d.Name,
+			DB:      d.DB,
+			Up:      d.Up,
+			Down:    d.Down,
+			Source:  s.URL,
+		})
+	}
+	SortMigrations(migrations)
+	return migrations, nil
+}

--- a/pkg/db/migration/templates/cockroach.sql
+++ b/pkg/db/migration/templates/cockroach.sql
@@ -1,0 +1,9 @@
+-- Migration template for CockroachDB
+BEGIN;
+-- Up migration SQL
+COMMIT;
+
+-- Down migration
+BEGIN;
+-- Down migration SQL
+COMMIT;

--- a/pkg/db/migration/templates/mysql.sql
+++ b/pkg/db/migration/templates/mysql.sql
@@ -1,0 +1,9 @@
+-- Migration template for MySQL
+START TRANSACTION;
+-- Up migration SQL
+COMMIT;
+
+-- Down migration
+START TRANSACTION;
+-- Down migration SQL
+COMMIT;

--- a/pkg/db/migration/templates/postgres.sql
+++ b/pkg/db/migration/templates/postgres.sql
@@ -1,0 +1,9 @@
+-- Migration template for PostgreSQL
+BEGIN;
+-- Write your up migration SQL here
+COMMIT;
+
+-- Down migration
+BEGIN;
+-- Write your down migration SQL here
+COMMIT;

--- a/pkg/db/migration/templates/sqlite.sql
+++ b/pkg/db/migration/templates/sqlite.sql
@@ -1,0 +1,9 @@
+-- Migration template for SQLite
+BEGIN TRANSACTION;
+-- Up migration SQL
+COMMIT;
+
+-- Down migration
+BEGIN TRANSACTION;
+-- Down migration SQL
+COMMIT;

--- a/pkg/db/migration/validation.go
+++ b/pkg/db/migration/validation.go
@@ -1,0 +1,26 @@
+// file: pkg/db/migration/validation.go
+// version: 1.0.0
+// guid: 3f9d8c7b-6a5e-4d3c-8b2a-1c0d9e8f7a6b
+
+package migration
+
+import "fmt"
+
+// Validator validates migrations before execution.
+type Validator interface {
+	Validate(Migration) error
+}
+
+// BasicValidator performs simple checks on migrations.
+type BasicValidator struct{}
+
+// Validate ensures migration fields are populated and SQL is present.
+func (BasicValidator) Validate(m Migration) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	if m.DB == "" {
+		return fmt.Errorf("db type required")
+	}
+	return nil
+}

--- a/pkg/db/migration/versioning.go
+++ b/pkg/db/migration/versioning.go
@@ -1,0 +1,80 @@
+// file: pkg/db/migration/versioning.go
+// version: 1.0.0
+// guid: 1d9c1d6f-e76b-48f1-9a34-b1587da83211
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// VersionTracker tracks applied migration versions and metadata.
+type VersionTracker interface {
+	Current(context.Context) (int, error)
+	SetVersion(context.Context, int, string) error
+	Last(context.Context) (Migration, error)
+	RemoveVersion(context.Context, int) error
+}
+
+// SQLVersionTracker implements VersionTracker using a database table.
+type SQLVersionTracker struct {
+	DB    *sql.DB
+	Table string
+}
+
+// EnsureTable creates the version tracking table if it does not exist.
+func (t SQLVersionTracker) EnsureTable(ctx context.Context) error {
+	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+        id SERIAL PRIMARY KEY,
+        version INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        applied_at TIMESTAMP DEFAULT NOW()
+    )`, t.Table)
+	if _, err := t.DB.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("create version table: %w", err)
+	}
+	return nil
+}
+
+// Current returns the latest applied migration version.
+func (t SQLVersionTracker) Current(ctx context.Context) (int, error) {
+	var v int
+	query := fmt.Sprintf("SELECT COALESCE(MAX(version),0) FROM %s", t.Table)
+	if err := t.DB.QueryRowContext(ctx, query).Scan(&v); err != nil {
+		return 0, fmt.Errorf("query current version: %w", err)
+	}
+	return v, nil
+}
+
+// SetVersion records a migration as applied.
+func (t SQLVersionTracker) SetVersion(ctx context.Context, v int, name string) error {
+	query := fmt.Sprintf("INSERT INTO %s (version, name) VALUES ($1, $2)", t.Table)
+	if _, err := t.DB.ExecContext(ctx, query, v, name); err != nil {
+		return fmt.Errorf("insert version: %w", err)
+	}
+	return nil
+}
+
+// RemoveVersion deletes a version record.
+func (t SQLVersionTracker) RemoveVersion(ctx context.Context, v int) error {
+	query := fmt.Sprintf("DELETE FROM %s WHERE version=$1", t.Table)
+	if _, err := t.DB.ExecContext(ctx, query, v); err != nil {
+		return fmt.Errorf("delete version: %w", err)
+	}
+	return nil
+}
+
+// Last returns the last applied migration.
+func (t SQLVersionTracker) Last(ctx context.Context) (Migration, error) {
+	query := fmt.Sprintf("SELECT version, name FROM %s ORDER BY version DESC LIMIT 1", t.Table)
+	var m Migration
+	if err := t.DB.QueryRowContext(ctx, query).Scan(&m.Version, &m.Name); err != nil {
+		if err == sql.ErrNoRows {
+			return Migration{}, nil
+		}
+		return Migration{}, fmt.Errorf("query last: %w", err)
+	}
+	return m, nil
+}


### PR DESCRIPTION
## Summary
- provide full-featured database migration framework with versioning, validation, rollback, and multi-database executors
- document migration system in changelog, README, and TODO

## Issues Addressed

### feat(db): implement migration system

**Description:** implement migration sources, executors, manager, version tracking, rollback utilities, and templates for Postgres, SQLite, CockroachDB, and MySQL.

**Files Modified:**
- [`pkg/db/migration/migration.go`](./pkg/db/migration/migration.go) - define migration model and helpers | [[diff]](../../pull/PR_NUMBER/files#diff-1) [[repo]](../../blob/main/pkg/db/migration/migration.go)
- [`pkg/db/migration/source.go`](./pkg/db/migration/source.go) - add source interface | [[diff]](../../pull/PR_NUMBER/files#diff-2) [[repo]](../../blob/main/pkg/db/migration/source.go)
- [`pkg/db/migration/source_file.go`](./pkg/db/migration/source_file.go) - implement filesystem source | [[diff]](../../pull/PR_NUMBER/files#diff-3) [[repo]](../../blob/main/pkg/db/migration/source_file.go)
- [`pkg/db/migration/source_embed.go`](./pkg/db/migration/source_embed.go) - load migrations from embed.FS | [[diff]](../../pull/PR_NUMBER/files#diff-4) [[repo]](../../blob/main/pkg/db/migration/source_embed.go)
- [`pkg/db/migration/source_db.go`](./pkg/db/migration/source_db.go) - add database-stored source | [[diff]](../../pull/PR_NUMBER/files#diff-5) [[repo]](../../blob/main/pkg/db/migration/source_db.go)
- [`pkg/db/migration/source_remote.go`](./pkg/db/migration/source_remote.go) - fetch migrations from HTTP endpoint | [[diff]](../../pull/PR_NUMBER/files#diff-6) [[repo]](../../blob/main/pkg/db/migration/source_remote.go)
- [`pkg/db/migration/executor.go`](./pkg/db/migration/executor.go) - define executor interface | [[diff]](../../pull/PR_NUMBER/files#diff-7) [[repo]](../../blob/main/pkg/db/migration/executor.go)
- [`pkg/db/migration/executor_sql.go`](./pkg/db/migration/executor_sql.go) - generic SQL executor | [[diff]](../../pull/PR_NUMBER/files#diff-8) [[repo]](../../blob/main/pkg/db/migration/executor_sql.go)
- [`pkg/db/migration/executor_postgres.go`](./pkg/db/migration/executor_postgres.go) - Postgres executor wrapper | [[diff]](../../pull/PR_NUMBER/files#diff-9) [[repo]](../../blob/main/pkg/db/migration/executor_postgres.go)
- [`pkg/db/migration/executor_sqlite.go`](./pkg/db/migration/executor_sqlite.go) - SQLite executor wrapper | [[diff]](../../pull/PR_NUMBER/files#diff-10) [[repo]](../../blob/main/pkg/db/migration/executor_sqlite.go)
- [`pkg/db/migration/executor_cockroach.go`](./pkg/db/migration/executor_cockroach.go) - CockroachDB executor wrapper | [[diff]](../../pull/PR_NUMBER/files#diff-11) [[repo]](../../blob/main/pkg/db/migration/executor_cockroach.go)
- [`pkg/db/migration/executor_mysql.go`](./pkg/db/migration/executor_mysql.go) - MySQL executor wrapper | [[diff]](../../pull/PR_NUMBER/files#diff-12) [[repo]](../../blob/main/pkg/db/migration/executor_mysql.go)
- [`pkg/db/migration/manager.go`](./pkg/db/migration/manager.go) - orchestrate migrations and parallel execution | [[diff]](../../pull/PR_NUMBER/files#diff-13) [[repo]](../../blob/main/pkg/db/migration/manager.go)
- [`pkg/db/migration/versioning.go`](./pkg/db/migration/versioning.go) - SQL version tracker with table management | [[diff]](../../pull/PR_NUMBER/files#diff-14) [[repo]](../../blob/main/pkg/db/migration/versioning.go)
- [`pkg/db/migration/rollback.go`](./pkg/db/migration/rollback.go) - implement rollback using tracker | [[diff]](../../pull/PR_NUMBER/files#diff-15) [[repo]](../../blob/main/pkg/db/migration/rollback.go)
- [`pkg/db/migration/validation.go`](./pkg/db/migration/validation.go) - add basic validator | [[diff]](../../pull/PR_NUMBER/files#diff-16) [[repo]](../../blob/main/pkg/db/migration/validation.go)
- [`pkg/db/migration/manager_test.go`](./pkg/db/migration/manager_test.go) - add unit tests for manager | [[diff]](../../pull/PR_NUMBER/files#diff-17) [[repo]](../../blob/main/pkg/db/migration/manager_test.go)
- [`pkg/db/migration/templates/postgres.sql`](./pkg/db/migration/templates/postgres.sql) - PostgreSQL migration template | [[diff]](../../pull/PR_NUMBER/files#diff-18) [[repo]](../../blob/main/pkg/db/migration/templates/postgres.sql)
- [`pkg/db/migration/templates/sqlite.sql`](./pkg/db/migration/templates/sqlite.sql) - SQLite migration template | [[diff]](../../pull/PR_NUMBER/files#diff-19) [[repo]](../../blob/main/pkg/db/migration/templates/sqlite.sql)
- [`pkg/db/migration/templates/cockroach.sql`](./pkg/db/migration/templates/cockroach.sql) - CockroachDB migration template | [[diff]](../../pull/PR_NUMBER/files#diff-20) [[repo]](../../blob/main/pkg/db/migration/templates/cockroach.sql)
- [`pkg/db/migration/templates/mysql.sql`](./pkg/db/migration/templates/mysql.sql) - MySQL migration template | [[diff]](../../pull/PR_NUMBER/files#diff-21) [[repo]](../../blob/main/pkg/db/migration/templates/mysql.sql)
- [`.github/issue-updates/146d6bf3-c888-4708-8097-3c33632c173e.json`](./.github/issue-updates/146d6bf3-c888-4708-8097-3c33632c173e.json) - issue creation for migration system | [[diff]](../../pull/PR_NUMBER/files#diff-22) [[repo]](../../blob/main/.github/issue-updates/146d6bf3-c888-4708-8097-3c33632c173e.json)
- [`.github/doc-updates/bbdd987c-8fcf-41cc-9b32-876909e7da31.json`](./.github/doc-updates/bbdd987c-8fcf-41cc-9b32-876909e7da31.json) - changelog entry for migration system | [[diff]](../../pull/PR_NUMBER/files#diff-23) [[repo]](../../blob/main/.github/doc-updates/bbdd987c-8fcf-41cc-9b32-876909e7da31.json)
- [`.github/doc-updates/06719804-b2f6-49e6-89ba-d8c0b41736e4.json`](./.github/doc-updates/06719804-b2f6-49e6-89ba-d8c0b41736e4.json) - README update referencing migrations | [[diff]](../../pull/PR_NUMBER/files#diff-24) [[repo]](../../blob/main/.github/doc-updates/06719804-b2f6-49e6-89ba-d8c0b41736e4.json)
- [`.github/doc-updates/8cd5927a-5d8e-4867-b144-06e42dbd6380.json`](./.github/doc-updates/8cd5927a-5d8e-4867-b144-06e42dbd6380.json) - add TODO task for migration CLI | [[diff]](../../pull/PR_NUMBER/files#diff-25) [[repo]](../../blob/main/.github/doc-updates/8cd5927a-5d8e-4867-b144-06e42dbd6380.json)

## Testing
- `go test ./pkg/db/migration -run TestManager -v`
- `go test ./pkg/db/... -run TestManager -v` *(fails: undefined dbpb.DatabaseService_QueryClient and related types)*

## Related Issues
- None


------
https://chatgpt.com/codex/tasks/task_e_6898095ca9c88321ae49f189c26c9943