### PR TITLE
feat(queue): implement queue service layer

### DIFF
--- a/.github/doc-updates/399ffada-ec79-4114-bdf1-3bda7d4f62f6.json
+++ b/.github/doc-updates/399ffada-ec79-4114-bdf1-3bda7d4f62f6.json
@@ -1,0 +1,16 @@
+{
+  "file": "pkg/queue/README.md",
+  "mode": "append",
+  "content": "# Queue Module\\n\\nImplements message queuing with in-memory and Redis providers, gRPC services, job scheduling, and monitoring.",
+  "guid": "399ffada-ec79-4114-bdf1-3bda7d4f62f6",
+  "created_at": "2025-08-10T23:56:43Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7d6b7505-3fb4-4048-a35f-7c14f364c127.json
+++ b/.github/doc-updates/7d6b7505-3fb4-4048-a35f-7c14f364c127.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "feat(queue): implement queue service layer with memory and redis providers, scheduler, and monitoring",
+  "guid": "7d6b7505-3fb4-4048-a35f-7c14f364c127",
+  "created_at": "2025-08-10T23:56:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/969d9454-5550-4052-9f5d-60704ec1f0b6.json
+++ b/.github/doc-updates/969d9454-5550-4052-9f5d-60704ec1f0b6.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Implement RabbitMQ and NATS queue providers",
+  "guid": "969d9454-5550-4052-9f5d-60704ec1f0b6",
+  "created_at": "2025-08-10T23:56:39Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/b627e562-a777-4b3f-aa17-4e495915b973.json
+++ b/.github/issue-updates/b627e562-a777-4b3f-aa17-4e495915b973.json
@@ -1,0 +1,12 @@
+{
+  "action": "comment",
+  "number": 29,
+  "body": "Starting queue module implementation: interfaces, providers, gRPC services",
+  "guid": "b627e562-a777-4b3f-aa17-4e495915b973",
+  "legacy_guid": "comment-issue-29-2025-08-10",
+  "created_at": "2025-08-10T23:40:51.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/.github/issue-updates/fce83b9a-f670-4cf3-a2b9-0479afde2961.json
+++ b/.github/issue-updates/fce83b9a-f670-4cf3-a2b9-0479afde2961.json
@@ -1,0 +1,12 @@
+{
+  "action": "comment",
+  "number": 29,
+  "body": "Implemented queue service layer with memory and redis providers, gRPC admin and monitoring services, and job scheduler",
+  "guid": "fce83b9a-f670-4cf3-a2b9-0479afde2961",
+  "legacy_guid": "comment-issue-29-2025-08-10",
+  "created_at": "2025-08-10T23:56:47.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/queue/context.go
+++ b/pkg/queue/context.go
@@ -1,0 +1,24 @@
+// file: pkg/queue/context.go
+// version: 1.0.0
+// guid: ff7f0b20-04ef-455b-8305-bdbad15665fc
+
+package queue
+
+import "context"
+
+// queueNameKey is an unexported type for context keys defined in this package.
+type queueNameKey struct{}
+
+// WithQueueName returns a new context with the provided queue name associated
+// with it. Providers can use QueueNameFromContext to retrieve the name and route
+// messages accordingly.
+func WithQueueName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, queueNameKey{}, name)
+}
+
+// QueueNameFromContext extracts a queue name from context. The boolean return
+// value indicates whether a queue name was present.
+func QueueNameFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(queueNameKey{}).(string)
+	return v, ok && v != ""
+}

--- a/pkg/queue/grpc/admin_service.go
+++ b/pkg/queue/grpc/admin_service.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/grpc/admin_service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: cc47b2b4-b308-48bc-8784-b08495f90dba
 //go:build queue_grpc
 // +build queue_grpc
@@ -7,6 +7,9 @@
 package grpc
 
 import (
+	"context"
+	"errors"
+
 	"github.com/jdfalk/gcommon/pkg/queue"
 	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
 )
@@ -18,4 +21,81 @@ type AdminService struct {
 
 func NewAdminService(q queue.Queue) *AdminService {
 	return &AdminService{q: q}
+}
+
+// CreateQueue delegates to the underlying Queue implementation to create a new
+// queue with the provided configuration.
+func (s *AdminService) CreateQueue(ctx context.Context, req *queuepb.CreateQueueRequest) (*queuepb.CreateQueueResponse, error) {
+	if req.GetConfig() == nil {
+		return nil, errors.New("queue config required")
+	}
+	if err := s.q.CreateQueue(ctx, req.GetConfig()); err != nil {
+		return nil, err
+	}
+	resp := &queuepb.CreateQueueResponse{}
+	resp.SetQueue(req.GetConfig())
+	return resp, nil
+}
+
+// DeleteTopic removes a queue. The proto uses DeleteTopic for historical
+// reasons though it maps directly to Queue.DeleteQueue in the provider.
+func (s *AdminService) DeleteTopic(ctx context.Context, req *queuepb.DeleteTopicRequest) (*queuepb.DeleteTopicResponse, error) {
+	if err := s.q.DeleteQueue(ctx, req.GetName()); err != nil {
+		return nil, err
+	}
+	return &queuepb.DeleteTopicResponse{}, nil
+}
+
+// GetQueueInfo returns statistics about a queue from the provider.
+func (s *AdminService) GetQueueInfo(ctx context.Context, req *queuepb.GetQueueInfoRequest) (*queuepb.GetQueueInfoResponse, error) {
+	info, err := s.q.GetQueueInfo(ctx, req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	resp := &queuepb.GetQueueInfoResponse{}
+	resp.SetInfo(info)
+	return resp, nil
+}
+
+// PauseQueue is not supported by the basic queue implementations and returns
+// an unimplemented error.
+func (s *AdminService) PauseQueue(context.Context, *queuepb.PauseQueueRequest) (*queuepb.PauseQueueResponse, error) {
+	return nil, errors.New("pause queue not implemented")
+}
+
+// ResumeQueue is not supported by the basic queue implementations and returns
+// an unimplemented error.
+func (s *AdminService) ResumeQueue(context.Context, *queuepb.ResumeQueueRequest) (*queuepb.ResumeQueueResponse, error) {
+	return nil, errors.New("resume queue not implemented")
+}
+
+// PurgeQueue removes all messages from a queue if supported. For the in-memory
+// and Redis implementations this equates to deleting and recreating the queue.
+func (s *AdminService) PurgeQueue(ctx context.Context, req *queuepb.PurgeRequest) (*queuepb.PurgeResponse, error) {
+	name := req.GetQueueName()
+	info, err := s.q.GetQueueInfo(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.q.DeleteQueue(ctx, name); err != nil {
+		return nil, err
+	}
+	cfg := &queuepb.QueueConfig{}
+	cfg.SetName(name)
+	if err := s.q.CreateQueue(ctx, cfg); err != nil {
+		return nil, err
+	}
+	resp := &queuepb.PurgeResponse{}
+	resp.SetSuccess(true)
+	resp.SetMessagesPurged(info.GetMessageCount())
+	return resp, nil
+}
+
+// ResetQueueStats resets the statistics for a queue. For in-memory and Redis
+// implementations this is equivalent to purging the queue.
+func (s *AdminService) ResetQueueStats(ctx context.Context, req *queuepb.ResetQueueStatsRequest) (*queuepb.ResetQueueStatsResponse, error) {
+	if _, err := s.PurgeQueue(ctx, &queuepb.PurgeRequest{QueueName: req.GetQueueName()}); err != nil {
+		return nil, err
+	}
+	return &queuepb.ResetQueueStatsResponse{}, nil
 }

--- a/pkg/queue/grpc/monitoring_service.go
+++ b/pkg/queue/grpc/monitoring_service.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/grpc/monitoring_service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c59f3164-6838-40da-bbeb-e4f0d1cf676c
 //go:build queue_grpc
 // +build queue_grpc
@@ -7,8 +7,12 @@
 package grpc
 
 import (
+	"context"
+	"time"
+
 	"github.com/jdfalk/gcommon/pkg/queue"
 	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"google.golang.org/grpc/metadata"
 )
 
 type MonitoringService struct {
@@ -18,4 +22,57 @@ type MonitoringService struct {
 
 func NewMonitoringService(q queue.Queue) *MonitoringService {
 	return &MonitoringService{q: q}
+}
+
+// GetClusterInfo returns placeholder cluster information. Real implementations
+// would gather metrics from all queue nodes.
+func (s *MonitoringService) GetClusterInfo(context.Context, *queuepb.GetClusterInfoRequest) (*queuepb.GetClusterInfoResponse, error) {
+	return &queuepb.GetClusterInfoResponse{ClusterName: "in-memory", NodeCount: 1}, nil
+}
+
+// GetQueueHealth returns basic health status based on queue length.
+func (s *MonitoringService) GetQueueHealth(ctx context.Context, req *queuepb.GetQueueHealthRequest) (*queuepb.GetQueueHealthResponse, error) {
+	info, err := s.q.GetQueueInfo(ctx, req.GetQueueName())
+	if err != nil {
+		return nil, err
+	}
+	status := queuepb.HealthStatus_HEALTH_STATUS_HEALTHY
+	if info.GetMessageCount() > 1000 {
+		status = queuepb.HealthStatus_HEALTH_STATUS_WARNING
+	}
+	return &queuepb.GetQueueHealthResponse{Status: status}, nil
+}
+
+// GetQueueStats proxies queue information from the provider.
+func (s *MonitoringService) GetQueueStats(ctx context.Context, req *queuepb.GetQueueStatsRequest) (*queuepb.QueueStatsResponse, error) {
+	info, err := s.q.GetQueueInfo(ctx, req.GetQueueName())
+	if err != nil {
+		return nil, err
+	}
+	return &queuepb.QueueStatsResponse{Info: info}, nil
+}
+
+// StreamMetrics streams periodic metrics to the client until the context is
+// cancelled. This is a basic example that sends queue length every second.
+func (s *MonitoringService) StreamMetrics(req *queuepb.StreamMetricsRequest, srv queuepb.QueueMonitoringService_StreamMetricsServer) error {
+	ctx := srv.Context()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case t := <-ticker.C:
+			info, err := s.q.GetQueueInfo(ctx, req.GetQueueName())
+			if err != nil {
+				return err
+			}
+			md, _ := metadata.FromIncomingContext(ctx)
+			_ = md // currently unused
+			if err := srv.Send(&queuepb.MetricsEvent{Timestamp: t.Unix(), PendingMessages: info.GetMessageCount()}); err != nil {
+				return err
+			}
+		}
+	}
 }

--- a/pkg/queue/grpc/server.go
+++ b/pkg/queue/grpc/server.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/grpc/server.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 739634b6-cbd8-471b-b71b-1e2f8c4d3120
 //go:build queue_grpc
 // +build queue_grpc
@@ -16,5 +16,7 @@ import (
 func NewServer(q queue.Queue) *grpc.Server {
 	srv := grpc.NewServer()
 	queuepb.RegisterQueueServiceServer(srv, NewQueueService(q))
+	queuepb.RegisterQueueAdminServiceServer(srv, NewAdminService(q))
+	queuepb.RegisterQueueMonitoringServiceServer(srv, NewMonitoringService(q))
 	return srv
 }

--- a/pkg/queue/jobs/scheduler.go
+++ b/pkg/queue/jobs/scheduler.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/jobs/scheduler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 617260de-03ba-4067-865d-2c83af7a4049
 
 package jobs
@@ -12,19 +12,30 @@ import (
 )
 
 type Scheduler struct {
-	mu   sync.Mutex
-	jobs map[string]*JobStatus
+	mu      sync.Mutex
+	jobs    map[string]*JobStatus
+	cancel  map[string]context.CancelFunc
+	running sync.WaitGroup
 }
 
+// NewScheduler creates a scheduler capable of running single-run and recurring
+// jobs. Jobs are tracked in-memory and no persistence is provided.
 func NewScheduler() *Scheduler {
-	return &Scheduler{jobs: make(map[string]*JobStatus)}
+	return &Scheduler{
+		jobs:   make(map[string]*JobStatus),
+		cancel: make(map[string]context.CancelFunc),
+	}
 }
 
+// ScheduleJob schedules a one-time job to run at the specified time.
 func (s *Scheduler) ScheduleJob(ctx context.Context, job *Job) error {
 	s.mu.Lock()
 	s.jobs[job.ID] = &JobStatus{ID: job.ID}
 	s.mu.Unlock()
+
+	s.running.Add(1)
 	time.AfterFunc(time.Until(job.RunAt), func() {
+		defer s.running.Done()
 		err := job.Handler(ctx, job)
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -38,13 +49,53 @@ func (s *Scheduler) ScheduleJob(ctx context.Context, job *Job) error {
 	return nil
 }
 
+// ScheduleRecurringJob schedules a job to run repeatedly at the given interval
+// until the context is cancelled or CancelJob is called.
+func (s *Scheduler) ScheduleRecurringJob(ctx context.Context, job *Job, interval time.Duration) error {
+	s.mu.Lock()
+	if _, exists := s.jobs[job.ID]; exists {
+		s.mu.Unlock()
+		return fmt.Errorf("job %s already scheduled", job.ID)
+	}
+	s.jobs[job.ID] = &JobStatus{ID: job.ID}
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel[job.ID] = cancel
+	s.mu.Unlock()
+
+	s.running.Add(1)
+	go func() {
+		defer s.running.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := job.Handler(ctx, job); err != nil {
+					s.mu.Lock()
+					s.jobs[job.ID].Error = err.Error()
+					s.mu.Unlock()
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// CancelJob stops a scheduled or recurring job if present.
 func (s *Scheduler) CancelJob(ctx context.Context, jobID string) error {
 	s.mu.Lock()
+	if cancel, ok := s.cancel[jobID]; ok {
+		cancel()
+		delete(s.cancel, jobID)
+	}
 	delete(s.jobs, jobID)
 	s.mu.Unlock()
 	return nil
 }
 
+// GetJobStatus retrieves the status for a job.
 func (s *Scheduler) GetJobStatus(ctx context.Context, jobID string) (*JobStatus, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -53,4 +104,10 @@ func (s *Scheduler) GetJobStatus(ctx context.Context, jobID string) (*JobStatus,
 		return nil, fmt.Errorf("job %s not found", jobID)
 	}
 	return status, nil
+}
+
+// Wait blocks until all scheduled jobs have completed. This is mainly useful
+// for tests to ensure all goroutines have finished processing.
+func (s *Scheduler) Wait() {
+	s.running.Wait()
 }

--- a/pkg/queue/jobs/scheduler_test.go
+++ b/pkg/queue/jobs/scheduler_test.go
@@ -1,11 +1,12 @@
 // file: pkg/queue/jobs/scheduler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e4f528b7-359e-45b8-83a7-b20b807cfa27
 
 package jobs
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -29,5 +30,43 @@ func TestScheduler_ScheduleJob(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("job did not run")
+	}
+}
+
+// TestScheduler_ScheduleRecurringJob ensures recurring jobs execute multiple times
+// until cancelled.
+func TestScheduler_ScheduleRecurringJob(t *testing.T) {
+	t.Parallel()
+	s := NewScheduler()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	count := 0
+	job := &Job{
+		ID: "recur",
+		Handler: func(context.Context, *Job) error {
+			mu.Lock()
+			count++
+			mu.Unlock()
+			if count >= 3 {
+				cancel()
+			}
+			return nil
+		},
+	}
+	if err := s.ScheduleRecurringJob(ctx, job, 10*time.Millisecond); err != nil {
+		t.Fatalf("schedule recurring: %v", err)
+	}
+
+	// Wait for cancellation
+	<-ctx.Done()
+	s.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count < 3 {
+		t.Fatalf("expected at least 3 executions, got %d", count)
 	}
 }

--- a/pkg/queue/jobs/worker.go
+++ b/pkg/queue/jobs/worker.go
@@ -1,13 +1,53 @@
 // file: pkg/queue/jobs/worker.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d0a9c07c-518c-4ea5-93d3-cca02f4d31ad
 
 package jobs
 
-// Worker represents a simple job worker placeholder.
-type Worker struct {
-	Scheduler *Scheduler
+import (
+	"context"
+	"errors"
+	"time"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+// Worker consumes messages from a Queue and schedules them for processing using
+// the Scheduler. Each message is wrapped in a Job whose Handler invokes the
+// provided Processor function.
+// Subscriber defines the subset of queue operations needed by Worker. This
+// interface is intentionally small to avoid circular dependencies with the
+// parent queue package.
+type Subscriber interface {
+	Subscribe(ctx context.Context, handler func(context.Context, *queuepb.QueueMessage) error) error
 }
 
-// Start begins processing jobs. This is a placeholder implementation.
-func (w *Worker) Start() {}
+// Worker consumes messages from a Subscriber implementation and schedules them
+// for processing using the Scheduler. Each message is wrapped in a Job whose
+// Handler invokes the provided Processor function.
+type Worker struct {
+	Scheduler *Scheduler
+	Queue     Subscriber
+}
+
+// Start begins processing messages from the worker's queue. It subscribes to
+// the queue and schedules incoming messages as jobs using the provided
+// Processor. The worker continues running until the context is cancelled.
+func (w *Worker) Start(ctx context.Context, processor Processor) error {
+	if w.Scheduler == nil || w.Queue == nil {
+		return errors.New("worker requires scheduler and queue")
+	}
+	if processor == nil {
+		return errors.New("processor required")
+	}
+
+	return w.Queue.Subscribe(ctx, func(msgCtx context.Context, m *queuepb.QueueMessage) error {
+		job := &Job{
+			ID:      m.GetId(),
+			Message: &queuepb.Message{},
+			RunAt:   time.Now(),
+			Handler: func(c context.Context, j *Job) error { return processor(c, j) },
+		}
+		return w.Scheduler.ScheduleJob(msgCtx, job)
+	})
+}

--- a/pkg/queue/jobs/worker_test.go
+++ b/pkg/queue/jobs/worker_test.go
@@ -1,0 +1,75 @@
+// file: pkg/queue/jobs/worker_test.go
+// version: 1.0.0
+// guid: 661cb72e-0291-4820-b56c-b8c49988f642
+
+package jobs
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+// dummyQueue is a minimal in-memory implementation of the Subscriber
+// interface used for testing the Worker without introducing package
+// dependencies that could result in import cycles.
+type dummyQueue struct{ ch chan *queuepb.QueueMessage }
+
+func newDummyQueue() *dummyQueue { return &dummyQueue{ch: make(chan *queuepb.QueueMessage, 1)} }
+
+func (d *dummyQueue) Publish(msg *queuepb.QueueMessage) { d.ch <- msg }
+
+func (d *dummyQueue) Subscribe(ctx context.Context, h func(context.Context, *queuepb.QueueMessage) error) error {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m := <-d.ch:
+				_ = h(ctx, m)
+			}
+		}
+	}()
+	return nil
+}
+
+// TestWorker_Start ensures that the worker subscribes to the queue and schedules
+// jobs for processing.
+func TestWorker_Start(t *testing.T) {
+	t.Parallel()
+	dq := newDummyQueue()
+	sched := NewScheduler()
+	worker := &Worker{Scheduler: sched, Queue: dq}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	processed := 0
+	processor := func(ctx context.Context, j *Job) error {
+		mu.Lock()
+		processed++
+		mu.Unlock()
+		cancel()
+		return nil
+	}
+
+	if err := worker.Start(ctx, processor); err != nil {
+		t.Fatalf("start worker: %v", err)
+	}
+
+	msg := &queuepb.QueueMessage{}
+	msg.SetId("1")
+	dq.Publish(msg)
+
+	<-ctx.Done()
+	sched.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if processed != 1 {
+		t.Fatalf("expected 1 job processed, got %d", processed)
+	}
+}

--- a/pkg/queue/providers/memory.go
+++ b/pkg/queue/providers/memory.go
@@ -1,55 +1,164 @@
 // file: pkg/queue/providers/memory.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2295c946-d671-4f1f-8dd4-85f7aa6d56be
 
 package providers
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
 	"github.com/jdfalk/gcommon/pkg/queue"
 	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
 )
 
+// memoryQueue stores messages and statistics for a single logical queue.
+type memoryQueue struct {
+	name  string
+	ch    chan *queuepb.QueueMessage
+	mu    sync.Mutex
+	count int64
+}
+
+// MemoryQueue provides an in-memory implementation of the Queue interface.
+// It supports multiple named queues with simple statistics tracking. This
+// implementation is intended for development and testing scenarios and is not
+// suitable for production use where durability and distributed processing are
+// required.
 type MemoryQueue struct {
-	ch chan *queuepb.QueueMessage
+	mu      sync.RWMutex
+	queues  map[string]*memoryQueue
+	buffer  int
+	running sync.WaitGroup
 }
 
+// NewMemoryQueue creates a new MemoryQueue instance with the specified buffer
+// size. A default queue named "default" is automatically created to provide
+// backwards compatibility with earlier placeholder implementations.
 func NewMemoryQueue(buffer int) *MemoryQueue {
-	return &MemoryQueue{ch: make(chan *queuepb.QueueMessage, buffer)}
+	mq := &MemoryQueue{
+		queues: make(map[string]*memoryQueue),
+		buffer: buffer,
+	}
+	mq.queues["default"] = &memoryQueue{name: "default", ch: make(chan *queuepb.QueueMessage, buffer)}
+	return mq
 }
 
+// Publish enqueues a message to the queue specified in the context. If the
+// queue does not exist, an error is returned. The context may be cancelled to
+// abort the publish operation.
 func (m *MemoryQueue) Publish(ctx context.Context, message *queuepb.QueueMessage) error {
+	name, ok := queue.QueueNameFromContext(ctx)
+	if !ok {
+		name = "default"
+	}
+	m.mu.RLock()
+	q, ok := m.queues[name]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("queue %s not found", name)
+	}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case m.ch <- message:
+	case q.ch <- message:
+		q.mu.Lock()
+		q.count++
+		q.mu.Unlock()
 		return nil
 	}
 }
 
+// Subscribe registers a handler that will receive messages from the queue
+// specified in the context. The handler is executed asynchronously for each
+// message. If the queue does not exist the subscription fails.
 func (m *MemoryQueue) Subscribe(ctx context.Context, handler queue.MessageHandler) error {
+	name, ok := queue.QueueNameFromContext(ctx)
+	if !ok {
+		name = "default"
+	}
+	m.mu.RLock()
+	q, ok := m.queues[name]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("queue %s not found", name)
+	}
+
+	m.running.Add(1)
 	go func() {
+		defer m.running.Done()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case msg := <-m.ch:
-				_ = handler(ctx, msg)
+			case msg := <-q.ch:
+				if err := handler(ctx, msg); err != nil {
+					// For in-memory provider we simply ignore handler errors but in
+					// real providers this would route to DLQ or retry mechanisms.
+				}
 			}
 		}
 	}()
 	return nil
 }
 
+// CreateQueue creates a new named queue with the provided configuration. If
+// the queue already exists an error is returned.
 func (m *MemoryQueue) CreateQueue(ctx context.Context, config *queuepb.QueueConfig) error {
+	if config.GetName() == "" {
+		return errors.New("queue name required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.queues[config.GetName()]; exists {
+		return fmt.Errorf("queue %s already exists", config.GetName())
+	}
+	m.queues[config.GetName()] = &memoryQueue{name: config.GetName(), ch: make(chan *queuepb.QueueMessage, m.buffer)}
 	return nil
 }
 
+// DeleteQueue removes a queue and all pending messages.
 func (m *MemoryQueue) DeleteQueue(ctx context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	q, ok := m.queues[name]
+	if !ok {
+		return fmt.Errorf("queue %s not found", name)
+	}
+	close(q.ch)
+	delete(m.queues, name)
 	return nil
 }
 
+// GetQueueInfo returns basic statistics about a queue.
 func (m *MemoryQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
-	return &queuepb.QueueInfo{}, nil
+	m.mu.RLock()
+	q, ok := m.queues[name]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("queue %s not found", name)
+	}
+	q.mu.Lock()
+	pending := int64(len(q.ch))
+	q.mu.Unlock()
+
+	info := &queuepb.QueueInfo{}
+	info.SetName(name)
+	info.SetMessageCount(pending)
+	return info, nil
+}
+
+// Shutdown waits for all active subscribers to finish processing.
+func (m *MemoryQueue) Shutdown(ctx context.Context) {
+	ch := make(chan struct{})
+	go func() {
+		m.running.Wait()
+		close(ch)
+	}()
+	select {
+	case <-ctx.Done():
+	case <-ch:
+	}
 }

--- a/pkg/queue/providers/memory_test.go
+++ b/pkg/queue/providers/memory_test.go
@@ -1,5 +1,5 @@
 // file: pkg/queue/providers/memory_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: eb1cb3f1-9651-4ffc-b83d-954f0fc32713
 
 package providers
@@ -36,6 +36,61 @@ func TestMemoryQueue_PublishSubscribe(t *testing.T) {
 	case got := <-received:
 		if got == nil {
 			t.Fatal("expected message")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+// TestMemoryQueue_NamedQueue verifies that messages published to a named queue
+// are routed only to subscribers of that queue.
+func TestMemoryQueue_NamedQueue(t *testing.T) {
+	t.Parallel()
+	q := NewMemoryQueue(2)
+
+	ctxA := queue.WithQueueName(context.Background(), "A")
+	ctxB := queue.WithQueueName(context.Background(), "B")
+
+	cfgA := &queuepb.QueueConfig{}
+	cfgA.SetName("A")
+	if err := q.CreateQueue(context.Background(), cfgA); err != nil {
+		t.Fatalf("create queue A: %v", err)
+	}
+	receivedA := make(chan *queuepb.QueueMessage, 1)
+	if err := q.Subscribe(ctxA, queue.MessageHandler(func(_ context.Context, m *queuepb.QueueMessage) error {
+		receivedA <- m
+		return nil
+	})); err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+
+	// Create queue B and subscribe
+	cfg := &queuepb.QueueConfig{}
+	cfg.SetName("B")
+	if err := q.CreateQueue(context.Background(), cfg); err != nil {
+		t.Fatalf("create queue B: %v", err)
+	}
+	receivedB := make(chan *queuepb.QueueMessage, 1)
+	if err := q.Subscribe(ctxB, queue.MessageHandler(func(_ context.Context, m *queuepb.QueueMessage) error {
+		receivedB <- m
+		return nil
+	})); err != nil {
+		t.Fatalf("subscribe B: %v", err)
+	}
+
+	// Publish message to queue B only
+	msg := &queuepb.QueueMessage{}
+	msg.SetId("msgB")
+	if err := q.Publish(ctxB, msg); err != nil {
+		t.Fatalf("publish B: %v", err)
+	}
+
+	select {
+	case <-receivedA:
+		t.Fatal("queue A should not receive message for queue B")
+	case m := <-receivedB:
+		if m.GetId() != "msgB" {
+			t.Fatalf("unexpected message id: %s", m.GetId())
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for message")

--- a/pkg/queue/providers/redis.go
+++ b/pkg/queue/providers/redis.go
@@ -1,37 +1,126 @@
 // file: pkg/queue/providers/redis.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 17ce4e70-7beb-4eea-9b16-69139474add4
 
 package providers
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/jdfalk/gcommon/pkg/queue"
 	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"google.golang.org/protobuf/proto"
 )
 
-type RedisQueue struct{}
+// RedisQueue implements Queue using Redis lists for storage. Each queue is
+// represented as a Redis list with a configurable key prefix. Messages are
+// marshaled using protobuf for transport.
+type RedisQueue struct {
+	client *redis.Client
+	prefix string
+}
 
-func NewRedisQueue() *RedisQueue { return &RedisQueue{} }
+// NewRedisQueue creates a Redis-backed queue provider. The addr parameter is
+// passed directly to the underlying redis client. The prefix parameter is
+// prepended to all Redis keys; if empty, "queue:" is used.
+func NewRedisQueue(addr, prefix string) (*RedisQueue, error) {
+	if prefix == "" {
+		prefix = "queue:"
+	}
+	r := &RedisQueue{
+		client: redis.NewClient(&redis.Options{Addr: addr}),
+		prefix: prefix,
+	}
+	if err := r.client.Ping(context.Background()).Err(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
 
+// key returns the redis key for a queue name.
+func (r *RedisQueue) key(name string) string { return r.prefix + name }
+
+// Publish enqueues a message into the Redis list associated with the queue
+// identified in the context. Messages are marshaled using protobuf.
 func (r *RedisQueue) Publish(ctx context.Context, message *queuepb.QueueMessage) error {
-	return errors.New("redis provider not implemented")
+	name, ok := queue.QueueNameFromContext(ctx)
+	if !ok {
+		name = "default"
+	}
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return err
+	}
+	return r.client.LPush(ctx, r.key(name), data).Err()
 }
 
+// Subscribe blocks waiting for messages from the specified queue and invokes
+// the handler for each one. This uses BRPOP with an infinite timeout to wait
+// for new messages. The method returns immediately after starting the listener.
 func (r *RedisQueue) Subscribe(ctx context.Context, handler queue.MessageHandler) error {
-	return errors.New("redis provider not implemented")
+	name, ok := queue.QueueNameFromContext(ctx)
+	if !ok {
+		name = "default"
+	}
+	key := r.key(name)
+
+	go func() {
+		for {
+			res, err := r.client.BRPop(ctx, 0*time.Second, key).Result()
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				// In case of transient errors wait briefly before retrying
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			if len(res) != 2 {
+				continue
+			}
+			var msg queuepb.QueueMessage
+			if err := proto.Unmarshal([]byte(res[1]), &msg); err != nil {
+				continue
+			}
+			_ = handler(ctx, &msg)
+		}
+	}()
+	return nil
 }
 
+// CreateQueue initializes a queue by creating an empty list. Redis creates
+// lists on first push so we perform a harmless LPUSH/LPOP sequence to ensure
+// the key exists.
 func (r *RedisQueue) CreateQueue(ctx context.Context, config *queuepb.QueueConfig) error {
-	return errors.New("redis provider not implemented")
+	if config.GetName() == "" {
+		return fmt.Errorf("queue name required")
+	}
+	key := r.key(config.GetName())
+	if err := r.client.LPush(ctx, key, "").Err(); err != nil {
+		return err
+	}
+	return r.client.LPop(ctx, key).Err()
 }
 
+// DeleteQueue removes the Redis list for the specified queue.
 func (r *RedisQueue) DeleteQueue(ctx context.Context, name string) error {
-	return errors.New("redis provider not implemented")
+	return r.client.Del(ctx, r.key(name)).Err()
 }
 
+// GetQueueInfo retrieves basic statistics for a queue using LLEN.
 func (r *RedisQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
-	return nil, errors.New("redis provider not implemented")
+	length, err := r.client.LLen(ctx, r.key(name)).Result()
+	if err != nil {
+		return nil, err
+	}
+	info := &queuepb.QueueInfo{}
+	info.SetName(name)
+	info.SetMessageCount(length)
+	return info, nil
 }
+
+// Close closes the underlying Redis client.
+func (r *RedisQueue) Close() error { return r.client.Close() }

--- a/pkg/queue/providers/redis_test.go
+++ b/pkg/queue/providers/redis_test.go
@@ -1,0 +1,62 @@
+// file: pkg/queue/providers/redis_test.go
+// version: 1.0.0
+// guid: fb4ee00a-7d62-4c2a-8585-0f47871b0284
+
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	queue "github.com/jdfalk/gcommon/pkg/queue"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+// TestRedisQueue_PublishSubscribe validates basic publish/subscribe flow using
+// a miniredis server.
+func TestRedisQueue_PublishSubscribe(t *testing.T) {
+	t.Parallel()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rq, err := NewRedisQueue(mr.Addr(), "")
+	if err != nil {
+		t.Fatalf("new redis queue: %v", err)
+	}
+	defer rq.Close()
+
+	ctx := queue.WithQueueName(context.Background(), "test")
+	cfg := &queuepb.QueueConfig{}
+	cfg.SetName("test")
+	if err := rq.CreateQueue(context.Background(), cfg); err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	received := make(chan *queuepb.QueueMessage, 1)
+	if err := rq.Subscribe(ctx, queue.MessageHandler(func(_ context.Context, m *queuepb.QueueMessage) error {
+		received <- m
+		return nil
+	})); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	msg := &queuepb.QueueMessage{}
+	msg.SetId("1")
+	if err := rq.Publish(ctx, msg); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case m := <-received:
+		if m.GetId() != "1" {
+			t.Fatalf("unexpected message id: %s", m.GetId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}


### PR DESCRIPTION
## Summary
- add in-memory and Redis queue providers with context-based routing and stats
- implement queue admin and monitoring gRPC services with job scheduling support
- introduce queue name context helpers, recurring job scheduler, and worker tests

## Testing
- `go test ./pkg/queue/...`


------
https://chatgpt.com/codex/tasks/task_e_68992d309c948321b0ac7c581b909f17