### PR TITLE
feat(organization): scaffold multi-tenant service layer

### DIFF
--- a/.github/doc-updates/0428b2af-251b-4305-8dd5-6a865c8e90ac.json
+++ b/.github/doc-updates/0428b2af-251b-4305-8dd5-6a865c8e90ac.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Implemented organization service layer with tenant, hierarchy, and team management",
+  "guid": "0428b2af-251b-4305-8dd5-6a865c8e90ac",
+  "created_at": "2025-08-10T23:45:24Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/8a7a1827-9197-46f9-a651-684704515662.json
+++ b/.github/doc-updates/8a7a1827-9197-46f9-a651-684704515662.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "It now includes a comprehensive organization module for multi-tenant management.",
+  "guid": "8a7a1827-9197-46f9-a651-684704515662",
+  "created_at": "2025-08-10T23:45:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/401d6972-e451-4e8e-ae3f-1bde8c5a9fda.json
+++ b/.github/issue-updates/401d6972-e451-4e8e-ae3f-1bde8c5a9fda.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Implement organization service layer",
+  "body": "Implement organization module with tenant, hierarchy, team management, and gRPC services",
+  "labels": ["module:organization", "type:enhancement"],
+  "guid": "401d6972-e451-4e8e-ae3f-1bde8c5a9fda",
+  "legacy_guid": "create-implement-organization-service-layer-2025-08-10",
+  "created_at": "2025-08-10T23:41:35.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/organization/examples/hierarchy.go
+++ b/pkg/organization/examples/hierarchy.go
@@ -1,0 +1,27 @@
+// file: pkg/organization/examples/hierarchy.go
+// version: 1.0.0
+// guid: f685d855-7fdf-4026-b36e-caa18267d1e0
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/organization/hierarchy"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// ExampleHierarchy demonstrates building a simple organization hierarchy.
+func ExampleHierarchy() {
+	ctx := context.Background()
+	tree := hierarchy.NewTree()
+	root := (&orgpb.HierarchyNode_builder{Id: gproto.String("root"), ParentId: gproto.String("")}).Build()
+	_ = tree.CreateNode(ctx, root)
+	dept := (&orgpb.HierarchyNode_builder{Id: gproto.String("dept1"), ParentId: gproto.String("root")}).Build()
+	_ = tree.CreateNode(ctx, dept)
+	children, _ := tree.GetChildren(ctx, "root")
+	fmt.Printf("children: %d\n", len(children))
+	// Output: children: 1
+}

--- a/pkg/organization/examples/team_setup.go
+++ b/pkg/organization/examples/team_setup.go
@@ -1,0 +1,25 @@
+// file: pkg/organization/examples/team_setup.go
+// version: 1.0.0
+// guid: 3fa73561-d864-472e-aae8-bc2faf95a90f
+
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/organization/teams"
+)
+
+// ExampleTeamSetup demonstrates creating a team and managing membership.
+func ExampleTeamSetup() {
+	ctx := context.Background()
+	tm := teams.NewManager()
+	team := &teams.Team{ID: "t1", Name: "TeamOne"}
+	_ = tm.CreateTeam(ctx, team)
+	_ = tm.AddMember(ctx, "t1", "user1", teams.RoleOwner)
+	_ = tm.AddMember(ctx, "t1", "user2", teams.RoleMember)
+	members, _ := tm.Members(ctx, "t1")
+	fmt.Printf("members: %d\n", len(members))
+	// Output: members: 2
+}

--- a/pkg/organization/factory.go
+++ b/pkg/organization/factory.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/factory.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b80b967-fa14-4400-8c4e-cd7d63efd1bd
 
 // Package organization exposes constructors for service implementations.
@@ -7,6 +7,7 @@ package organization
 
 import (
 	"github.com/jdfalk/gcommon/pkg/organization/hierarchy"
+	"github.com/jdfalk/gcommon/pkg/organization/teams"
 	"github.com/jdfalk/gcommon/pkg/organization/tenant"
 )
 
@@ -14,6 +15,7 @@ import (
 type Services struct {
 	Tenant    TenantManager
 	Hierarchy HierarchyManager
+	Teams     TeamManager
 }
 
 // NewServices returns initialized organization service implementations.
@@ -21,5 +23,6 @@ func NewServices() *Services {
 	return &Services{
 		Tenant:    tenant.NewManager(),
 		Hierarchy: hierarchy.NewTree(),
+		Teams:     teams.NewManager(),
 	}
 }

--- a/pkg/organization/grpc/hierarchy_service.go
+++ b/pkg/organization/grpc/hierarchy_service.go
@@ -1,0 +1,43 @@
+// file: pkg/organization/grpc/hierarchy_service.go
+// version: 1.1.0
+// guid: 945d140a-9706-44d2-b754-2e7eb48e2ee0
+
+// Package grpc implements hierarchy gRPC services.
+package grpc
+
+import (
+	"context"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// HierarchyService implements HierarchyServiceServer.
+type HierarchyService struct {
+	orgpb.UnimplementedHierarchyServiceServer
+}
+
+// NewHierarchyService returns a stub HierarchyService.
+// TODO: Implement full hierarchy management.
+func NewHierarchyService() *HierarchyService { return &HierarchyService{} }
+
+func (s *HierarchyService) CreateDepartment(context.Context, *orgpb.CreateDepartmentRequest) (*orgpb.CreateDepartmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "CreateDepartment not implemented")
+}
+
+func (s *HierarchyService) GetDepartment(context.Context, *orgpb.GetDepartmentRequest) (*orgpb.GetDepartmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetDepartment not implemented")
+}
+
+func (s *HierarchyService) UpdateDepartment(context.Context, *orgpb.UpdateDepartmentRequest) (*orgpb.UpdateDepartmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "UpdateDepartment not implemented")
+}
+
+func (s *HierarchyService) DeleteDepartment(context.Context, *orgpb.DeleteDepartmentRequest) (*orgpb.DeleteDepartmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "DeleteDepartment not implemented")
+}
+
+func (s *HierarchyService) ListDepartments(context.Context, *orgpb.ListDepartmentsRequest) (*orgpb.ListDepartmentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ListDepartments not implemented")
+}

--- a/pkg/organization/grpc/org_service.go
+++ b/pkg/organization/grpc/org_service.go
@@ -1,0 +1,67 @@
+// file: pkg/organization/grpc/org_service.go
+// version: 1.1.0
+// guid: 9fe51dbb-bbe9-40d4-9d9c-dff684494e8d
+
+// Package grpc provides OrganizationService gRPC server implementations.
+package grpc
+
+import (
+	"context"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// OrganizationService implements OrganizationServiceServer.
+type OrganizationService struct {
+	orgpb.UnimplementedOrganizationServiceServer
+}
+
+// NewOrganizationService returns a stub OrganizationService.
+// TODO: Implement full organization management logic.
+func NewOrganizationService() *OrganizationService { return &OrganizationService{} }
+
+func (s *OrganizationService) CreateOrganization(context.Context, *orgpb.CreateOrganizationRequest) (*orgpb.CreateOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "CreateOrganization not implemented")
+}
+
+func (s *OrganizationService) GetOrganization(context.Context, *orgpb.GetOrganizationRequest) (*orgpb.GetOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetOrganization not implemented")
+}
+
+func (s *OrganizationService) UpdateOrganization(context.Context, *orgpb.UpdateOrganizationRequest) (*orgpb.UpdateOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "UpdateOrganization not implemented")
+}
+
+func (s *OrganizationService) DeleteOrganization(context.Context, *orgpb.DeleteOrganizationRequest) (*orgpb.DeleteOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "DeleteOrganization not implemented")
+}
+
+func (s *OrganizationService) ListOrganizations(context.Context, *orgpb.ListOrganizationsRequest) (*orgpb.ListOrganizationsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ListOrganizations not implemented")
+}
+
+func (s *OrganizationService) AddMember(context.Context, *orgpb.AddMemberRequest) (*orgpb.AddMemberResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "AddMember not implemented")
+}
+
+func (s *OrganizationService) RemoveMember(context.Context, *orgpb.RemoveMemberRequest) (*orgpb.RemoveMemberResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "RemoveMember not implemented")
+}
+
+func (s *OrganizationService) UpdateMember(context.Context, *orgpb.UpdateMemberRequest) (*orgpb.UpdateMemberResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "UpdateMember not implemented")
+}
+
+func (s *OrganizationService) ListMembers(context.Context, *orgpb.ListMembersRequest) (*orgpb.ListMembersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ListMembers not implemented")
+}
+
+func (s *OrganizationService) GetOrganizationSettings(context.Context, *orgpb.GetOrganizationSettingsRequest) (*orgpb.GetOrganizationSettingsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetOrganizationSettings not implemented")
+}
+
+func (s *OrganizationService) UpdateOrganizationSettings(context.Context, *orgpb.UpdateOrganizationSettingsRequest) (*orgpb.UpdateOrganizationSettingsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "UpdateOrganizationSettings not implemented")
+}

--- a/pkg/organization/grpc/server.go
+++ b/pkg/organization/grpc/server.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/grpc/server.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a6b4ad3-d481-47d1-9ba2-fa0a391e287b
 
 package grpc
@@ -10,6 +10,8 @@ import (
 )
 
 // Register registers organization gRPC services with the server.
-func Register(s *grpc.Server, ts orgpb.TenantServiceServer) {
+func Register(s *grpc.Server, ts orgpb.TenantServiceServer, os orgpb.OrganizationServiceServer, hs orgpb.HierarchyServiceServer) {
 	orgpb.RegisterTenantServiceServer(s, ts)
+	orgpb.RegisterOrganizationServiceServer(s, os)
+	orgpb.RegisterHierarchyServiceServer(s, hs)
 }

--- a/pkg/organization/hierarchy/inheritance.go
+++ b/pkg/organization/hierarchy/inheritance.go
@@ -1,0 +1,104 @@
+// file: pkg/organization/hierarchy/inheritance.go
+// version: 1.0.0
+// guid: d6d5b61f-068c-4c52-87de-4dc3e9509afa
+
+// Package hierarchy provides permission inheritance utilities for organization structures.
+package hierarchy
+
+import (
+	"context"
+	"errors"
+)
+
+// InheritanceResolver resolves effective permissions for principals considering hierarchy relationships.
+type InheritanceResolver struct {
+	Tree        *Tree
+	Permissions *PermissionManager
+}
+
+// NewInheritanceResolver returns a resolver with provided tree and permission manager.
+func NewInheritanceResolver(t *Tree, pm *PermissionManager) *InheritanceResolver {
+	return &InheritanceResolver{Tree: t, Permissions: pm}
+}
+
+// EffectivePermissions returns the accumulated permissions for a principal at the specified node.
+// It traverses up the hierarchy to aggregate inherited permissions.
+func (r *InheritanceResolver) EffectivePermissions(ctx context.Context, nodeID, principal string) (PermissionSet, error) {
+	if r.Tree == nil || r.Permissions == nil {
+		return nil, errors.New("resolver not initialized")
+	}
+	result := NewPermissionSet()
+	current := nodeID
+	for current != "" {
+		pset, err := r.Permissions.Permissions(ctx, current, principal)
+		if err == nil {
+			result.Add(pset.AsSlice()...)
+		}
+		node, err := r.Tree.GetNode(ctx, current)
+		if err != nil {
+			break
+		}
+		current = node.GetParentId()
+	}
+	return result, nil
+}
+
+// HasPermission checks if the principal has the specified permission at the node considering inheritance.
+func (r *InheritanceResolver) HasPermission(ctx context.Context, nodeID, principal string, perm Permission) (bool, error) {
+	perms, err := r.EffectivePermissions(ctx, nodeID, principal)
+	if err != nil {
+		return false, err
+	}
+	return perms.Has(perm), nil
+}
+
+// Inherit assigns permissions from parent to child node for a principal.
+// This function copies current permissions of the principal on the parent node and grants them to the child.
+func (r *InheritanceResolver) Inherit(ctx context.Context, parentID, childID, principal string) error {
+	if parentID == "" || childID == "" {
+		return errors.New("missing parent or child id")
+	}
+	pset, err := r.Permissions.Permissions(ctx, parentID, principal)
+	if err != nil {
+		return err
+	}
+	return r.Permissions.Grant(ctx, childID, principal, pset)
+}
+
+// RevokeInherited removes permissions on a child that were inherited from the parent.
+// It determines the parent's permissions and revokes them from the child node.
+func (r *InheritanceResolver) RevokeInherited(ctx context.Context, parentID, childID, principal string) error {
+	pset, err := r.Permissions.Permissions(ctx, parentID, principal)
+	if err != nil {
+		return err
+	}
+	return r.Permissions.Revoke(ctx, childID, principal, pset)
+}
+
+// Sync ensures that child nodes mirror the parent's permissions for the principal.
+// Any additional permissions on the child not present on parent are removed.
+func (r *InheritanceResolver) Sync(ctx context.Context, parentID, childID, principal string) error {
+	parentSet, err := r.Permissions.Permissions(ctx, parentID, principal)
+	if err != nil {
+		return err
+	}
+	childSet, err := r.Permissions.Permissions(ctx, childID, principal)
+	if err != nil {
+		return err
+	}
+	// Revoke permissions on child not present on parent
+	for p := range childSet {
+		if !parentSet.Has(p) {
+			childSet.Remove(p)
+		}
+	}
+	// Grant missing permissions from parent
+	for p := range parentSet {
+		if !childSet.Has(p) {
+			childSet.Add(p)
+		}
+	}
+	// Clear current assignment and set updated permissions
+	r.Permissions.Clear(ctx, childID, principal)
+	return r.Permissions.Grant(ctx, childID, principal, childSet)
+}

--- a/pkg/organization/hierarchy/permissions.go
+++ b/pkg/organization/hierarchy/permissions.go
@@ -1,0 +1,152 @@
+// file: pkg/organization/hierarchy/permissions.go
+// version: 1.0.0
+// guid: 9ba185ed-256c-40f9-987d-5a1b3e027aa4
+
+// Package hierarchy implements hierarchical permission management.
+package hierarchy
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Permission defines an action that can be performed within the hierarchy.
+type Permission string
+
+const (
+	// PermRead allows read access to a node.
+	PermRead Permission = "read"
+	// PermWrite allows write access to a node.
+	PermWrite Permission = "write"
+	// PermAdmin allows administrative actions on a node.
+	PermAdmin Permission = "admin"
+)
+
+// PermissionSet represents a collection of permissions.
+type PermissionSet map[Permission]struct{}
+
+// NewPermissionSet creates a PermissionSet from a list of permissions.
+func NewPermissionSet(perms ...Permission) PermissionSet {
+	ps := make(PermissionSet)
+	for _, p := range perms {
+		ps[p] = struct{}{}
+	}
+	return ps
+}
+
+// Has reports whether the permission set contains the permission.
+func (ps PermissionSet) Has(p Permission) bool {
+	_, ok := ps[p]
+	return ok
+}
+
+// Add inserts permissions into the set.
+func (ps PermissionSet) Add(perms ...Permission) {
+	for _, p := range perms {
+		ps[p] = struct{}{}
+	}
+}
+
+// Remove deletes permissions from the set.
+func (ps PermissionSet) Remove(perms ...Permission) {
+	for _, p := range perms {
+		delete(ps, p)
+	}
+}
+
+// Copy returns a shallow copy of the permission set.
+func (ps PermissionSet) Copy() PermissionSet {
+	cp := make(PermissionSet)
+	for p := range ps {
+		cp[p] = struct{}{}
+	}
+	return cp
+}
+
+// PermissionManager stores permissions per hierarchy node and principal.
+type PermissionManager struct {
+	mu          sync.RWMutex
+	assignments map[string]map[string]PermissionSet // nodeID -> principal -> perms
+}
+
+// NewPermissionManager returns an initialized PermissionManager.
+func NewPermissionManager() *PermissionManager {
+	return &PermissionManager{assignments: make(map[string]map[string]PermissionSet)}
+}
+
+// Grant adds permissions for the principal on the node.
+func (m *PermissionManager) Grant(ctx context.Context, nodeID, principal string, perms PermissionSet) error {
+	if nodeID == "" || principal == "" {
+		return errors.New("missing node or principal")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.assignments[nodeID]; !ok {
+		m.assignments[nodeID] = make(map[string]PermissionSet)
+	}
+	if _, ok := m.assignments[nodeID][principal]; !ok {
+		m.assignments[nodeID][principal] = make(PermissionSet)
+	}
+	m.assignments[nodeID][principal].Add(perms.AsSlice()...)
+	return nil
+}
+
+// Revoke removes permissions for the principal on the node.
+func (m *PermissionManager) Revoke(ctx context.Context, nodeID, principal string, perms PermissionSet) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	principals, ok := m.assignments[nodeID]
+	if !ok {
+		return errors.New("node not found")
+	}
+	pset, ok := principals[principal]
+	if !ok {
+		return errors.New("principal not found")
+	}
+	pset.Remove(perms.AsSlice()...)
+	if len(pset) == 0 {
+		delete(principals, principal)
+	}
+	return nil
+}
+
+// Permissions retrieves permissions for a principal on a node.
+func (m *PermissionManager) Permissions(ctx context.Context, nodeID, principal string) (PermissionSet, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	principals, ok := m.assignments[nodeID]
+	if !ok {
+		return nil, errors.New("node not found")
+	}
+	pset, ok := principals[principal]
+	if !ok {
+		return nil, errors.New("principal not found")
+	}
+	return pset.Copy(), nil
+}
+
+// Clear removes all permissions for a node or, if principal provided, for that principal on the node.
+func (m *PermissionManager) Clear(ctx context.Context, nodeID, principal string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if principal == "" {
+		delete(m.assignments, nodeID)
+		return
+	}
+	if principals, ok := m.assignments[nodeID]; ok {
+		delete(principals, principal)
+		if len(principals) == 0 {
+			delete(m.assignments, nodeID)
+		}
+	}
+}
+
+// AsSlice converts the permission set into a slice.
+func (ps PermissionSet) AsSlice() []Permission {
+	result := make([]Permission, 0, len(ps))
+	for p := range ps {
+		result = append(result, p)
+	}
+	return result
+}

--- a/pkg/organization/hierarchy/tree_test.go
+++ b/pkg/organization/hierarchy/tree_test.go
@@ -1,0 +1,46 @@
+// file: pkg/organization/hierarchy/tree_test.go
+// version: 1.0.0
+// guid: 4cbcec60-0989-4ed3-818a-f0a4208d4f9a
+
+package hierarchy
+
+import (
+	"context"
+	"testing"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// TestTree_BasicOperations verifies basic node operations.
+func TestTree_BasicOperations(t *testing.T) {
+	// Setup
+	tree := NewTree()
+	ctx := context.Background()
+	root := (&orgpb.HierarchyNode_builder{Id: gproto.String("root"), ParentId: gproto.String("")}).Build()
+	if err := tree.CreateNode(ctx, root); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	child := (&orgpb.HierarchyNode_builder{Id: gproto.String("child"), ParentId: gproto.String("root")}).Build()
+	if err := tree.CreateNode(ctx, child); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	// Exercise
+	if err := tree.MoveNode(ctx, "child", ""); err != nil {
+		t.Fatalf("move node: %v", err)
+	}
+
+	// Verify
+	got, err := tree.GetNode(ctx, "child")
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got.GetParentId() != "" {
+		t.Fatalf("expected parent '', got %s", got.GetParentId())
+	}
+	children, _ := tree.GetChildren(ctx, "root")
+	if len(children) != 0 {
+		t.Fatalf("expected no children")
+	}
+}

--- a/pkg/organization/interfaces.go
+++ b/pkg/organization/interfaces.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 674239c9-d92a-4b83-9ec8-c88c1b3dd040
 
 // Package organization provides service interfaces for managing organizations.
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	"github.com/jdfalk/gcommon/pkg/organization/teams"
 )
 
 // TenantManager defines operations for tenant lifecycle management.
@@ -26,4 +27,18 @@ type HierarchyManager interface {
 	GetNode(ctx context.Context, nodeID string) (*orgpb.HierarchyNode, error)
 	GetChildren(ctx context.Context, parentID string) ([]*orgpb.HierarchyNode, error)
 	MoveNode(ctx context.Context, nodeID, newParentID string) error
+}
+
+// TeamManager defines operations for team management.
+type TeamManager interface {
+	CreateTeam(ctx context.Context, team *teams.Team) error
+	GetTeam(ctx context.Context, teamID string) (*teams.Team, error)
+	UpdateTeam(ctx context.Context, team *teams.Team) error
+	DeleteTeam(ctx context.Context, teamID string) error
+	ListTeams(ctx context.Context) ([]*teams.Team, error)
+	AddMember(ctx context.Context, teamID, userID string, role teams.Role) error
+	RemoveMember(ctx context.Context, teamID, userID string) error
+	UpdateMemberRole(ctx context.Context, teamID, userID string, role teams.Role) error
+	Members(ctx context.Context, teamID string) ([]*teams.Member, error)
+	RoleOf(ctx context.Context, teamID, userID string) (teams.Role, error)
 }

--- a/pkg/organization/policies/data.go
+++ b/pkg/organization/policies/data.go
@@ -1,0 +1,72 @@
+// file: pkg/organization/policies/data.go
+// version: 1.0.0
+// guid: 077dc19f-a8ca-435c-8ef8-fc00cb359db1
+
+// Package policies defines data governance rules for organizations.
+package policies
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// DataPolicy enforces data retention and locality rules.
+type DataPolicy struct {
+	RetentionPeriod time.Duration
+	AllowedRegions  []string
+}
+
+// DataPolicyManager manages policies per tenant.
+type DataPolicyManager struct {
+	mu       sync.RWMutex
+	policies map[string]*DataPolicy
+}
+
+// NewDataPolicyManager creates a manager instance.
+func NewDataPolicyManager() *DataPolicyManager {
+	return &DataPolicyManager{policies: make(map[string]*DataPolicy)}
+}
+
+// SetPolicy sets the data policy for a tenant.
+func (m *DataPolicyManager) SetPolicy(ctx context.Context, tenantID string, p *DataPolicy) error {
+	if tenantID == "" || p == nil {
+		return errors.New("invalid input")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.policies[tenantID] = p
+	return nil
+}
+
+// GetPolicy retrieves the data policy for a tenant.
+func (m *DataPolicyManager) GetPolicy(ctx context.Context, tenantID string) (*DataPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	p, ok := m.policies[tenantID]
+	if !ok {
+		return nil, errors.New("policy not found")
+	}
+	cp := *p
+	return &cp, nil
+}
+
+// Enforce checks whether data access complies with policy.
+func (m *DataPolicyManager) Enforce(ctx context.Context, tenantID, region string, created time.Time) error {
+	m.mu.RLock()
+	p, ok := m.policies[tenantID]
+	m.mu.RUnlock()
+	if !ok {
+		return errors.New("policy not found")
+	}
+	if time.Since(created) > p.RetentionPeriod {
+		return errors.New("data retention exceeded")
+	}
+	for _, r := range p.AllowedRegions {
+		if r == region {
+			return nil
+		}
+	}
+	return errors.New("region not allowed")
+}

--- a/pkg/organization/policies/security.go
+++ b/pkg/organization/policies/security.go
@@ -1,0 +1,59 @@
+// file: pkg/organization/policies/security.go
+// version: 1.0.0
+// guid: 9ba15281-3de3-4379-86e4-30d38df290e2
+
+// Package policies contains security policy enforcement for organizations.
+package policies
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+// SecurityPolicy defines cross-tenant security restrictions.
+type SecurityPolicy struct {
+	AllowedHashes []string
+}
+
+// SecurityManager stores security policies per tenant and verifies access tokens.
+type SecurityManager struct {
+	mu       sync.RWMutex
+	policies map[string]*SecurityPolicy
+}
+
+// NewSecurityManager returns an initialized manager.
+func NewSecurityManager() *SecurityManager {
+	return &SecurityManager{policies: make(map[string]*SecurityPolicy)}
+}
+
+// SetPolicy sets the security policy for a tenant.
+func (m *SecurityManager) SetPolicy(ctx context.Context, tenantID string, p *SecurityPolicy) error {
+	if tenantID == "" || p == nil {
+		return errors.New("invalid input")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.policies[tenantID] = p
+	return nil
+}
+
+// ValidateToken verifies that the token hash is allowed for the tenant.
+func (m *SecurityManager) ValidateToken(ctx context.Context, tenantID, token string) error {
+	m.mu.RLock()
+	p, ok := m.policies[tenantID]
+	m.mu.RUnlock()
+	if !ok {
+		return errors.New("policy not found")
+	}
+	h := sha256.Sum256([]byte(token))
+	hash := hex.EncodeToString(h[:])
+	for _, allowed := range p.AllowedHashes {
+		if hash == allowed {
+			return nil
+		}
+	}
+	return errors.New("token not allowed")
+}

--- a/pkg/organization/teams/manager.go
+++ b/pkg/organization/teams/manager.go
@@ -1,9 +1,135 @@
 // file: pkg/organization/teams/manager.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 06c314f0-0e40-4ac7-8c2e-ce2577b0905a
 
-// Package teams provides placeholders for team management functionality.
+// Package teams implements in-memory team management services.
 package teams
 
-// This file intentionally left minimal; full team management is pending
-// future implementation.
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Team represents a collection of users.
+type Team struct {
+	ID   string
+	Name string
+}
+
+// Manager provides team CRUD operations and membership management.
+type Manager struct {
+	mu         sync.RWMutex
+	teams      map[string]*Team
+	membership *MembershipManager
+}
+
+// NewManager returns a Manager with initialized maps and membership manager.
+func NewManager() *Manager {
+	return &Manager{
+		teams:      make(map[string]*Team),
+		membership: NewMembershipManager(),
+	}
+}
+
+// CreateTeam stores a team definition.
+func (m *Manager) CreateTeam(ctx context.Context, team *Team) error {
+	if team == nil || team.ID == "" {
+		return errors.New("missing team id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.teams[team.ID]; exists {
+		return errors.New("team exists")
+	}
+	m.teams[team.ID] = team
+	return nil
+}
+
+// GetTeam retrieves a team by ID.
+func (m *Manager) GetTeam(ctx context.Context, teamID string) (*Team, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.teams[teamID]
+	if !ok {
+		return nil, errors.New("team not found")
+	}
+	return t, nil
+}
+
+// UpdateTeam updates a team name.
+func (m *Manager) UpdateTeam(ctx context.Context, team *Team) error {
+	if team == nil || team.ID == "" {
+		return errors.New("missing team id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.teams[team.ID]; !ok {
+		return errors.New("team not found")
+	}
+	m.teams[team.ID] = team
+	return nil
+}
+
+// DeleteTeam removes a team and its memberships.
+func (m *Manager) DeleteTeam(ctx context.Context, teamID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.teams[teamID]; !ok {
+		return errors.New("team not found")
+	}
+	delete(m.teams, teamID)
+	m.membership.Clear(ctx, teamID)
+	return nil
+}
+
+// ListTeams returns all stored teams.
+func (m *Manager) ListTeams(ctx context.Context) ([]*Team, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*Team, 0, len(m.teams))
+	for _, t := range m.teams {
+		result = append(result, t)
+	}
+	return result, nil
+}
+
+// AddMember adds a user to the team with the specified role.
+func (m *Manager) AddMember(ctx context.Context, teamID, userID string, role Role) error {
+	if _, err := m.GetTeam(ctx, teamID); err != nil {
+		return err
+	}
+	return m.membership.AddMember(ctx, teamID, userID, role)
+}
+
+// RemoveMember removes a user from the team.
+func (m *Manager) RemoveMember(ctx context.Context, teamID, userID string) error {
+	if _, err := m.GetTeam(ctx, teamID); err != nil {
+		return err
+	}
+	return m.membership.RemoveMember(ctx, teamID, userID)
+}
+
+// UpdateMemberRole updates the role for a team member.
+func (m *Manager) UpdateMemberRole(ctx context.Context, teamID, userID string, role Role) error {
+	if _, err := m.GetTeam(ctx, teamID); err != nil {
+		return err
+	}
+	return m.membership.UpdateRole(ctx, teamID, userID, role)
+}
+
+// Members returns a list of members for a team.
+func (m *Manager) Members(ctx context.Context, teamID string) ([]*Member, error) {
+	if _, err := m.GetTeam(ctx, teamID); err != nil {
+		return nil, err
+	}
+	return m.membership.ListMembers(ctx, teamID)
+}
+
+// RoleOf retrieves a member's role within a team.
+func (m *Manager) RoleOf(ctx context.Context, teamID, userID string) (Role, error) {
+	if _, err := m.GetTeam(ctx, teamID); err != nil {
+		return Role(""), err
+	}
+	return m.membership.RoleOf(ctx, teamID, userID)
+}

--- a/pkg/organization/teams/manager_test.go
+++ b/pkg/organization/teams/manager_test.go
@@ -1,0 +1,59 @@
+// file: pkg/organization/teams/manager_test.go
+// version: 1.0.0
+// guid: 3fb1b858-2942-41fc-870c-a61d25388ceb
+
+package teams
+
+import (
+	"context"
+	"testing"
+)
+
+// TestManager_TeamAndMembers verifies team and membership operations.
+func TestManager_TeamAndMembers(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	m := NewManager()
+	team := &Team{ID: "t1", Name: "TeamOne"}
+	if err := m.CreateTeam(ctx, team); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	// Add members
+	if err := m.AddMember(ctx, "t1", "u1", RoleOwner); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := m.AddMember(ctx, "t1", "u2", RoleMember); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	// Verify members
+	members, err := m.Members(ctx, "t1")
+	if err != nil {
+		t.Fatalf("members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members")
+	}
+
+	// Update role
+	if err := m.UpdateMemberRole(ctx, "t1", "u2", RoleAdmin); err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+	role, err := m.RoleOf(ctx, "t1", "u2")
+	if err != nil {
+		t.Fatalf("role of: %v", err)
+	}
+	if role != RoleAdmin {
+		t.Fatalf("expected admin role")
+	}
+
+	// Remove member
+	if err := m.RemoveMember(ctx, "t1", "u1"); err != nil {
+		t.Fatalf("remove member: %v", err)
+	}
+	members, _ = m.Members(ctx, "t1")
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member after removal")
+	}
+}

--- a/pkg/organization/teams/membership.go
+++ b/pkg/organization/teams/membership.go
@@ -1,0 +1,105 @@
+// file: pkg/organization/teams/membership.go
+// version: 1.0.0
+// guid: 7daa5513-0b44-45c6-a783-cf5a8b2d5fcf
+
+// Package teams provides team membership utilities.
+package teams
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Member represents a team member with a specific role.
+type Member struct {
+	UserID string
+	Role   Role
+}
+
+// MembershipManager manages team memberships in memory.
+type MembershipManager struct {
+	mu      sync.RWMutex
+	members map[string][]*Member // teamID -> members
+}
+
+// NewMembershipManager returns an initialized MembershipManager.
+func NewMembershipManager() *MembershipManager {
+	return &MembershipManager{members: make(map[string][]*Member)}
+}
+
+// AddMember adds a user to the team with the given role.
+func (m *MembershipManager) AddMember(ctx context.Context, teamID, userID string, role Role) error {
+	if teamID == "" || userID == "" {
+		return errors.New("missing team or user id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, member := range m.members[teamID] {
+		if member.UserID == userID {
+			return errors.New("member already exists")
+		}
+	}
+	m.members[teamID] = append(m.members[teamID], &Member{UserID: userID, Role: role})
+	return nil
+}
+
+// RemoveMember removes a user from the team.
+func (m *MembershipManager) RemoveMember(ctx context.Context, teamID, userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	members := m.members[teamID]
+	for i, member := range members {
+		if member.UserID == userID {
+			m.members[teamID] = append(members[:i], members[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("member not found")
+}
+
+// UpdateRole changes a member's role.
+func (m *MembershipManager) UpdateRole(ctx context.Context, teamID, userID string, role Role) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	members := m.members[teamID]
+	for _, member := range members {
+		if member.UserID == userID {
+			member.Role = role
+			return nil
+		}
+	}
+	return errors.New("member not found")
+}
+
+// ListMembers returns all members of a team.
+func (m *MembershipManager) ListMembers(ctx context.Context, teamID string) ([]*Member, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	members, ok := m.members[teamID]
+	if !ok {
+		return nil, errors.New("team not found")
+	}
+	result := make([]*Member, len(members))
+	copy(result, members)
+	return result, nil
+}
+
+// RoleOf returns the role for the specified user in the team.
+func (m *MembershipManager) RoleOf(ctx context.Context, teamID, userID string) (Role, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, member := range m.members[teamID] {
+		if member.UserID == userID {
+			return member.Role, nil
+		}
+	}
+	return Role(""), errors.New("member not found")
+}
+
+// Clear removes all members from a team.
+func (m *MembershipManager) Clear(ctx context.Context, teamID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.members, teamID)
+}

--- a/pkg/organization/teams/roles.go
+++ b/pkg/organization/teams/roles.go
@@ -1,0 +1,40 @@
+// file: pkg/organization/teams/roles.go
+// version: 1.0.0
+// guid: f49f2012-5d35-4336-848b-e8203d626289
+
+// Package teams defines team roles and utilities.
+package teams
+
+import "strings"
+
+// Role defines a team role with associated permissions.
+type Role string
+
+const (
+	// RoleMember represents standard team membership.
+	RoleMember Role = "member"
+	// RoleAdmin represents administrative team membership.
+	RoleAdmin Role = "admin"
+	// RoleOwner represents ownership of the team.
+	RoleOwner Role = "owner"
+)
+
+// ParseRole converts a string to a Role value, normalizing case.
+func ParseRole(r string) Role {
+	switch strings.ToLower(r) {
+	case "admin":
+		return RoleAdmin
+	case "owner":
+		return RoleOwner
+	default:
+		return RoleMember
+	}
+}
+
+// String returns the string representation of the role.
+func (r Role) String() string { return string(r) }
+
+// RolesEqual compares roles ignoring case.
+func RolesEqual(a, b Role) bool {
+	return strings.EqualFold(a.String(), b.String())
+}

--- a/pkg/organization/tenant/billing.go
+++ b/pkg/organization/tenant/billing.go
@@ -1,0 +1,164 @@
+// file: pkg/organization/tenant/billing.go
+// version: 1.1.0
+// guid: df9428d4-0a64-4f66-ae1c-97f16f56dcda
+
+// Package tenant provides basic billing and quota tracking for tenants.
+package tenant
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Quota defines resource limits for a tenant.
+type Quota struct {
+	CPUSeconds   int64
+	MemoryBytes  int64
+	StorageBytes int64
+	NetworkBytes int64
+}
+
+// BillingRecord captures usage and cost information for a billing period.
+type BillingRecord struct {
+	TenantID string
+	Period   time.Time
+	Usage    *Usage
+	CostUSD  float64
+}
+
+// BillingManager tracks tenant quotas, usage and billing records.
+type BillingManager struct {
+	mu      sync.RWMutex
+	quotas  map[string]*Quota
+	usage   map[string]*Usage
+	records map[string][]*BillingRecord
+	pricing PricingModel
+}
+
+// PricingModel defines cost multipliers for usage metrics.
+type PricingModel struct {
+	CPUSecondUSD   float64
+	MemoryByteUSD  float64
+	StorageByteUSD float64
+	NetworkByteUSD float64
+}
+
+// NewBillingManager returns an initialized BillingManager with default pricing.
+func NewBillingManager() *BillingManager {
+	return &BillingManager{
+		quotas:  make(map[string]*Quota),
+		usage:   make(map[string]*Usage),
+		records: make(map[string][]*BillingRecord),
+		pricing: PricingModel{
+			CPUSecondUSD:   0.001,
+			MemoryByteUSD:  0.0000001,
+			StorageByteUSD: 0.00000005,
+			NetworkByteUSD: 0.00000002,
+		},
+	}
+}
+
+// SetQuota sets resource limits for a tenant.
+func (m *BillingManager) SetQuota(ctx context.Context, tenantID string, q *Quota) error {
+	if tenantID == "" {
+		return errors.New("missing tenant id")
+	}
+	if q == nil {
+		return errors.New("missing quota")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.quotas[tenantID] = q
+	if _, ok := m.usage[tenantID]; !ok {
+		m.usage[tenantID] = &Usage{}
+	}
+	return nil
+}
+
+// AddUsage accumulates usage for the tenant and returns whether the quota has been exceeded.
+func (m *BillingManager) AddUsage(ctx context.Context, tenantID string, u *Usage) (bool, error) {
+	if u == nil {
+		return false, errors.New("missing usage")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, ok := m.usage[tenantID]
+	if !ok {
+		current = &Usage{}
+		m.usage[tenantID] = current
+	}
+	current.CpuSeconds += u.CpuSeconds
+	current.MemoryBytes += u.MemoryBytes
+	current.StorageBytes += u.StorageBytes
+	current.NetworkBytes += u.NetworkBytes
+	q, ok := m.quotas[tenantID]
+	if !ok {
+		return false, errors.New("quota not set")
+	}
+	exceeded := current.CpuSeconds > q.CPUSeconds ||
+		current.MemoryBytes > q.MemoryBytes ||
+		current.StorageBytes > q.StorageBytes ||
+		current.NetworkBytes > q.NetworkBytes
+	return exceeded, nil
+}
+
+// GenerateRecord finalizes current usage into a billing record and resets usage counters.
+func (m *BillingManager) GenerateRecord(ctx context.Context, tenantID string, period time.Time) (*BillingRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	usage, ok := m.usage[tenantID]
+	if !ok {
+		return nil, errors.New("usage not found")
+	}
+	// Calculate cost
+	cost := float64(usage.CpuSeconds)*m.pricing.CPUSecondUSD +
+		float64(usage.MemoryBytes)*m.pricing.MemoryByteUSD +
+		float64(usage.StorageBytes)*m.pricing.StorageByteUSD +
+		float64(usage.NetworkBytes)*m.pricing.NetworkByteUSD
+	record := &BillingRecord{
+		TenantID: tenantID,
+		Period:   period,
+		Usage:    usage,
+		CostUSD:  cost,
+	}
+	m.records[tenantID] = append(m.records[tenantID], record)
+	// Reset usage after generating record
+	m.usage[tenantID] = &Usage{}
+	return record, nil
+}
+
+// Records returns billing records for a tenant.
+func (m *BillingManager) Records(ctx context.Context, tenantID string) ([]*BillingRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	recs, ok := m.records[tenantID]
+	if !ok {
+		return nil, errors.New("no billing records")
+	}
+	result := make([]*BillingRecord, len(recs))
+	copy(result, recs)
+	return result, nil
+}
+
+// CurrentUsage returns the current accumulated usage for a tenant.
+func (m *BillingManager) CurrentUsage(ctx context.Context, tenantID string) (*Usage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	usage, ok := m.usage[tenantID]
+	if !ok {
+		return nil, errors.New("usage not found")
+	}
+	copy := *usage
+	return &copy, nil
+}
+
+// Remove clears all billing information for a tenant.
+func (m *BillingManager) Remove(ctx context.Context, tenantID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.quotas, tenantID)
+	delete(m.usage, tenantID)
+	delete(m.records, tenantID)
+}

--- a/pkg/organization/tenant/billing_test.go
+++ b/pkg/organization/tenant/billing_test.go
@@ -1,0 +1,41 @@
+// file: pkg/organization/tenant/billing_test.go
+// version: 1.1.0
+// guid: a6c070e9-ded4-42d6-a224-37abad83a389
+
+package tenant
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestBillingManager_QuotaAndRecord verifies quota enforcement and record generation.
+func TestBillingManager_QuotaAndRecord(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	bm := NewBillingManager()
+	quota := &Quota{CPUSeconds: 5}
+	if err := bm.SetQuota(ctx, "t1", quota); err != nil {
+		t.Fatalf("set quota: %v", err)
+	}
+	usage := &Usage{CpuSeconds: 10}
+
+	// Exercise
+	exceeded, err := bm.AddUsage(ctx, "t1", usage)
+	if err != nil {
+		t.Fatalf("add usage: %v", err)
+	}
+	if !exceeded {
+		t.Fatalf("expected quota exceeded")
+	}
+
+	// Generate record
+	rec, err := bm.GenerateRecord(ctx, "t1", time.Now())
+	if err != nil {
+		t.Fatalf("generate record: %v", err)
+	}
+	if rec.Usage.CpuSeconds != 10 {
+		t.Fatalf("expected usage 10")
+	}
+}

--- a/pkg/organization/tenant/isolation.go
+++ b/pkg/organization/tenant/isolation.go
@@ -1,0 +1,149 @@
+// file: pkg/organization/tenant/isolation.go
+// version: 1.1.0
+// guid: e0e9b8e1-fd68-4d0f-b71c-21107150ba42
+
+// Package tenant provides tenant isolation and data segregation helpers.
+package tenant
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Usage captures resource consumption metrics.
+type Usage struct {
+	CpuSeconds   int64
+	MemoryBytes  int64
+	StorageBytes int64
+	NetworkBytes int64
+}
+
+// IsolationConfig defines resource isolation rules for a tenant.
+type IsolationConfig struct {
+	// AllowedDomains enumerates domains a tenant may access.
+	AllowedDomains []string
+	// RestrictedResources lists resource identifiers the tenant cannot touch.
+	RestrictedResources []string
+	// CustomPolicies references optional policy identifiers applied to the tenant.
+	CustomPolicies []string
+}
+
+// IsolationManager manages tenant isolation configurations in memory.
+type IsolationManager struct {
+	mu      sync.RWMutex
+	configs map[string]*IsolationConfig
+	usage   map[string]*Usage
+}
+
+// NewIsolationManager creates an initialized IsolationManager.
+func NewIsolationManager() *IsolationManager {
+	return &IsolationManager{
+		configs: make(map[string]*IsolationConfig),
+		usage:   make(map[string]*Usage),
+	}
+}
+
+// Configure sets isolation rules for a tenant, replacing any existing config.
+// It also initializes usage tracking if not present.
+func (m *IsolationManager) Configure(ctx context.Context, tenantID string, cfg *IsolationConfig) error {
+	if tenantID == "" {
+		return errors.New("missing tenant id")
+	}
+	if cfg == nil {
+		return errors.New("missing isolation config")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.configs[tenantID] = cfg
+	if _, ok := m.usage[tenantID]; !ok {
+		m.usage[tenantID] = &Usage{}
+	}
+	return nil
+}
+
+// Get returns the isolation configuration for a tenant.
+func (m *IsolationManager) Get(ctx context.Context, tenantID string) (*IsolationConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cfg, ok := m.configs[tenantID]
+	if !ok {
+		return nil, errors.New("isolation config not found")
+	}
+	return cfg, nil
+}
+
+// RecordUsage updates usage statistics for a tenant.
+// This function is thread-safe and accumulates resource counts per category.
+func (m *IsolationManager) RecordUsage(ctx context.Context, tenantID string, usage *Usage) error {
+	if usage == nil {
+		return errors.New("missing usage")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, ok := m.usage[tenantID]
+	if !ok {
+		current = &Usage{}
+		m.usage[tenantID] = current
+	}
+	current.CpuSeconds += usage.CpuSeconds
+	current.MemoryBytes += usage.MemoryBytes
+	current.StorageBytes += usage.StorageBytes
+	current.NetworkBytes += usage.NetworkBytes
+	return nil
+}
+
+// Usage returns current usage statistics for a tenant.
+func (m *IsolationManager) Usage(ctx context.Context, tenantID string) (*Usage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	usage, ok := m.usage[tenantID]
+	if !ok {
+		return nil, errors.New("usage not found")
+	}
+	copy := *usage
+	return &copy, nil
+}
+
+// Enforce checks whether a resource access is permitted under the tenant's isolation rules.
+// It returns an error if the tenant attempts to access a restricted resource or domain.
+func (m *IsolationManager) Enforce(ctx context.Context, tenantID, domain, resource string) error {
+	m.mu.RLock()
+	cfg, ok := m.configs[tenantID]
+	m.mu.RUnlock()
+	if !ok {
+		return errors.New("isolation config not found")
+	}
+	for _, d := range cfg.AllowedDomains {
+		if d == domain {
+			// Domain allowed, proceed to resource check.
+			for _, r := range cfg.RestrictedResources {
+				if r == resource {
+					return errors.New("resource access denied")
+				}
+			}
+			return nil
+		}
+	}
+	return errors.New("domain access denied")
+}
+
+// Remove deletes isolation settings and usage tracking for a tenant.
+func (m *IsolationManager) Remove(ctx context.Context, tenantID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.configs, tenantID)
+	delete(m.usage, tenantID)
+	return nil
+}
+
+// List returns all tenant IDs with isolation configurations.
+func (m *IsolationManager) List(ctx context.Context) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ids := make([]string, 0, len(m.configs))
+	for id := range m.configs {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/pkg/organization/tenant/isolation_test.go
+++ b/pkg/organization/tenant/isolation_test.go
@@ -1,0 +1,56 @@
+// file: pkg/organization/tenant/isolation_test.go
+// version: 1.1.0
+// guid: ce431a3e-e0db-45c9-b44b-efe5caad3b5b
+
+package tenant
+
+import (
+	"context"
+	"testing"
+)
+
+// TestIsolationManager_ConfigAndEnforce verifies configuration and enforcement logic.
+func TestIsolationManager_ConfigAndEnforce(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	m := NewIsolationManager()
+	cfg := &IsolationConfig{AllowedDomains: []string{"example.com"}, RestrictedResources: []string{"r1"}}
+
+	// Exercise
+	if err := m.Configure(ctx, "t1", cfg); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+
+	// Verify allowed access
+	if err := m.Enforce(ctx, "t1", "example.com", "r2"); err != nil {
+		t.Fatalf("enforce allowed: %v", err)
+	}
+
+	// Verify restricted resource
+	if err := m.Enforce(ctx, "t1", "example.com", "r1"); err == nil {
+		t.Fatalf("expected restriction")
+	}
+
+	// Verify domain denial
+	if err := m.Enforce(ctx, "t1", "bad.com", "r2"); err == nil {
+		t.Fatalf("expected domain denial")
+	}
+}
+
+// TestIsolationManager_RecordUsage ensures usage is accumulated.
+func TestIsolationManager_RecordUsage(t *testing.T) {
+	ctx := context.Background()
+	m := NewIsolationManager()
+	_ = m.Configure(ctx, "t1", &IsolationConfig{})
+	usage := &Usage{CpuSeconds: 10}
+	if err := m.RecordUsage(ctx, "t1", usage); err != nil {
+		t.Fatalf("record usage: %v", err)
+	}
+	got, err := m.Usage(ctx, "t1")
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if got.CpuSeconds != 10 {
+		t.Fatalf("expected cpu 10, got %d", got.CpuSeconds)
+	}
+}


### PR DESCRIPTION
## Summary
- add tenant isolation and billing managers
- implement team management and hierarchy permission utilities
- stub organization gRPC services and register with server
- add data and security policy managers with examples

## Testing
- `go test ./pkg/organization/...`


------
https://chatgpt.com/codex/tasks/task_e_68992d7a654c8321a27e998dc8bd9441