### PR TITLE
feat(cache): add memcached provider and batch operations

### DIFF
--- a/.github/doc-updates/3e99c55a-ef90-4757-a41f-b698c9bc4740.json
+++ b/.github/doc-updates/3e99c55a-ef90-4757-a41f-b698c9bc4740.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "after",
+  "content": "- Added memcached provider and extended cache operations",
+  "guid": "3e99c55a-ef90-4757-a41f-b698c9bc4740",
+  "created_at": "2025-08-10T23:46:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8f4b76eb-c0e2-4b5e-ab85-9ba307680fa6.json
+++ b/.github/doc-updates/8f4b76eb-c0e2-4b5e-ab85-9ba307680fa6.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added memcached cache provider and extended cache service operations",
+  "guid": "8f4b76eb-c0e2-4b5e-ab85-9ba307680fa6",
+  "created_at": "2025-08-10T23:46:57Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/64510b7d-21c6-4bc8-8927-2639f3e61e2b.json
+++ b/.github/issue-updates/64510b7d-21c6-4bc8-8927-2639f3e61e2b.json
@@ -1,0 +1,13 @@
+{
+  "action": "update",
+  "number": 21,
+  "body": "Implemented memcached cache provider and extended gRPC cache service methods",
+  "labels": ["module:cache", "language:go"],
+  "guid": "64510b7d-21c6-4bc8-8927-2639f3e61e2b",
+  "legacy_guid": "update-issue-21-2025-08-10",
+  "created_at": "2025-08-10T23:47:08.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jdfalk/gcommon
 go 1.23.0
 
 require (
+	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jackc/pgx/v4 v4.18.3

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21j
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf h1:TqhNAT4zKbTdLa62d2HDBFdvgSbIGB3eJE8HqhgiL9I=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/cache/factory.go
+++ b/pkg/cache/factory.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/factory.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d54fe3da-43e0-4e13-8201-017a79499f05
 
 package cache
@@ -15,6 +15,7 @@ import (
 const (
 	ProviderMemory      = "memory"
 	ProviderRedis       = "redis"
+	ProviderMemcached   = "memcached"
 	ProviderDistributed = "distributed"
 )
 
@@ -25,6 +26,8 @@ func New(provider string) (Cache, error) {
 		return providers.NewMemoryCache(0, policies.NewLRU()), nil
 	case ProviderRedis:
 		return providers.NewRedisCache(nil), nil
+	case ProviderMemcached:
+		return providers.NewMemcachedCache(nil), nil
 	case ProviderDistributed:
 		return providers.NewDistributedCache(nil), nil
 	default:

--- a/pkg/cache/grpc/cache_service.go
+++ b/pkg/cache/grpc/cache_service.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/grpc/cache_service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 887175af-36ad-491a-aa36-b40741b29935
 
 package cachegrpc
@@ -10,6 +10,7 @@ import (
 
 	cachepkg "github.com/jdfalk/gcommon/pkg/cache"
 	cachepb "github.com/jdfalk/gcommon/pkg/cache/proto"
+	cachetypes "github.com/jdfalk/gcommon/pkg/cache/types"
 	gproto "google.golang.org/protobuf/proto"
 )
 
@@ -74,4 +75,98 @@ func (s *CacheService) Clear(ctx context.Context, req *cachepb.ClearRequest) (*c
 func (s *CacheService) GetStats(ctx context.Context, req *cachepb.GetStatsRequest) (*cachepb.GetStatsResponse, error) {
 	stats := s.cache.GetStats()
 	return cachepb.GetStatsResponse_builder{TotalItems: gproto.Int64(stats.GetTotalItems()), Success: gproto.Bool(true)}.Build(), nil
+}
+
+// GetMultiple retrieves multiple values.
+func (s *CacheService) GetMultiple(ctx context.Context, req *cachepb.GetMultipleRequest) (*cachepb.GetMultipleResponse, error) {
+	vals, err := s.cache.GetMultiple(ctx, req.GetKeys())
+	if err != nil {
+		return nil, err
+	}
+	resp := cachepb.GetMultipleResponse_builder{}
+	for k, v := range vals {
+		if b, ok := v.([]byte); ok {
+			resp.Values[k] = b
+		}
+	}
+	return resp.Build(), nil
+}
+
+// SetMultiple stores multiple values.
+func (s *CacheService) SetMultiple(ctx context.Context, req *cachepb.SetMultipleRequest) (*cachepb.SetMultipleResponse, error) {
+	ttl := time.Duration(0)
+	if req.GetTtl() != nil {
+		ttl = req.GetTtl().AsDuration()
+	}
+	items := make(map[string]cachetypes.CacheItem, len(req.GetValues()))
+	for k, v := range req.GetValues() {
+		items[k] = cachetypes.CacheItem{Value: v, TTL: ttl}
+	}
+	if err := s.cache.SetMultiple(ctx, items); err != nil {
+		return nil, err
+	}
+	return cachepb.SetMultipleResponse_builder{Success: gproto.Bool(true), SetCount: gproto.Int32(int32(len(items)))}.Build(), nil
+}
+
+// DeleteMultiple removes multiple keys.
+func (s *CacheService) DeleteMultiple(ctx context.Context, req *cachepb.DeleteMultipleRequest) (*cachepb.DeleteMultipleResponse, error) {
+	if err := s.cache.DeleteMultiple(ctx, req.GetKeys()); err != nil {
+		return nil, err
+	}
+	return cachepb.DeleteMultipleResponse_builder{DeletedCount: gproto.Int32(int32(len(req.GetKeys())))}.Build(), nil
+}
+
+// Increment increments a counter.
+func (s *CacheService) Increment(ctx context.Context, req *cachepb.IncrementRequest) (*cachepb.IncrementResponse, error) {
+	ttl := time.Duration(0)
+	if req.GetTtl() != nil {
+		ttl = req.GetTtl().AsDuration()
+	}
+	// Ensure key exists with initial value if provided
+	if req.GetInitialValue() != 0 {
+		_ = s.cache.Set(ctx, req.GetKey(), req.GetInitialValue(), ttl)
+	}
+	val, err := s.cache.Increment(ctx, req.GetKey(), req.GetDelta())
+	if err != nil {
+		return nil, err
+	}
+	return cachepb.IncrementResponse_builder{NewValue: gproto.Int64(val), Success: gproto.Bool(true)}.Build(), nil
+}
+
+// Decrement decrements a counter.
+func (s *CacheService) Decrement(ctx context.Context, req *cachepb.DecrementRequest) (*cachepb.DecrementResponse, error) {
+	val, err := s.cache.Decrement(ctx, req.GetKey(), req.GetDelta())
+	if err != nil {
+		return nil, err
+	}
+	return cachepb.DecrementResponse_builder{NewValue: gproto.Int64(val), Success: gproto.Bool(true)}.Build(), nil
+}
+
+// Keys lists keys matching a pattern.
+func (s *CacheService) Keys(ctx context.Context, req *cachepb.KeysRequest) (*cachepb.KeysResponse, error) {
+	keys, err := s.cache.Keys(ctx, req.GetPattern())
+	if err != nil {
+		return nil, err
+	}
+	return cachepb.KeysResponse_builder{Keys: keys, TotalCount: gproto.Int64(int64(len(keys))), Success: gproto.Bool(true)}.Build(), nil
+}
+
+// Flush flushes cache contents.
+func (s *CacheService) Flush(ctx context.Context, req *cachepb.FlushRequest) (*cachepb.FlushResponse, error) {
+	if err := s.cache.Flush(ctx); err != nil {
+		return nil, err
+	}
+	return cachepb.FlushResponse_builder{Success: gproto.Bool(true)}.Build(), nil
+}
+
+// TouchExpiration updates TTL for a key.
+func (s *CacheService) TouchExpiration(ctx context.Context, req *cachepb.TouchExpirationRequest) (*cachepb.TouchExpirationResponse, error) {
+	var ttl time.Duration
+	if req.GetTtl() != nil {
+		ttl = req.GetTtl().AsDuration()
+	}
+	if err := s.cache.TouchExpiration(ctx, req.GetKey(), ttl); err != nil {
+		return nil, err
+	}
+	return cachepb.TouchExpirationResponse_builder{Success: gproto.Bool(true), KeyExisted: gproto.Bool(true)}.Build(), nil
 }

--- a/pkg/cache/interfaces.go
+++ b/pkg/cache/interfaces.go
@@ -1,13 +1,15 @@
 // file: pkg/cache/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 234f51b5-07a9-40e0-a00e-b83139c62244
 
 package cache
 
 import (
 	"context"
-	cachepb "github.com/jdfalk/gcommon/pkg/cache/proto"
 	"time"
+
+	cachepb "github.com/jdfalk/gcommon/pkg/cache/proto"
+	cachetypes "github.com/jdfalk/gcommon/pkg/cache/types"
 )
 
 // Cache defines the basic caching operations.
@@ -18,18 +20,27 @@ type Cache interface {
 	Exists(ctx context.Context, key string) (bool, error)
 	Clear(ctx context.Context) error
 	GetStats() *cachepb.CacheStats
+
+	// GetMultiple retrieves multiple values by keys.
+	GetMultiple(ctx context.Context, keys []string) (map[string]any, error)
+	// SetMultiple stores multiple key-value pairs atomically.
+	SetMultiple(ctx context.Context, items map[string]cachetypes.CacheItem) error
+	// DeleteMultiple removes multiple keys atomically.
+	DeleteMultiple(ctx context.Context, keys []string) error
+	// Increment atomically increments a numeric value by n and returns the new value.
+	Increment(ctx context.Context, key string, n int64) (int64, error)
+	// Decrement atomically decrements a numeric value by n and returns the new value.
+	Decrement(ctx context.Context, key string, n int64) (int64, error)
+	// Keys lists all keys matching the pattern.
+	Keys(ctx context.Context, pattern string) ([]string, error)
+	// Flush persists or clears cache depending on backend.
+	Flush(ctx context.Context) error
+	// TouchExpiration updates the TTL for the given key.
+	TouchExpiration(ctx context.Context, key string, ttl time.Duration) error
 }
 
 // DistributedCache extends Cache with distributed operations.
 type DistributedCache interface {
 	Cache
 	InvalidatePattern(ctx context.Context, pattern string) error
-	BulkGet(ctx context.Context, keys []string) (map[string]any, error)
-	BulkSet(ctx context.Context, items map[string]CacheItem) error
-}
-
-// CacheItem represents a cache item for bulk operations.
-type CacheItem struct {
-	Value any
-	TTL   time.Duration
 }

--- a/pkg/cache/providers/distributed_test.go
+++ b/pkg/cache/providers/distributed_test.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/providers/distributed_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1a2b3c4-d5e6-47f8-9a0b-1c2d3e4f5a6b
 
 package providers

--- a/pkg/cache/providers/memcached.go
+++ b/pkg/cache/providers/memcached.go
@@ -1,0 +1,166 @@
+// file: pkg/cache/providers/memcached.go
+// version: 1.0.0
+// guid: e1f2a3b4-c5d6-47e8-9f0a-b1c2d3e4f5a6
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/jdfalk/gcommon/pkg/cache/metrics"
+	cachepb "github.com/jdfalk/gcommon/pkg/cache/proto"
+	cachetypes "github.com/jdfalk/gcommon/pkg/cache/types"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// MemcachedCache implements Cache using a memcached backend.
+//
+// NOTE: This is a basic implementation and does not cover the entire
+// memcached feature set. More advanced features should be added.
+type MemcachedCache struct {
+	client  *memcache.Client
+	metrics *metrics.Collector
+}
+
+// NewMemcachedCache creates a new MemcachedCache. If client is nil, it will
+// connect to a local memcached instance at 127.0.0.1:11211.
+func NewMemcachedCache(client *memcache.Client) *MemcachedCache {
+	if client == nil {
+		client = memcache.New("127.0.0.1:11211")
+	}
+	return &MemcachedCache{client: client, metrics: &metrics.Collector{}}
+}
+
+// Get retrieves a value by key.
+func (m *MemcachedCache) Get(ctx context.Context, key string) (any, error) {
+	it, err := m.client.Get(key)
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		m.metrics.Miss()
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	m.metrics.Hit()
+	return it.Value, nil
+}
+
+// Set stores a value with optional TTL.
+func (m *MemcachedCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("memcached only supports byte values")
+	}
+	return m.client.Set(&memcache.Item{Key: key, Value: b, Expiration: int32(ttl.Seconds())})
+}
+
+// Delete removes a key.
+func (m *MemcachedCache) Delete(ctx context.Context, key string) error {
+	err := m.client.Delete(key)
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		return nil
+	}
+	return err
+}
+
+// Exists checks if a key exists.
+func (m *MemcachedCache) Exists(ctx context.Context, key string) (bool, error) {
+	_, err := m.client.Get(key)
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		m.metrics.Miss()
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	m.metrics.Hit()
+	return true, nil
+}
+
+// Clear flushes all keys from memcached.
+func (m *MemcachedCache) Clear(ctx context.Context) error {
+	return m.client.FlushAll()
+}
+
+// GetStats returns cache statistics collected locally.
+func (m *MemcachedCache) GetStats() *cachepb.CacheStats {
+	stats := m.metrics.Stats()
+	return cachepb.CacheStats_builder{CacheHits: gproto.Int64(stats.Hits), CacheMisses: gproto.Int64(stats.Misses)}.Build()
+}
+
+// GetMultiple retrieves multiple values by keys.
+func (m *MemcachedCache) GetMultiple(ctx context.Context, keys []string) (map[string]any, error) {
+	items, err := m.client.GetMulti(keys)
+	if err != nil {
+		return nil, err
+	}
+	res := make(map[string]any, len(items))
+	for k, it := range items {
+		res[k] = it.Value
+		m.metrics.Hit()
+	}
+	// memcache library does not return missing keys, count misses
+	m.metrics.Miss()
+	return res, nil
+}
+
+// SetMultiple stores multiple key-value pairs.
+func (m *MemcachedCache) SetMultiple(ctx context.Context, items map[string]cachetypes.CacheItem) error {
+	for k, it := range items {
+		if err := m.Set(ctx, k, it.Value, it.TTL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteMultiple removes multiple keys.
+func (m *MemcachedCache) DeleteMultiple(ctx context.Context, keys []string) error {
+	for _, k := range keys {
+		if err := m.Delete(ctx, k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Increment increments a counter and returns the new value.
+func (m *MemcachedCache) Increment(ctx context.Context, key string, n int64) (int64, error) {
+	val, err := m.client.Increment(key, uint64(n))
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		// memcache can't auto-create on increment with expiration, so set initial
+		if err := m.client.Set(&memcache.Item{Key: key, Value: []byte("0")}); err != nil {
+			return 0, err
+		}
+		val, err = m.client.Increment(key, uint64(n))
+	}
+	return int64(val), err
+}
+
+// Decrement decrements a counter and returns the new value.
+func (m *MemcachedCache) Decrement(ctx context.Context, key string, n int64) (int64, error) {
+	val, err := m.client.Decrement(key, uint64(n))
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		if err := m.client.Set(&memcache.Item{Key: key, Value: []byte("0")}); err != nil {
+			return 0, err
+		}
+		val, err = m.client.Decrement(key, uint64(n))
+	}
+	return int64(val), err
+}
+
+// Keys returns an error as memcached does not support listing keys.
+func (m *MemcachedCache) Keys(ctx context.Context, pattern string) ([]string, error) {
+	return nil, errors.New("memcached: keys listing not supported")
+}
+
+// Flush flushes the cache.
+func (m *MemcachedCache) Flush(ctx context.Context) error { return m.client.FlushAll() }
+
+// TouchExpiration updates the TTL for a key.
+func (m *MemcachedCache) TouchExpiration(ctx context.Context, key string, ttl time.Duration) error {
+	return m.client.Touch(key, int32(ttl.Seconds()))
+}

--- a/pkg/cache/providers/memcached_test.go
+++ b/pkg/cache/providers/memcached_test.go
@@ -1,0 +1,39 @@
+// file: pkg/cache/providers/memcached_test.go
+// version: 1.0.0
+// guid: f2a3b4c5-d6e7-48f9-0a1b-2c3d4e5f6a7b
+
+package providers
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+// TestMemcachedCache_GetSet verifies basic operations with a real memcached server.
+func TestMemcachedCache_GetSet(t *testing.T) {
+	cmd := exec.Command("memcached", "-p", "11212")
+	if err := cmd.Start(); err != nil {
+		t.Skip("memcached not installed")
+	}
+	defer cmd.Process.Kill()
+	time.Sleep(500 * time.Millisecond)
+
+	client := memcache.New("127.0.0.1:11212")
+	cache := NewMemcachedCache(client)
+	ctx := context.Background()
+
+	if err := cache.Set(ctx, "k", []byte("v"), time.Minute); err != nil {
+		t.Skipf("memcached not available: %v", err)
+	}
+	val, err := cache.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(val.([]byte)) != "v" {
+		t.Fatalf("expected v got %v", val)
+	}
+}

--- a/pkg/cache/providers/redis.go
+++ b/pkg/cache/providers/redis.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/providers/redis.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c2d3e4f5-a6b7-48c9-0d1e-2f3a4b5c6d7e
 
 package providers
@@ -11,6 +11,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/jdfalk/gcommon/pkg/cache/metrics"
 	cachepb "github.com/jdfalk/gcommon/pkg/cache/proto"
+	cachetypes "github.com/jdfalk/gcommon/pkg/cache/types"
 	gproto "google.golang.org/protobuf/proto"
 )
 
@@ -75,4 +76,62 @@ func (r *RedisCache) Clear(ctx context.Context) error {
 func (r *RedisCache) GetStats() *cachepb.CacheStats {
 	stats := r.metrics.Stats()
 	return cachepb.CacheStats_builder{CacheHits: gproto.Int64(stats.Hits), CacheMisses: gproto.Int64(stats.Misses)}.Build()
+}
+
+// GetMultiple retrieves multiple values.
+func (r *RedisCache) GetMultiple(ctx context.Context, keys []string) (map[string]any, error) {
+	vals, err := r.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, err
+	}
+	res := make(map[string]any)
+	for i, v := range vals {
+		if v != nil {
+			res[keys[i]] = v
+			r.metrics.Hit()
+		} else {
+			r.metrics.Miss()
+		}
+	}
+	return res, nil
+}
+
+// SetMultiple sets multiple key-value pairs.
+func (r *RedisCache) SetMultiple(ctx context.Context, items map[string]cachetypes.CacheItem) error {
+	pipe := r.client.TxPipeline()
+	for k, it := range items {
+		pipe.Set(ctx, k, it.Value, it.TTL)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// DeleteMultiple deletes multiple keys.
+func (r *RedisCache) DeleteMultiple(ctx context.Context, keys []string) error {
+	return r.client.Del(ctx, keys...).Err()
+}
+
+// Increment increments by n.
+func (r *RedisCache) Increment(ctx context.Context, key string, n int64) (int64, error) {
+	return r.client.IncrBy(ctx, key, n).Result()
+}
+
+// Decrement decrements by n.
+func (r *RedisCache) Decrement(ctx context.Context, key string, n int64) (int64, error) {
+	return r.client.DecrBy(ctx, key, n).Result()
+}
+
+// Keys lists keys matching pattern.
+func (r *RedisCache) Keys(ctx context.Context, pattern string) ([]string, error) {
+	return r.client.Keys(ctx, pattern).Result()
+}
+
+// Flush flushes database.
+func (r *RedisCache) Flush(ctx context.Context) error {
+	return r.client.FlushDB(ctx).Err()
+}
+
+// TouchExpiration updates TTL of key.
+func (r *RedisCache) TouchExpiration(ctx context.Context, key string, ttl time.Duration) error {
+	return r.client.Expire(ctx, key, ttl).Err()
 }

--- a/pkg/cache/providers/redis_test.go
+++ b/pkg/cache/providers/redis_test.go
@@ -1,5 +1,5 @@
 // file: pkg/cache/providers/redis_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e0f1a2b3-c4d5-46e7-8f9a-0b1c2d3e4f5a
 
 package providers
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
+	cachetypes "github.com/jdfalk/gcommon/pkg/cache/types"
 )
 
 // TestRedisCache_GetSet verifies basic operations.
@@ -34,5 +35,26 @@ func TestRedisCache_GetSet(t *testing.T) {
 	}
 	if val != "v" {
 		t.Fatalf("expected 'v', got %v", val)
+	}
+}
+
+// TestRedisCache_Batch verifies batch operations.
+func TestRedisCache_Batch(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	cache := NewRedisCache(client)
+	ctx := context.Background()
+
+	items := map[string]cachetypes.CacheItem{
+		"a": {Value: "1", TTL: 0},
+		"b": {Value: "2", TTL: 0},
+	}
+	if err := cache.SetMultiple(ctx, items); err != nil {
+		t.Fatalf("set multiple: %v", err)
+	}
+	vals, err := cache.GetMultiple(ctx, []string{"a", "b"})
+	if err != nil || len(vals) != 2 {
+		t.Fatalf("get multiple failed")
 	}
 }

--- a/pkg/cache/types/item.go
+++ b/pkg/cache/types/item.go
@@ -1,0 +1,13 @@
+// file: pkg/cache/types/item.go
+// version: 1.0.0
+// guid: a3b4c5d6-e7f8-49a0-b1c2-d3e4f5a6b7c8
+
+package types
+
+import "time"
+
+// CacheItem represents a cache item for bulk operations.
+type CacheItem struct {
+	Value any
+	TTL   time.Duration
+}


### PR DESCRIPTION
## Summary
- add memcached cache provider and basic implementation
- extend cache interfaces and gRPC service with batch and counter operations
- document memcached support and update cache issue

## Testing
- `go test ./pkg/cache/... -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68992d6e41388321a3e93af2f786d385