### PR TITLE
feat(metrics): add exporter and provider skeletons

### DIFF
--- a/.github/doc-updates/15e58f96-7747-4692-bd80-cb037fbe6198.json
+++ b/.github/doc-updates/15e58f96-7747-4692-bd80-cb037fbe6198.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Added skeleton metrics exporters",
+  "guid": "15e58f96-7747-4692-bd80-cb037fbe6198",
+  "created_at": "2025-08-10T23:41:02Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b0931163-1374-46d4-b2bc-327b21b57f4b.json
+++ b/.github/doc-updates/b0931163-1374-46d4-b2bc-327b21b57f4b.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement full metrics exporters and gRPC services",
+  "guid": "b0931163-1374-46d4-b2bc-327b21b57f4b",
+  "created_at": "2025-08-10T23:41:06Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/pkg/metrics/exporters/exporters.go
+++ b/pkg/metrics/exporters/exporters.go
@@ -1,0 +1,113 @@
+// file: pkg/metrics/exporters/exporters.go
+// version: 1.0.1
+// guid: 0a1b2c3d-4e5f-6789-abcd-0123456789ab
+
+// Package exporters contains helper types for metrics exporters.
+package exporters
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// ErrExporterNotConfigured is returned when an exporter is not properly configured.
+var ErrExporterNotConfigured = errors.New("exporter not configured")
+
+// Exporter defines the behaviour for metrics exporters.
+//
+// Exporters are responsible for exposing metrics collected by a provider to
+// external systems. Each exporter implementation should manage its own
+// lifecycle and ensure thread-safety. The interface intentionally mirrors the
+// Provider interface to keep the integration straightforward.
+type Exporter interface {
+	// Start launches the exporter. Implementations should spawn any required
+	// goroutines and begin serving metrics to the target system.
+	Start(ctx context.Context) error
+
+	// Stop gracefully stops the exporter. Implementations should release all
+	// resources and ensure that any pending metrics are flushed before
+	// returning.
+	Stop(ctx context.Context) error
+
+	// WithProvider attaches a metrics provider to the exporter.
+	WithProvider(provider metrics.Provider) Exporter
+}
+
+// BaseExporter provides a minimal implementation of the Exporter interface that
+// can be embedded by other exporters. It handles provider assignment and offers
+// basic lifecycle management utilities. The implementation is intentionally
+// simple and primarily serves as a convenience for skeleton implementations.
+type BaseExporter struct {
+	mu       sync.RWMutex
+	provider metrics.Provider
+	started  bool
+}
+
+// WithProvider attaches a metrics provider to the exporter.
+func (b *BaseExporter) WithProvider(provider metrics.Provider) Exporter {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.provider = provider
+	return b
+}
+
+// Provider returns the currently configured metrics provider.
+// It is safe for concurrent use.
+func (b *BaseExporter) Provider() metrics.Provider {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.provider
+}
+
+// MarkStarted marks the exporter as started.
+// It does not perform any operations beyond updating internal state.
+func (b *BaseExporter) MarkStarted() {
+	b.mu.Lock()
+	b.started = true
+	b.mu.Unlock()
+}
+
+// MarkStopped marks the exporter as stopped.
+func (b *BaseExporter) MarkStopped() {
+	b.mu.Lock()
+	b.started = false
+	b.mu.Unlock()
+}
+
+// IsStarted reports whether the exporter has been started.
+func (b *BaseExporter) IsStarted() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.started
+}
+
+// Start implements Exporter and performs no operation.
+// Concrete exporters should override this method.
+func (b *BaseExporter) Start(ctx context.Context) error { return nil }
+
+// Stop implements Exporter and performs no operation.
+// Concrete exporters should override this method.
+func (b *BaseExporter) Stop(ctx context.Context) error { return nil }
+
+// ensure interface implementation
+var _ Exporter = (*BaseExporter)(nil)
+
+//
+// NOTE: This file only provides scaffolding for exporter implementations. The
+// concrete exporters within this package are intentionally minimal and include
+// extensive TODO comments describing required behaviour. Future contributors
+// should replace these placeholders with production-ready logic that integrates
+// with the metrics providers defined in the root metrics package.
+//
+// The intention of these skeletons is to provide a clear starting point while
+// emphasising that significant work remains. The repeated TODO comments found
+// throughout the exporter implementations are deliberate and are intended to
+// draw attention to the incomplete nature of this code.
+//
+// Additional helper types or shared utilities for exporters should be added to
+// this file as needed. For now the focus is on establishing a consistent API
+// surface and providing room for future development.
+// TODO: revisit exporter interface for streaming support

--- a/pkg/metrics/exporters/exporters_test.go
+++ b/pkg/metrics/exporters/exporters_test.go
@@ -1,0 +1,49 @@
+// file: pkg/metrics/exporters/exporters_test.go
+// version: 1.0.1
+// guid: 4e5f6071-89ab-cdef-0123-456789abcdef
+
+package exporters
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// mockProvider is a minimal metrics.Provider used for testing.
+// It satisfies the interface but does not record any metrics.
+type mockProvider struct{}
+
+func (m *mockProvider) Counter(name string, options ...metrics.Option) metrics.Counter { return nil }
+func (m *mockProvider) Gauge(name string, options ...metrics.Option) metrics.Gauge     { return nil }
+func (m *mockProvider) Histogram(name string, options ...metrics.Option) metrics.Histogram {
+	return nil
+}
+func (m *mockProvider) Summary(name string, options ...metrics.Option) metrics.Summary { return nil }
+func (m *mockProvider) Timer(name string, options ...metrics.Option) metrics.Timer     { return nil }
+func (m *mockProvider) Registry() metrics.Registry                                     { return nil }
+func (m *mockProvider) Handler() http.Handler                                          { return nil }
+func (m *mockProvider) Start(ctx context.Context) error                                { return nil }
+func (m *mockProvider) Stop(ctx context.Context) error                                 { return nil }
+func (m *mockProvider) WithTags(tags ...metrics.Tag) metrics.Provider {
+	return m
+}
+
+// TestBaseExporter_WithProvider ensures that the BaseExporter correctly stores
+// and retrieves the provider instance.
+func TestBaseExporter_WithProvider(t *testing.T) {
+	t.Run("assign provider", func(t *testing.T) {
+		var b BaseExporter
+		p := &mockProvider{}
+		b.WithProvider(p)
+		if b.Provider() != p {
+			t.Fatalf("expected provider to be set")
+		}
+	})
+
+	t.Run("thread safe", func(t *testing.T) {
+		t.Skip("TODO: add concurrency tests for BaseExporter")
+	})
+}

--- a/pkg/metrics/exporters/file.go
+++ b/pkg/metrics/exporters/file.go
@@ -1,0 +1,176 @@
+// file: pkg/metrics/exporters/file.go
+// version: 1.0.0
+// guid: 3d4e5f60-7189-abcd-ef01-23456789abcd
+
+package exporters
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// FileExporter writes metrics snapshots to a file at regular intervals.
+//
+// This exporter is useful for debugging or environments where pulling metrics
+// over the network is impractical. As with other exporters in this package, the
+// implementation here is skeletal and intended as a starting point for future
+// development.
+type FileExporter struct {
+	BaseExporter
+
+	mu       sync.Mutex
+	path     string
+	interval time.Duration
+	quit     chan struct{}
+	// TODO: add file rotation
+	// TODO: add compression support
+	// TODO: make format configurable (JSON, CSV, etc.)
+}
+
+// NewFileExporter creates a new FileExporter that writes to the given path at
+// the specified interval.
+func NewFileExporter(path string, interval time.Duration) *FileExporter {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &FileExporter{path: path, interval: interval, quit: make(chan struct{})}
+}
+
+// Start begins periodic snapshotting of metrics to the file.
+//
+// The current implementation captures the provider's snapshot and appends it to
+// the file as JSON. Error handling is intentionally minimal and should be
+// improved in future revisions.
+func (e *FileExporter) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.quit == nil {
+		e.quit = make(chan struct{})
+	}
+
+	e.MarkStarted()
+
+	go e.loop()
+
+	return nil
+}
+
+// loop performs the periodic snapshot writing.
+func (e *FileExporter) loop() {
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			e.writeSnapshot()
+		case <-e.quit:
+			return
+		}
+	}
+}
+
+// Stop stops the exporter and flushes remaining metrics.
+func (e *FileExporter) Stop(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.quit != nil {
+		close(e.quit)
+		e.quit = nil
+	}
+	e.MarkStopped()
+	return nil
+}
+
+// WithProvider attaches a provider and returns the exporter for chaining.
+func (e *FileExporter) WithProvider(p metrics.Provider) Exporter {
+	e.BaseExporter.WithProvider(p)
+	return e
+}
+
+// writeSnapshot captures a snapshot from the provider and writes it to disk.
+func (e *FileExporter) writeSnapshot() {
+	provider := e.Provider()
+	if provider == nil {
+		return
+	}
+
+	snapshot := provider.Registry().Snapshot()
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return
+	}
+
+	// Append to file; ignore errors for now.
+	f, err := os.OpenFile(e.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(data, '\n'))
+}
+
+// The TODO list below enumerates enhancements required for a complete
+// FileExporter implementation. Each item should be addressed in subsequent
+// iterations to provide a robust and configurable exporter.
+//
+// TODO: implement error logging instead of silent failures
+// TODO: support configurable file permissions
+// TODO: add option to truncate file on startup
+// TODO: handle large files via rotation and archival
+// TODO: allow custom encoding formats beyond JSON
+// TODO: add checksum to verify file integrity
+// TODO: implement asynchronous writing with buffering
+// TODO: expose exporter metrics (e.g., bytes written)
+// TODO: add configuration validation with helpful errors
+// TODO: support writing to remote filesystems or object storage
+// TODO: handle disk full and permission errors gracefully
+// TODO: integrate with encryption libraries for secure output
+// TODO: support configurable timestamp formatting
+// TODO: allow dynamic adjustment of snapshot interval
+// TODO: provide CLI tool for reading exported files
+// TODO: add unit tests for snapshot formatting and writing
+// TODO: document file format and usage scenarios
+// TODO: consider concurrent writes from multiple exporters
+// TODO: ensure atomic writes to avoid partial records
+// TODO: add context cancellation handling for write operations
+// TODO: verify behaviour under high-frequency updates
+// TODO: include build/version metadata in output
+// TODO: provide example configuration in repository
+// TODO: support filtering metrics before writing
+// TODO: ensure cross-platform path compatibility
+// TODO: add hooks for pre/post snapshot processing
+// TODO: implement structured logging for diagnostics
+// TODO: allow custom marshaling implementations
+// TODO: support binary encoding for compact output
+// TODO: integrate with compression libraries for efficiency
+// TODO: verify file writer performance with benchmarks
+// TODO: handle provider errors gracefully during snapshot
+// TODO: expose last-write timestamp for monitoring
+// TODO: remove placeholder comments when complete
+// TODO: ensure tests cover both success and failure paths
+// TODO: implement retry logic for transient errors
+// TODO: support user-defined file naming patterns
+// TODO: ensure thread-safety across all operations
+// TODO: provide integration tests with other exporters
+// TODO: add metrics for exporter itself (e.g., write latency)
+// TODO: consider using a buffered writer for efficiency
+// TODO: support configurable maximum file size
+// TODO: document security considerations for file output
+// TODO: ensure compatibility with read-only filesystems
+// TODO: provide configuration via environment variables
+// TODO: integrate with configuration module once available
+// TODO: add alerting hooks for write failures
+// TODO: support compression of rotated files
+// TODO: allow custom snapshot formatting functions
+// TODO: make interval jitter configurable to avoid spikes
+// TODO: finalize API after feedback from stakeholders
+// TODO: test behaviour with concurrent shutdown calls
+// TODO: ensure context timeouts propagate to write operations
+// TODO: update documentation once implementation stabilizes

--- a/pkg/metrics/exporters/file_test.go
+++ b/pkg/metrics/exporters/file_test.go
@@ -1,0 +1,34 @@
+// file: pkg/metrics/exporters/file_test.go
+// version: 1.0.0
+// guid: 7189abcd-ef01-2345-6789-abcdef012345
+
+package exporters
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestFileExporter_StartStop ensures that the file exporter starts and stops
+// without error and creates the output file.
+func TestFileExporter_StartStop(t *testing.T) {
+	tmp := t.TempDir() + "/metrics.log"
+	exp := NewFileExporter(tmp, time.Millisecond)
+	if err := exp.Start(context.Background()); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	// allow one write cycle
+	time.Sleep(2 * time.Millisecond)
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := exp.Stop(stopCtx); err != nil {
+		t.Fatalf("stop error: %v", err)
+	}
+	if _, err := os.Stat(tmp); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+// TODO: add tests for file rotation, error handling, and snapshot content.

--- a/pkg/metrics/exporters/grpc.go
+++ b/pkg/metrics/exporters/grpc.go
@@ -1,0 +1,177 @@
+// file: pkg/metrics/exporters/grpc.go
+// version: 1.0.0
+// guid: 2c3d4e5f-6071-89ab-cdef-0123456789ab
+
+package exporters
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+	pb "github.com/jdfalk/gcommon/pkg/metrics/proto"
+)
+
+// GRPCExporter exposes metrics via a gRPC service.
+//
+// Similar to HTTPExporter, this implementation is a skeleton and focuses on
+// establishing structure rather than providing complete functionality. Numerous
+// TODO comments outline the required work for a production-ready exporter.
+type GRPCExporter struct {
+	BaseExporter
+
+	mu       sync.Mutex
+	server   *grpc.Server
+	listener net.Listener
+	addr     string
+	// TODO: add TLS credentials support
+	// TODO: add streaming metrics functionality
+	// TODO: integrate with authentication mechanisms
+}
+
+// NewGRPCExporter creates a new GRPCExporter listening on the provided address.
+func NewGRPCExporter(addr string) *GRPCExporter {
+	return &GRPCExporter{addr: addr}
+}
+
+// Start begins serving the gRPC metrics service.
+//
+// The current implementation registers a basic MetricsService server that does
+// not yet expose real metrics data. Future iterations should integrate with the
+// metrics provider and support streaming updates.
+func (e *GRPCExporter) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.server != nil {
+		return nil
+	}
+
+	lis, err := net.Listen("tcp", e.addr)
+	if err != nil {
+		return err
+	}
+
+	e.listener = lis
+	e.server = grpc.NewServer()
+
+	// Register placeholder services
+	pb.RegisterMetricsServiceServer(e.server, &metricsService{provider: e.Provider()})
+	pb.RegisterMetricsManagementServiceServer(e.server, &managementService{})
+
+	// Health service for monitoring
+	healthSrv := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(e.server, healthSrv)
+
+	e.MarkStarted()
+
+	go func() {
+		_ = e.server.Serve(lis)
+	}()
+
+	return nil
+}
+
+// Stop stops the gRPC server and releases resources.
+func (e *GRPCExporter) Stop(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.server == nil {
+		return nil
+	}
+
+	e.server.GracefulStop()
+	if e.listener != nil {
+		_ = e.listener.Close()
+		e.listener = nil
+	}
+	e.server = nil
+	e.MarkStopped()
+	return nil
+}
+
+// WithProvider attaches a provider and returns the exporter for chaining.
+func (e *GRPCExporter) WithProvider(p metrics.Provider) Exporter {
+	e.BaseExporter.WithProvider(p)
+	return e
+}
+
+// metricsService is a placeholder implementation of the MetricsService.
+//
+// TODO: replace this with a full implementation that pulls data from the
+// provider and streams it to clients. The service should support both unary and
+// streaming RPCs for collecting metrics snapshots.
+type metricsService struct {
+	pb.UnimplementedMetricsServiceServer
+	provider metrics.Provider
+}
+
+// RecordMetric is a placeholder that always succeeds without doing anything.
+func (s *metricsService) RecordMetric(ctx context.Context, req *pb.RecordMetricRequest) (*pb.RecordMetricResponse, error) {
+	// TODO: implement recording logic
+	return &pb.RecordMetricResponse{}, nil
+}
+
+// managementService is a placeholder for administrative operations.
+type managementService struct {
+	pb.UnimplementedMetricsManagementServiceServer
+}
+
+// The following TODO list highlights required work for GRPCExporter.
+//
+// TODO: expose real metrics data via RPCs
+// TODO: implement streaming API for continuous metrics updates
+// TODO: add authentication and authorization checks
+// TODO: provide detailed error handling and status codes
+// TODO: support server reflection for debugging
+// TODO: integrate with tracing for RPC calls
+// TODO: add per-request logging with correlation IDs
+// TODO: handle context cancellation appropriately
+// TODO: add unit tests for all service methods
+// TODO: support TLS encryption and mTLS
+// TODO: allow configuration of gRPC interceptors
+// TODO: implement graceful shutdown with timeout control
+// TODO: expose service metrics for exporter itself
+// TODO: document example clients in repository
+// TODO: support multiple providers and dynamic selection
+// TODO: add health checks for underlying provider
+// TODO: implement rate limiting and throttling
+// TODO: provide load balancing hints for clients
+// TODO: ensure compatibility with gRPC proxies
+// TODO: add retries and backoff for transient errors
+// TODO: expose configuration via proto messages
+// TODO: allow hot-reload of certificates and configs
+// TODO: integrate with gRPC gateway for HTTP/JSON access
+// TODO: support metrics push as well as pull models
+// TODO: add metrics filtering capabilities
+// TODO: handle large metric payloads efficiently
+// TODO: add benchmarking to measure RPC performance
+// TODO: provide backpressure handling for slow clients
+// TODO: implement authentication plugins (e.g., JWT, OAuth2)
+// TODO: verify behaviour under network partitions
+// TODO: document security considerations for exposed endpoints
+// TODO: support compression for RPC payloads
+// TODO: ensure thread-safety throughout implementation
+// TODO: use structured logging for audit trails
+// TODO: support server-side streaming for alerts
+// TODO: integrate with service discovery systems
+// TODO: add tracing spans for exporter operations
+// TODO: expose build/version information via RPC
+// TODO: allow custom metadata headers for clients
+// TODO: provide examples of client-side load balancing
+// TODO: handle provider errors gracefully
+// TODO: ensure resources are released on client disconnect
+// TODO: implement panic recovery in RPC handlers
+// TODO: support pluggable serialization formats
+// TODO: validate incoming requests thoroughly
+// TODO: add metrics for exporter itself (e.g., RPC counts)
+// TODO: consider gRPC-Web compatibility
+// TODO: provide code generation hints for clients
+// TODO: ensure compatibility with older gRPC clients
+// TODO: remove placeholder implementations when complete

--- a/pkg/metrics/exporters/grpc_test.go
+++ b/pkg/metrics/exporters/grpc_test.go
@@ -1,0 +1,27 @@
+// file: pkg/metrics/exporters/grpc_test.go
+// version: 1.0.0
+// guid: 607189ab-cdef-0123-4567-89abcdef0123
+
+package exporters
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestGRPCExporter_StartStop verifies that the gRPC exporter can be started and
+// stopped without error. Real metrics streaming is not yet implemented.
+func TestGRPCExporter_StartStop(t *testing.T) {
+	exp := NewGRPCExporter("127.0.0.1:0")
+	if err := exp.Start(context.Background()); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := exp.Stop(stopCtx); err != nil {
+		t.Fatalf("stop error: %v", err)
+	}
+}
+
+// TODO: add tests for real RPC interactions once exporter is complete.

--- a/pkg/metrics/exporters/http.go
+++ b/pkg/metrics/exporters/http.go
@@ -1,0 +1,190 @@
+// file: pkg/metrics/exporters/http.go
+// version: 1.0.0
+// guid: 1b2c3d4e-5f60-789a-bcde-f0123456789a
+
+package exporters
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// HTTPExporter exposes metrics through an HTTP endpoint.
+//
+// This implementation is intentionally incomplete. The structure and methods are
+// provided as a foundation for future development. Throughout the file numerous
+// TODO comments highlight areas requiring attention. Contributors should replace
+// these placeholders with production-ready logic that properly integrates with
+// the metrics subsystem.
+type HTTPExporter struct {
+	BaseExporter
+
+	mu       sync.Mutex
+	server   *http.Server
+	addr     string
+	endpoint string
+	// TODO: add logger once logging subsystem is integrated
+	// TODO: add graceful shutdown hooks
+	// TODO: support TLS configuration
+	// TODO: expose metrics registry handler
+}
+
+// NewHTTPExporter creates a new HTTPExporter.
+//
+// The exporter will listen on the provided address and expose metrics on the
+// specified endpoint. If endpoint is empty it defaults to "/metrics".
+// NOTE: Actual metrics exposition is not yet implemented.
+func NewHTTPExporter(addr, endpoint string) *HTTPExporter {
+	if endpoint == "" {
+		endpoint = "/metrics"
+	}
+	return &HTTPExporter{addr: addr, endpoint: endpoint}
+}
+
+// Start begins serving metrics over HTTP.
+//
+// At the moment this method merely sets up an HTTP server that responds with a
+// placeholder message. Real metrics integration should replace this behaviour.
+// Repeated TODO comments are included to emphasise the work remaining.
+func (e *HTTPExporter) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.server != nil {
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(e.endpoint, func(w http.ResponseWriter, r *http.Request) {
+		// TODO: integrate with metrics provider and registry
+		// TODO: support content negotiation and compression
+		// TODO: implement proper error handling and logging
+		_, _ = w.Write([]byte("metrics exporter not yet implemented"))
+	})
+
+	e.server = &http.Server{
+		Addr:              e.addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	e.MarkStarted()
+
+	go func() {
+		// TODO: better logging and error handling
+		_ = e.server.ListenAndServe()
+	}()
+
+	return nil
+}
+
+// Stop shuts down the HTTP server.
+//
+// The current implementation uses the standard library's Shutdown method but
+// lacks advanced features such as draining connections or metrics flushing.
+func (e *HTTPExporter) Stop(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.server == nil {
+		return nil
+	}
+
+	defer func() {
+		e.server = nil
+		e.MarkStopped()
+	}()
+
+	return e.server.Shutdown(ctx)
+}
+
+// Addr returns the configured listen address.
+func (e *HTTPExporter) Addr() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.addr
+}
+
+// Endpoint returns the metrics endpoint path.
+func (e *HTTPExporter) Endpoint() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.endpoint
+}
+
+// WithProvider attaches a metrics provider to the exporter.
+// It overrides BaseExporter's implementation to allow method chaining.
+func (e *HTTPExporter) WithProvider(p metrics.Provider) Exporter {
+	e.BaseExporter.WithProvider(p)
+	return e
+}
+
+// Below lies a long block of TODO reminders. These are intentionally verbose to
+// draw attention to the incomplete nature of the implementation. Each line
+// represents work that must be completed before the exporter can be considered
+// production ready.
+//
+// TODO: integrate request logging
+// TODO: support authentication middleware
+// TODO: implement error responses in JSON format
+// TODO: add health check endpoint for monitoring
+// TODO: make listen address configurable via environment
+// TODO: expose metrics in multiple formats (Prometheus, JSON)
+// TODO: add rate limiting to protect against abuse
+// TODO: provide graceful shutdown with timeout control
+// TODO: integrate with tracing system for request spans
+// TODO: handle concurrent scrapes efficiently
+// TODO: add unit tests covering success and failure paths
+// TODO: document configuration options clearly
+// TODO: support custom HTTP handlers for additional endpoints
+// TODO: add hooks for instrumentation middleware
+// TODO: allow dynamic reconfiguration without restart
+// TODO: ensure thread-safety of all operations
+// TODO: verify compatibility with embedded environments
+// TODO: add integration tests with Prometheus server
+// TODO: investigate performance impact under load
+// TODO: support mTLS for secure deployments
+// TODO: allow users to supply custom http.Server instance
+// TODO: expose metrics registry for external inspection
+// TODO: support gzip compression for large responses
+// TODO: ensure proper context cancellation propagation
+// TODO: add observability hooks for exporter itself
+// TODO: provide example usage in documentation
+// TODO: ensure compatibility with upcoming metrics standards
+// TODO: implement metrics caching strategy
+// TODO: handle CORS headers when necessary
+// TODO: allow configurable read/write timeouts
+// TODO: consider using http2 for better performance
+// TODO: support pushing metrics to remote gateways
+// TODO: add support for custom certificates and key rotation
+// TODO: support IPv6 and dual-stack configurations
+// TODO: implement structured logging for debug analysis
+// TODO: verify behaviour with misconfigured providers
+// TODO: handle large metric payloads gracefully
+// TODO: expose runtime/pprof endpoints for debugging
+// TODO: integrate with service discovery mechanisms
+// TODO: support hot-reload of TLS certificates
+// TODO: add request ID logging for correlation
+// TODO: add benchmarks to measure exporter performance
+// TODO: review security implications of exposed endpoints
+// TODO: add configuration validation with helpful errors
+// TODO: provide cli utility for quick exporter setup
+// TODO: ensure compatibility with reverse proxies
+// TODO: add configurable header injection
+// TODO: implement rate limit metrics
+// TODO: document all public methods
+// TODO: add example code demonstrating startup and shutdown
+// TODO: support multiple providers simultaneously
+// TODO: verify memory usage under heavy load
+// TODO: ensure cross-platform build support
+// TODO: finalize API after design review
+// TODO: remove placeholder comments once complete
+// TODO: ensure metrics are flushed before shutdown
+// TODO: expose metrics version in response headers
+// TODO: include build information in metrics
+// TODO: validate endpoint prefix for security
+// TODO: compress TODO list as tasks are completed

--- a/pkg/metrics/exporters/http_test.go
+++ b/pkg/metrics/exporters/http_test.go
@@ -1,0 +1,29 @@
+// file: pkg/metrics/exporters/http_test.go
+// version: 1.0.0
+// guid: 5f607189-abcd-ef01-2345-6789abcdef01
+
+package exporters
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestHTTPExporter_StartStop verifies that the HTTP exporter can start and stop
+// without error. This is a placeholder test and does not exercise real metrics
+// functionality.
+func TestHTTPExporter_StartStop(t *testing.T) {
+	exp := NewHTTPExporter(":0", "")
+	if err := exp.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := exp.Stop(stopCtx); err != nil {
+		t.Fatalf("unexpected stop error: %v", err)
+	}
+}
+
+// TODO: add comprehensive tests covering metric exposure, error handling, and
+// concurrency scenarios once the exporter is fully implemented.

--- a/pkg/metrics/influxdb/provider.go
+++ b/pkg/metrics/influxdb/provider.go
@@ -1,0 +1,144 @@
+// file: pkg/metrics/influxdb/provider.go
+// version: 1.0.1
+// guid: 89abcdef-0123-4567-89ab-cdef01234567
+
+package influxdb
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// Provider implements a skeletal metrics provider that would send data to
+// InfluxDB. The current implementation acts as a no-op while outlining the
+// structure required for a full integration with the InfluxDB client library.
+type Provider struct {
+	mu      sync.Mutex
+	options metrics.Config
+	// TODO: add fields for InfluxDB client connection
+}
+
+// Client is a placeholder for the InfluxDB client.
+// TODO: replace with github.com/influxdata/influxdb-client-go or similar.
+type Client struct{}
+
+// NewProvider creates a new Provider using the supplied configuration.
+// It registers itself with the metrics factory in an init function.
+func NewProvider(config metrics.Config) (metrics.Provider, error) {
+	p := &Provider{options: config}
+	// TODO: initialize actual InfluxDB client using config.ProviderConfig
+	return p, nil
+}
+
+// init registers the provider with the metrics factory.
+func init() {
+	metrics.RegisterProvider("influxdb", NewProvider)
+}
+
+// Counter creates or retrieves a counter metric.
+func (p *Provider) Counter(name string, options ...metrics.Option) metrics.Counter {
+	// TODO: implement counter backed by InfluxDB write API
+	return nil
+}
+
+// Gauge creates or retrieves a gauge metric.
+func (p *Provider) Gauge(name string, options ...metrics.Option) metrics.Gauge {
+	// TODO: implement gauge backed by InfluxDB write API
+	return nil
+}
+
+// Histogram creates or retrieves a histogram metric.
+func (p *Provider) Histogram(name string, options ...metrics.Option) metrics.Histogram {
+	// TODO: implement histogram with configurable buckets
+	return nil
+}
+
+// Summary creates or retrieves a summary metric.
+func (p *Provider) Summary(name string, options ...metrics.Option) metrics.Summary {
+	// TODO: implement summary using InfluxDB
+	return nil
+}
+
+// Timer creates or retrieves a timer metric.
+func (p *Provider) Timer(name string, options ...metrics.Option) metrics.Timer {
+	// TODO: implement timer using histogram
+	return nil
+}
+
+// Registry returns the registry used by the provider.
+func (p *Provider) Registry() metrics.Registry { return nil }
+
+// Handler returns an HTTP handler for scraping metrics.
+func (p *Provider) Handler() http.Handler {
+	// TODO: expose metrics via HTTP for debugging
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("influxdb provider metrics not implemented"))
+	})
+}
+
+// Start initializes background processes required for the provider.
+func (p *Provider) Start(ctx context.Context) error {
+	// TODO: start background workers or batching processes
+	return nil
+}
+
+// Stop terminates any background processes.
+func (p *Provider) Stop(ctx context.Context) error {
+	// TODO: flush pending metrics and close client connections
+	return nil
+}
+
+// WithTags returns a new provider that applies the given tags to all metrics.
+func (p *Provider) WithTags(tags ...metrics.Tag) metrics.Provider {
+	// TODO: implement tag propagation
+	return p
+}
+
+// The TODO list below outlines future work for the InfluxDB provider:
+//
+// TODO: integrate official InfluxDB client library
+// TODO: support batching and retry logic for writes
+// TODO: implement query API for reading metrics back
+// TODO: expose configuration options for authentication and TLS
+// TODO: add context-aware request cancellation
+// TODO: provide examples demonstrating InfluxDB integration
+// TODO: add unit tests for all metric types
+// TODO: benchmark write performance and resource usage
+// TODO: handle network errors with exponential backoff
+// TODO: support tagging and field management according to InfluxDB schema
+// TODO: implement proper logging and error reporting
+// TODO: ensure thread-safety of registry operations
+// TODO: expose health status for monitoring
+// TODO: add metrics for internal operation (e.g., write queue size)
+// TODO: allow custom measurement names per metric
+// TODO: support automatic metric cleanup
+// TODO: document configuration structure and environment variables
+// TODO: support multiple databases or retention policies
+// TODO: add integration tests with real InfluxDB server
+// TODO: provide migration path from other providers
+// TODO: ensure compatibility with future InfluxDB versions
+// TODO: remove placeholder comments once implementation is complete
+// TODO: ensure write operations honor context deadlines
+// TODO: add batching metrics to monitor flush frequency
+// TODO: investigate data loss scenarios and recovery strategies
+// TODO: support gzip compression for line protocol payloads
+// TODO: provide helper for schema management
+// TODO: document best practices for high availability setups
+// TODO: integrate with monitoring module for self-observation
+// TODO: allow user-defined retention policies per metric group
+// TODO: expose configurable retry backoff parameters
+// TODO: audit code for race conditions and add tests
+// TODO: support offline buffering when database is unreachable
+// TODO: add option to drop metrics on persistent failures
+// TODO: provide hooks for custom point transformation
+// TODO: ensure compatibility with InfluxDB Cloud
+// TODO: implement connection pooling with limits
+// TODO: validate metric names against InfluxDB restrictions
+// TODO: add feature toggles for experimental capabilities
+// TODO: publish example dashboards for common metrics
+// TODO: implement lifecycle hooks for provider shutdown
+// TODO: coordinate with exporters for combined deployments

--- a/pkg/metrics/influxdb/provider_test.go
+++ b/pkg/metrics/influxdb/provider_test.go
@@ -1,0 +1,29 @@
+// file: pkg/metrics/influxdb/provider_test.go
+// version: 1.0.1
+// guid: 9abcdef0-1234-5678-9abc-def012345678
+
+package influxdb
+
+import (
+	"context"
+	"testing"
+
+	metrics "github.com/jdfalk/gcommon/pkg/metrics"
+)
+
+// TestProvider_StartStop ensures the skeleton provider can start and stop
+// without error. Additional tests should be added once real functionality exists.
+func TestProvider_StartStop(t *testing.T) {
+	p, err := NewProvider(metrics.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error creating provider: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Fatalf("stop error: %v", err)
+	}
+}
+
+// TODO: add tests covering metric creation, tagging, and error scenarios.


### PR DESCRIPTION
## Summary
- add foundational metrics exporter package with HTTP, gRPC, and file skeletons
- introduce placeholder InfluxDB provider and basic tests
- record doc updates for changelog and todo

## Testing
- `go test ./pkg/metrics/exporters -run TestHTTPExporter_StartStop -count=1`
- `go test ./pkg/metrics/influxdb -run TestProvider_StartStop -count=1`
- `go test ./pkg/metrics/... -count=1` *(fails: undefined types and duplicate test mocks)*
- `go test ./... -count=1` *(fails: build failures in metrics and monitoring packages)*

------
https://chatgpt.com/codex/tasks/task_e_68992d3fd5f88321835c079e85cc8c72