### PR TITLE
feat(grpc): scaffold unified service framework

### DIFF
--- a/.github/doc-updates/0b656e39-e888-41e0-8b5d-67520852ae67.json
+++ b/.github/doc-updates/0b656e39-e888-41e0-8b5d-67520852ae67.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Finalize gRPC client utilities and cross-module communication",
+  "guid": "0b656e39-e888-41e0-8b5d-67520852ae67",
+  "created_at": "2025-08-10T14:38:35Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/177086d9-198d-44de-82b4-354ad2b417d5.json
+++ b/.github/doc-updates/177086d9-198d-44de-82b4-354ad2b417d5.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Refine gRPC server registration and lifecycle management",
+  "guid": "177086d9-198d-44de-82b4-354ad2b417d5",
+  "created_at": "2025-08-10T12:34:39Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/23ee35ba-9f3d-4a78-9979-6b115217c46a.json
+++ b/.github/doc-updates/23ee35ba-9f3d-4a78-9979-6b115217c46a.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add unified gRPC service registration scaffold",
+  "guid": "23ee35ba-9f3d-4a78-9979-6b115217c46a",
+  "created_at": "2025-08-10T02:56:24Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/31384994-d322-4635-983a-da9351961dfc.json
+++ b/.github/doc-updates/31384994-d322-4635-983a-da9351961dfc.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "- Implemented unified gRPC service registration scaffold",
+  "guid": "31384994-d322-4635-983a-da9351961dfc",
+  "created_at": "2025-08-10T02:56:22Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/42baee6f-1ad8-4305-af79-e4ef1f7a5727.json
+++ b/.github/doc-updates/42baee6f-1ad8-4305-af79-e4ef1f7a5727.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "### Unified gRPC Server Example\\n\\n",
+  "guid": "42baee6f-1ad8-4305-af79-e4ef1f7a5727",
+  "created_at": "2025-08-10T14:38:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/95e396a6-ff21-4c3a-bb76-889aaec9b4ed.json
+++ b/.github/doc-updates/95e396a6-ff21-4c3a-bb76-889aaec9b4ed.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Finalize unified gRPC server manager implementation",
+  "guid": "95e396a6-ff21-4c3a-bb76-889aaec9b4ed",
+  "created_at": "2025-08-10T02:56:26Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9db72f2f-0f75-4add-ae4f-79adab15654b.json
+++ b/.github/doc-updates/9db72f2f-0f75-4add-ae4f-79adab15654b.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "- Unified gRPC server with service registry and lifecycle helpers",
+  "guid": "9db72f2f-0f75-4add-ae4f-79adab15654b",
+  "created_at": "2025-08-10T12:35:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b9459a6e-1208-40f8-98ce-c89f8df1c31d.json
+++ b/.github/doc-updates/b9459a6e-1208-40f8-98ce-c89f8df1c31d.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "feat: unify gRPC server and service registration across modules",
+  "guid": "b9459a6e-1208-40f8-98ce-c89f8df1c31d",
+  "created_at": "2025-08-10T14:38:32Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/0b5a6639-2f78-4a42-812b-46c450a9ea8d.json
+++ b/.github/issue-updates/0b5a6639-2f78-4a42-812b-46c450a9ea8d.json
@@ -1,0 +1,13 @@
+{
+  "action": "comment",
+  "number": 882,
+  "body": "Implemented server registration delegation and lifecycle hooks",
+  "guid": "0b5a6639-2f78-4a42-812b-46c450a9ea8d",
+  "legacy_guid": "comment-issue-882-2025-08-10",
+  "created_at": "2025-08-10T12:34:46.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null ,
+  "parent": "module:grpc,type:feature"
+}

--- a/.github/issue-updates/0c2a4832-31e3-44bb-81d1-c289a6fc9795.json
+++ b/.github/issue-updates/0c2a4832-31e3-44bb-81d1-c289a6fc9795.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "gRPC: add unified service registration scaffold",
+  "body": "Add service registry and server interfaces to unify gRPC service management.",
+  "labels": ["module:grpc", "type:feature"],
+  "guid": "0c2a4832-31e3-44bb-81d1-c289a6fc9795",
+  "legacy_guid": "create-grpc-add-unified-service-registration-scaffold-2025-08-10",
+  "created_at": "2025-08-10T02:56:17.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/21dfe79e-d04c-479d-b016-6ac4cadda60a.json
+++ b/.github/issue-updates/21dfe79e-d04c-479d-b016-6ac4cadda60a.json
@@ -1,0 +1,12 @@
+{
+  "action": "comment",
+  "number": 882,
+  "body": "Implemented comprehensive gRPC service consolidation scaffold",
+  "guid": "21dfe79e-d04c-479d-b016-6ac4cadda60a",
+  "legacy_guid": "comment-issue-882-2025-08-10",
+  "created_at": "2025-08-10T14:38:19.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/grpc/client/balancer.go
+++ b/pkg/grpc/client/balancer.go
@@ -1,0 +1,27 @@
+// file: pkg/grpc/client/balancer.go
+// version: 1.0.0
+// guid: e4b1f03e-6cd6-4bf4-ab25-b04a22172853
+
+package client
+
+import "sync/atomic"
+
+// RoundRobin implements a simple round-robin balancer over addresses.
+type RoundRobin struct {
+	addrs []string
+	idx   uint32
+}
+
+// NewRoundRobin creates a new balancer with provided addresses.
+func NewRoundRobin(addrs []string) *RoundRobin {
+	return &RoundRobin{addrs: append([]string(nil), addrs...)}
+}
+
+// Next returns the next address in sequence.
+func (r *RoundRobin) Next() string {
+	if len(r.addrs) == 0 {
+		return ""
+	}
+	i := atomic.AddUint32(&r.idx, 1)
+	return r.addrs[int(i)%len(r.addrs)]
+}

--- a/pkg/grpc/client/discovery.go
+++ b/pkg/grpc/client/discovery.go
@@ -1,0 +1,26 @@
+// file: pkg/grpc/client/discovery.go
+// version: 1.0.0
+// guid: 129fc533-97d8-4e8a-86d1-77dd2474035b
+
+package client
+
+// Discovery provides a simple registry for service addresses.
+type Discovery struct {
+	services map[string]string
+}
+
+// NewDiscovery creates an empty discovery registry.
+func NewDiscovery() *Discovery {
+	return &Discovery{services: make(map[string]string)}
+}
+
+// Register records a service name and address.
+func (d *Discovery) Register(name, addr string) {
+	d.services[name] = addr
+}
+
+// Lookup returns the address for a service name.
+func (d *Discovery) Lookup(name string) (string, bool) {
+	addr, ok := d.services[name]
+	return addr, ok
+}

--- a/pkg/grpc/client/doc.go
+++ b/pkg/grpc/client/doc.go
@@ -1,0 +1,6 @@
+// file: pkg/grpc/client/doc.go
+// version: 1.0.0
+// guid: 902d05c0-709c-4996-bb36-9594dfee90d9
+
+// Package client provides utilities for managing gRPC client connections.
+package client

--- a/pkg/grpc/client/manager.go
+++ b/pkg/grpc/client/manager.go
@@ -1,0 +1,55 @@
+// file: pkg/grpc/client/manager.go
+// version: 1.0.0
+// guid: babb42de-3c57-4ab6-bb3c-0f2f4de27d91
+
+package client
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// Manager handles gRPC client connections with pooling and reuse.
+type Manager struct {
+	mu    sync.Mutex
+	conns map[string]*grpc.ClientConn
+}
+
+// NewManager creates a new Manager instance.
+func NewManager() *Manager {
+	return &Manager{conns: make(map[string]*grpc.ClientConn)}
+}
+
+// Get returns a cached connection or dials a new one.
+func (m *Manager) Get(ctx context.Context, addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	m.mu.Lock()
+	if conn, ok := m.conns[addr]; ok {
+		m.mu.Unlock()
+		return conn, nil
+	}
+	m.mu.Unlock()
+	conn, err := grpc.DialContext(ctx, addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.conns[addr] = conn
+	m.mu.Unlock()
+	return conn, nil
+}
+
+// Close closes all managed connections.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var firstErr error
+	for addr, c := range m.conns {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		delete(m.conns, addr)
+	}
+	return firstErr
+}

--- a/pkg/grpc/client/manager_test.go
+++ b/pkg/grpc/client/manager_test.go
@@ -1,0 +1,58 @@
+// file: pkg/grpc/client/manager_test.go
+// version: 1.0.0
+// guid: 661964dc-f1fb-4294-b2ec-180e2fb8df01
+
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufSize = 1024 * 1024
+
+func dialer() (*grpc.ClientConn, func(), error) {
+	lis := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	go func() { _ = s.Serve(lis) }()
+	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithInsecure())
+	cleanup := func() {
+		conn.Close()
+		s.Stop()
+	}
+	return conn, cleanup, err
+}
+
+// TestManagerGet verifies connections are cached.
+func TestManagerGet(t *testing.T) {
+	_, cleanup, err := dialer()
+	if err != nil {
+		t.Fatalf("dialer setup failed: %v", err)
+	}
+	cleanup()
+
+	ctx := context.Background()
+	m := NewManager()
+	conn1, err := m.Get(ctx, "example", grpc.WithInsecure(), grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+		return bufconn.Listen(1).Dial()
+	}))
+	if err != nil {
+		t.Fatalf("first get failed: %v", err)
+	}
+	conn2, err := m.Get(ctx, "example")
+	if err != nil {
+		t.Fatalf("second get failed: %v", err)
+	}
+	if conn1 != conn2 {
+		t.Fatalf("expected cached connection")
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+}

--- a/pkg/grpc/examples/client_usage.go
+++ b/pkg/grpc/examples/client_usage.go
@@ -1,0 +1,23 @@
+// file: pkg/grpc/examples/client_usage.go
+// version: 1.0.0
+// guid: f044b36e-ee3d-453d-9b8f-5c3f02833dc7
+
+package examples
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/grpc/client"
+)
+
+// ClientUsageExample demonstrates dialing a service.
+func ClientUsageExample(ctx context.Context) error {
+	mgr := client.NewManager()
+	conn, err := mgr.Get(ctx, "localhost:50051")
+	if err != nil {
+		return err
+	}
+	defer mgr.Close()
+	_ = conn
+	return nil
+}

--- a/pkg/grpc/examples/doc.go
+++ b/pkg/grpc/examples/doc.go
@@ -1,0 +1,6 @@
+// file: pkg/grpc/examples/doc.go
+// version: 1.0.0
+// guid: 6ed3157b-040c-474e-b9a2-46b99ac3f4e0
+
+// Package examples provides usage examples for the unified gRPC framework.
+package examples

--- a/pkg/grpc/examples/microservice.go
+++ b/pkg/grpc/examples/microservice.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/examples/microservice.go
+// version: 1.0.0
+// guid: a2110206-b6c9-48f2-bb62-3735714f3c9b
+
+package examples
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	svc "github.com/jdfalk/gcommon/pkg/grpc/services"
+	"google.golang.org/grpc"
+)
+
+// MicroserviceTemplate shows how a module could expose a gRPC service.
+func MicroserviceTemplate(ctx context.Context, desc *grpc.ServiceDesc, impl interface{}) error {
+	cfg := server.Config{Address: ":0"}
+	s := cfg.Build()
+	svc.RegisterConfigService(s, impl, desc)
+	return s.Start(ctx)
+}

--- a/pkg/grpc/examples/unified_server.go
+++ b/pkg/grpc/examples/unified_server.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/examples/unified_server.go
+// version: 1.0.0
+// guid: 33ef035a-8fe1-4893-8115-b3893260681b
+
+package examples
+
+import (
+	"context"
+	"log"
+
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+)
+
+// UnifiedServerExample demonstrates constructing and starting a server.
+func UnifiedServerExample(ctx context.Context) {
+	cfg := server.Config{Address: ":50051"}
+	srv := cfg.Build()
+	if err := srv.Start(ctx); err != nil {
+		log.Printf("start failed: %v", err)
+	}
+}

--- a/pkg/grpc/interceptors/auth.go
+++ b/pkg/grpc/interceptors/auth.go
@@ -1,0 +1,25 @@
+// file: pkg/grpc/interceptors/auth.go
+// version: 1.0.0
+// guid: 2a603731-2dd9-4498-906d-b0f0e951d199
+
+package interceptors
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AuthUnary returns a unary interceptor performing basic authorization checks.
+func AuthUnary(check func(context.Context) error) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if check != nil {
+			if err := check(ctx); err != nil {
+				return nil, status.Error(codes.PermissionDenied, err.Error())
+			}
+		}
+		return handler(ctx, req)
+	}
+}

--- a/pkg/grpc/interceptors/doc.go
+++ b/pkg/grpc/interceptors/doc.go
@@ -1,0 +1,6 @@
+// file: pkg/grpc/interceptors/doc.go
+// version: 1.0.0
+// guid: 9460e750-6e93-41fb-8f27-d3b856f87571
+
+// Package interceptors contains reusable gRPC server interceptors.
+package interceptors

--- a/pkg/grpc/interceptors/logging.go
+++ b/pkg/grpc/interceptors/logging.go
@@ -1,0 +1,23 @@
+// file: pkg/grpc/interceptors/logging.go
+// version: 1.0.0
+// guid: 9d891769-7a3a-4624-816d-25f7ed0a0fd1
+
+package interceptors
+
+import (
+	"context"
+	"log"
+
+	"google.golang.org/grpc"
+)
+
+// LoggingUnary logs basic request information.
+func LoggingUnary(logger *log.Logger) grpc.UnaryServerInterceptor {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		logger.Printf("%s called", info.FullMethod)
+		return handler(ctx, req)
+	}
+}

--- a/pkg/grpc/interceptors/metrics.go
+++ b/pkg/grpc/interceptors/metrics.go
@@ -1,0 +1,24 @@
+// file: pkg/grpc/interceptors/metrics.go
+// version: 1.0.0
+// guid: 715446ee-c03f-4f96-a128-e6737a860e18
+
+package interceptors
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// MetricsUnary measures request duration for metrics collection.
+func MetricsUnary(observer func(method string, d time.Duration, err error)) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		if observer != nil {
+			observer(info.FullMethod, time.Since(start), err)
+		}
+		return resp, err
+	}
+}

--- a/pkg/grpc/interceptors/recovery.go
+++ b/pkg/grpc/interceptors/recovery.go
@@ -1,0 +1,24 @@
+// file: pkg/grpc/interceptors/recovery.go
+// version: 1.0.0
+// guid: dd905d5e-5d3d-4aa5-b47e-7519638ee1d0
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
+// RecoveryUnary intercepts panics and returns an error instead.
+func RecoveryUnary() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic: %v", r)
+			}
+		}()
+		return handler(ctx, req)
+	}
+}

--- a/pkg/grpc/server/config.go
+++ b/pkg/grpc/server/config.go
@@ -1,0 +1,27 @@
+// file: pkg/grpc/server/config.go
+// version: 1.0.0
+// guid: 96fc0ab4-11ca-43cc-9132-1e6b69be0c27
+
+package server
+
+import "google.golang.org/grpc"
+
+// Config captures basic gRPC server configuration.
+type Config struct {
+	Address    string
+	UnaryInts  []grpc.UnaryServerInterceptor
+	StreamInts []grpc.StreamServerInterceptor
+	ServerOpts []grpc.ServerOption
+}
+
+// Build constructs a GRPCServer based on the configuration.
+func (c Config) Build() *Server {
+	opts := append([]grpc.ServerOption{}, c.ServerOpts...)
+	if len(c.UnaryInts) > 0 {
+		opts = append(opts, grpc.ChainUnaryInterceptor(c.UnaryInts...))
+	}
+	if len(c.StreamInts) > 0 {
+		opts = append(opts, grpc.ChainStreamInterceptor(c.StreamInts...))
+	}
+	return NewServer(c.Address, opts...)
+}

--- a/pkg/grpc/server/manager.go
+++ b/pkg/grpc/server/manager.go
@@ -1,0 +1,93 @@
+// file: pkg/grpc/server/manager.go
+// version: 1.0.0
+// guid: a7152ca2-3531-41f8-ac92-1273baf0ccea
+
+// Package server provides unified server lifecycle management utilities.
+package server
+
+import (
+	"context"
+	"sync"
+)
+
+// Manager coordinates the startup and shutdown of one or more gRPC servers.
+type Manager struct {
+	servers []GRPCServer
+	mu      sync.Mutex
+}
+
+// NewManager creates a new empty Manager instance.
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// AddServer registers a GRPCServer with the manager.
+func (m *Manager) AddServer(s GRPCServer) {
+	if s == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.servers = append(m.servers, s)
+}
+
+// StartAll starts all managed servers concurrently and waits for completion.
+func (m *Manager) StartAll(ctx context.Context) error {
+	m.mu.Lock()
+	servers := append([]GRPCServer(nil), m.servers...)
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(servers))
+	errs := make(chan error, len(servers))
+	for _, srv := range servers {
+		go func(s GRPCServer) {
+			defer wg.Done()
+			if err := s.Start(ctx); err != nil {
+				errs <- err
+			}
+		}(srv)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StopAll stops all managed servers concurrently and waits for completion.
+func (m *Manager) StopAll(ctx context.Context) error {
+	m.mu.Lock()
+	servers := append([]GRPCServer(nil), m.servers...)
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(servers))
+	errChan := make(chan error, len(servers))
+	for _, srv := range servers {
+		go func(s GRPCServer) {
+			defer wg.Done()
+			if err := s.Stop(ctx); err != nil {
+				errChan <- err
+			}
+		}(srv)
+	}
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Servers returns a snapshot of managed servers.
+func (m *Manager) Servers() []GRPCServer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]GRPCServer(nil), m.servers...)
+}

--- a/pkg/grpc/server/manager_test.go
+++ b/pkg/grpc/server/manager_test.go
@@ -1,0 +1,72 @@
+// file: pkg/grpc/server/manager_test.go
+// version: 1.0.0
+// guid: 732664f0-f0b9-42e5-8675-9e311ec28fe1
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	health "github.com/jdfalk/gcommon/pkg/health"
+	"google.golang.org/grpc"
+)
+
+// mockServer implements GRPCServer for testing purposes.
+type mockServer struct {
+	started int
+	stopped int
+}
+
+func (m *mockServer) Start(context.Context) error {
+	m.started++
+	return nil
+}
+
+func (m *mockServer) Stop(context.Context) error {
+	m.stopped++
+	return nil
+}
+
+func (m *mockServer) RegisterService(*grpc.ServiceDesc, interface{}) {}
+func (m *mockServer) RegisterHealthService(provider health.Provider) {}
+func (m *mockServer) RegisterReflectionService()                     {}
+func (m *mockServer) GetRegisteredServices() []string                { return nil }
+func (m *mockServer) GetAddress() string                             { return "" }
+func (m *mockServer) GetStats() *ServerStats                         { return &ServerStats{} }
+
+// TestManagerStartStop verifies Manager starts and stops all servers.
+func TestManagerStartStop(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager()
+	s1 := &mockServer{}
+	s2 := &mockServer{}
+	m.AddServer(s1)
+	m.AddServer(s2)
+
+	if err := m.StartAll(ctx); err != nil {
+		t.Fatalf("StartAll failed: %v", err)
+	}
+	if s1.started != 1 || s2.started != 1 {
+		t.Fatalf("servers not started: %d %d", s1.started, s2.started)
+	}
+
+	if err := m.StopAll(ctx); err != nil {
+		t.Fatalf("StopAll failed: %v", err)
+	}
+	if s1.stopped != 1 || s2.stopped != 1 {
+		t.Fatalf("servers not stopped: %d %d", s1.stopped, s2.stopped)
+	}
+}
+
+// TestManagerEmpty ensures starting an empty manager does nothing.
+func TestManagerEmpty(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager()
+	if err := m.StartAll(ctx); err != nil {
+		t.Fatalf("StartAll empty failed: %v", err)
+	}
+	if err := m.StopAll(ctx); err != nil {
+		t.Fatalf("StopAll empty failed: %v", err)
+	}
+}

--- a/pkg/grpc/server/middleware.go
+++ b/pkg/grpc/server/middleware.go
@@ -1,0 +1,40 @@
+// file: pkg/grpc/server/middleware.go
+// version: 1.0.0
+// guid: e816bc12-3528-4515-8007-8df0d951c42d
+
+package server
+
+import (
+	"context"
+	"google.golang.org/grpc"
+)
+
+// ChainUnary creates a single unary interceptor from a list.
+func ChainUnary(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		var chained grpc.UnaryHandler = handler
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			inter := interceptors[i]
+			next := chained
+			chained = func(c context.Context, r interface{}) (interface{}, error) {
+				return inter(c, r, info, next)
+			}
+		}
+		return chained(ctx, req)
+	}
+}
+
+// ChainStream creates a single stream interceptor from a list.
+func ChainStream(interceptors ...grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		var chained grpc.StreamHandler = handler
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			inter := interceptors[i]
+			next := chained
+			chained = func(current interface{}, stream grpc.ServerStream) error {
+				return inter(current, stream, info, next)
+			}
+		}
+		return chained(srv, ss)
+	}
+}

--- a/pkg/grpc/server/registry.go
+++ b/pkg/grpc/server/registry.go
@@ -1,0 +1,179 @@
+// file: pkg/grpc/server/registry.go
+// version: 1.1.0
+// guid: 6d7d1e9f-4b71-4e3c-9a31-6c7bde9d2d92
+
+// Package server provides unified gRPC service registration utilities.
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	healthgrpc "github.com/jdfalk/gcommon/pkg/health"
+	healthpb "github.com/jdfalk/gcommon/pkg/health/proto"
+)
+
+// ServiceRegistrar defines methods for registering gRPC services.
+type ServiceRegistrar interface {
+	RegisterService(desc *grpc.ServiceDesc, impl interface{})
+	RegisterHealthService(provider healthgrpc.Provider)
+	RegisterReflectionService()
+	GetRegisteredServices() []string
+}
+
+// ServerStats contains simple runtime statistics for the server.
+type ServerStats struct {
+	mu       sync.RWMutex
+	services []string
+}
+
+// add records a newly registered service.
+func (s *ServerStats) add(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.services = append(s.services, name)
+}
+
+// Services returns a snapshot of registered service names.
+func (s *ServerStats) Services() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.services...)
+}
+
+// Registry implements ServiceRegistrar on top of a gRPC server.
+type Registry struct {
+	server *grpc.Server
+	stats  *ServerStats
+}
+
+// NewRegistry creates a new Registry for the provided gRPC server.
+func NewRegistry(s *grpc.Server) *Registry {
+	return &Registry{
+		server: s,
+		stats:  &ServerStats{},
+	}
+}
+
+// RegisterService registers a generic gRPC service.
+func (r *Registry) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {
+	if desc == nil || impl == nil {
+		return
+	}
+	r.server.RegisterService(desc, impl)
+	r.stats.add(desc.ServiceName)
+}
+
+// RegisterHealthService registers the health service using the provided provider.
+func (r *Registry) RegisterHealthService(provider healthgrpc.Provider) {
+	if provider == nil {
+		return
+	}
+	hs := healthgrpc.NewGRPCServer(provider)
+	hs.Register(r.server)
+	r.stats.add(healthpb.HealthService_ServiceDesc.ServiceName)
+}
+
+// RegisterReflectionService enables gRPC reflection on the server.
+func (r *Registry) RegisterReflectionService() {
+	reflection.Register(r.server)
+	r.stats.add("grpc.reflection.v1alpha.ServerReflection")
+}
+
+// GetRegisteredServices returns all registered service names.
+func (r *Registry) GetRegisteredServices() []string {
+	return r.stats.Services()
+}
+
+// GRPCServer defines lifecycle methods for a gRPC server.
+type GRPCServer interface {
+	ServiceRegistrar
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	GetAddress() string
+	GetStats() *ServerStats
+}
+
+// Server provides a minimal implementation of GRPCServer.
+type Server struct {
+	addr     string
+	server   *grpc.Server
+	registry *Registry
+}
+
+// NewServer creates a new gRPC server listening on the provided address.
+func NewServer(addr string, opts ...grpc.ServerOption) *Server {
+	s := grpc.NewServer(opts...)
+	return &Server{
+		addr:     addr,
+		server:   s,
+		registry: NewRegistry(s),
+	}
+}
+
+// Start begins serving on the configured address.
+func (s *Server) Start(ctx context.Context) error {
+	lis, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	go func() {
+		_ = s.server.Serve(lis)
+	}()
+	return nil
+}
+
+// Stop gracefully stops the gRPC server.
+func (s *Server) Stop(ctx context.Context) error {
+	stopped := make(chan struct{})
+	go func() {
+		s.server.GracefulStop()
+		close(stopped)
+	}()
+	select {
+	case <-ctx.Done():
+		s.server.Stop()
+		return ctx.Err()
+	case <-stopped:
+		return nil
+	}
+}
+
+// RegisterService registers services using the provided registrar.
+func (s *Server) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {
+	s.registry.RegisterService(desc, impl)
+}
+
+// RegisterHealthService registers the health service using the provided provider.
+func (s *Server) RegisterHealthService(provider healthgrpc.Provider) {
+	s.registry.RegisterHealthService(provider)
+}
+
+// RegisterReflectionService enables gRPC reflection on the server.
+func (s *Server) RegisterReflectionService() {
+	s.registry.RegisterReflectionService()
+}
+
+// GetRegisteredServices returns all registered service names.
+func (s *Server) GetRegisteredServices() []string {
+	return s.registry.GetRegisteredServices()
+}
+
+// GetAddress returns the server's listening address.
+func (s *Server) GetAddress() string {
+	return s.addr
+}
+
+// GetStats returns server statistics.
+func (s *Server) GetStats() *ServerStats {
+	return s.registry.stats
+}
+
+// Registrar exposes the internal registry.
+func (s *Server) Registrar() *Registry {
+	return s.registry
+}

--- a/pkg/grpc/services/auth.go
+++ b/pkg/grpc/services/auth.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/auth.go
+// version: 1.0.0
+// guid: 0fb7f539-ddcf-4619-b13e-1f0a807112bd
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// AuthService defines the service interface placeholder.
+type AuthService interface{}
+
+// RegisterAuthService registers the auth service with the server registrar.
+func RegisterAuthService(reg server.ServiceRegistrar, srv AuthService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/cache.go
+++ b/pkg/grpc/services/cache.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/cache.go
+// version: 1.0.0
+// guid: e21ba8d6-6139-4b87-b6a5-fb37481f50b3
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// CacheService defines the service interface placeholder.
+type CacheService interface{}
+
+// RegisterCacheService registers the cache service with the server registrar.
+func RegisterCacheService(reg server.ServiceRegistrar, srv CacheService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/config.go
+++ b/pkg/grpc/services/config.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/config.go
+// version: 1.0.0
+// guid: 97724ed0-22e2-4cb2-847c-b805c1bf1a26
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// ConfigService defines the service interface placeholder.
+type ConfigService interface{}
+
+// RegisterConfigService registers the config service with the server registrar.
+func RegisterConfigService(reg server.ServiceRegistrar, srv ConfigService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/doc.go
+++ b/pkg/grpc/services/doc.go
@@ -1,0 +1,7 @@
+// file: pkg/grpc/services/doc.go
+// version: 1.0.0
+// guid: dc4c2d85-7560-4414-98bb-538ea73d396f
+
+// Package services provides helpers for registering module gRPC services
+// with a unified server registry.
+package services

--- a/pkg/grpc/services/health.go
+++ b/pkg/grpc/services/health.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/health.go
+// version: 1.0.0
+// guid: 395f5306-edf9-44b2-a223-832dc5d0ec0a
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// HealthService defines the service interface placeholder.
+type HealthService interface{}
+
+// RegisterHealthService registers the health service with the server registrar.
+func RegisterHealthService(reg server.ServiceRegistrar, srv HealthService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/metrics.go
+++ b/pkg/grpc/services/metrics.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/metrics.go
+// version: 1.0.0
+// guid: f7dd3d3c-578f-4e67-8dfb-20637804d787
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// MetricsService defines the service interface placeholder.
+type MetricsService interface{}
+
+// RegisterMetricsService registers the metrics service with the server registrar.
+func RegisterMetricsService(reg server.ServiceRegistrar, srv MetricsService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/notification.go
+++ b/pkg/grpc/services/notification.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/notification.go
+// version: 1.0.0
+// guid: 3844d098-1eb8-4f8f-b90b-4f88458c2798
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// NotificationService defines the service interface placeholder.
+type NotificationService interface{}
+
+// RegisterNotificationService registers the notification service with the server registrar.
+func RegisterNotificationService(reg server.ServiceRegistrar, srv NotificationService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/organization.go
+++ b/pkg/grpc/services/organization.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/organization.go
+// version: 1.0.0
+// guid: af24d9f3-e842-42e1-aaf9-8c0934f4e96c
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// OrganizationService defines the service interface placeholder.
+type OrganizationService interface{}
+
+// RegisterOrganizationService registers the organization service with the server registrar.
+func RegisterOrganizationService(reg server.ServiceRegistrar, srv OrganizationService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/queue.go
+++ b/pkg/grpc/services/queue.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/queue.go
+// version: 1.0.0
+// guid: 518331ab-1310-486e-b9ab-7a8b1143f000
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// QueueService defines the service interface placeholder.
+type QueueService interface{}
+
+// RegisterQueueService registers the queue service with the server registrar.
+func RegisterQueueService(reg server.ServiceRegistrar, srv QueueService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}

--- a/pkg/grpc/services/web.go
+++ b/pkg/grpc/services/web.go
@@ -1,0 +1,21 @@
+// file: pkg/grpc/services/web.go
+// version: 1.0.0
+// guid: 8819127a-b305-4a64-9828-5312b3335f41
+
+package services
+
+import (
+	"github.com/jdfalk/gcommon/pkg/grpc/server"
+	"google.golang.org/grpc"
+)
+
+// WebService defines the service interface placeholder.
+type WebService interface{}
+
+// RegisterWebService registers the web service with the server registrar.
+func RegisterWebService(reg server.ServiceRegistrar, srv WebService, desc *grpc.ServiceDesc) {
+	if reg == nil || srv == nil || desc == nil {
+		return
+	}
+	reg.RegisterService(desc, srv)
+}


### PR DESCRIPTION
## Summary
- add server manager, configuration, and middleware chaining for multi-service gRPC orchestration
- provide service registration helpers, client utilities, and reusable auth/metrics/logging/recovery interceptors
- document unified gRPC server usage and track progress in changelog, README, TODO, and issue #882

## Testing
- `go test ./pkg/grpc/server ./pkg/grpc/client` *(fails: metrics package redeclarations)*
- `go test ./...` *(fails: undefined database proto types)*

------
https://chatgpt.com/codex/tasks/task_e_68980920b6788321b0b7ace8dae5353d