### PR TITLE
feat: add initial examples and tutorials for core modules

### DIFF
--- a/.github/doc-updates/0d577ea9-833d-4897-9fdf-6d34274b793e.json
+++ b/.github/doc-updates/0d577ea9-833d-4897-9fdf-6d34274b793e.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Examples and Tutorials\\n\\nTODO: Add content for this section",
+  "guid": "0d577ea9-833d-4897-9fdf-6d34274b793e",
+  "created_at": "2025-08-10T23:44:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/72d5400e-c47d-4d01-a06a-0126d5168037.json
+++ b/.github/doc-updates/72d5400e-c47d-4d01-a06a-0126d5168037.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Complete remaining module examples",
+  "guid": "72d5400e-c47d-4d01-a06a-0126d5168037",
+  "created_at": "2025-08-10T23:44:55Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/fffabf1d-ef21-44f5-86a9-9006518b57cb.json
+++ b/.github/doc-updates/fffabf1d-ef21-44f5-86a9-9006518b57cb.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added examples for config and queue modules (Task 11).",
+  "guid": "fffabf1d-ef21-44f5-86a9-9006518b57cb",
+  "created_at": "2025-08-10T23:44:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/examples/getting-started/basic-setup/README.md
+++ b/examples/getting-started/basic-setup/README.md
@@ -1,7 +1,35 @@
 <!-- file: examples/getting-started/basic-setup/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 92d02bc5-e8b2-4591-847f-9e228ae9ccd9 -->
 
 # Basic Setup Example
 
-This example shows a minimal Go application using gcommon.
+This example demonstrates the smallest possible program that uses gcommon. It
+loads configuration from a YAML file and prints the resulting map to standard
+output.
+
+## Prerequisites
+
+- Go 1.23 or later
+- A `config.yaml` file in the same directory (a sample is shown below)
+
+```yaml
+app:
+  name: demo
+  port: 8080
+```
+
+## Running the Example
+
+```bash
+go run .
+```
+
+The program loads the configuration and prints the merged settings. Additional
+sources such as environment variables can be added by extending the loader in
+`main.go`.
+
+## Next Steps
+
+- Explore other examples in this repository
+- Read the configuration module documentation for advanced scenarios

--- a/examples/getting-started/basic-setup/main.go
+++ b/examples/getting-started/basic-setup/main.go
@@ -1,33 +1,50 @@
 // file: examples/getting-started/basic-setup/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f47dcc6d-2d49-421d-bfce-b39ae5779d50
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
+        "github.com/jdfalk/gcommon/pkg/config/sources"
 )
 
-// TODO: Complete basic-setup example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for basic-setup
-	return nil
+// setup creates a simple configuration loader that reads from a YAML file.
+//
+// The loader is returned so that run can demonstrate how to use it. In a real
+// application additional sources (environment variables, command line flags,
+// remote stores) would be provided.
+func setup(ctx context.Context) (*config.Loader, error) {
+        file := sources.FileSource{Path: "config.yaml"}
+        loader := config.NewLoader(nil, config.ConfigSource(file))
+        return loader, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run basic-setup logic
-	fmt.Println("TODO: run basic-setup")
-	return nil
+// run loads the configuration and prints it to stdout. This function serves as
+// the minimal "Hello World" style demonstration of using gcommon's config
+// package.
+func run(ctx context.Context, loader *config.Loader) error {
+        cfg, err := loader.Load()
+        if err != nil {
+                return err
+        }
+        fmt.Printf("loaded config: %v\n", cfg)
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
+        loader, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, loader); err != nil {
+                panic(err)
+        }
 }

--- a/examples/getting-started/common-patterns/README.md
+++ b/examples/getting-started/common-patterns/README.md
@@ -1,7 +1,32 @@
 <!-- file: examples/getting-started/common-patterns/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 03cb484b-3610-45e6-ae96-0737e532e4c3 -->
 
 # Common Patterns Example
 
-Placeholder for common gcommon integration patterns.
+This example illustrates how configuration, metrics, and queue components can be
+combined in a small application. It loads settings from environment variables,
+publishes a message to a queue, and tracks processing with a counter metric.
+
+## Highlights
+
+- Environment-based configuration loading
+- In-memory queue for message passing
+- Prometheus metrics provider for instrumentation
+
+## Running
+
+```bash
+go run .
+```
+
+## Environment Variables
+
+Set the following variables to see configuration merging in action:
+
+```bash
+export APP_PORT=9000
+export APP_ENV=development
+```
+
+The loaded configuration is printed to the console.

--- a/examples/getting-started/common-patterns/main.go
+++ b/examples/getting-started/common-patterns/main.go
@@ -1,33 +1,89 @@
 // file: examples/getting-started/common-patterns/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 30361479-35e5-4d3f-b9a8-b990d37a2ae3
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
+        "github.com/jdfalk/gcommon/pkg/config/sources"
+        "github.com/jdfalk/gcommon/pkg/metrics"
+        prom "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
+        "github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
-// TODO: Complete common-patterns example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for common-patterns
-	return nil
+// app encapsulates commonly used components that appear across many examples:
+// configuration loading, metrics collection, and queue publishing.
+type app struct {
+        loader   *config.Loader
+        metrics  metrics.Provider
+        messages chan string
 }
 
-func run(ctx context.Context) error {
-	// TODO: run common-patterns logic
-	fmt.Println("TODO: run common-patterns")
-	return nil
+// setup wires together configuration, metrics, and a memory queue provider.
+func setup(ctx context.Context) (*app, error) {
+        // Load configuration from environment with APP_ prefix
+        env := sources.EnvSource{Prefix: "APP_"}
+        loader := config.NewLoader(nil, config.ConfigSource(env))
+
+        // Metrics provider for instrumentation
+        provider, err := prom.NewProvider(metrics.Config{})
+        if err != nil {
+                return nil, err
+        }
+        if err := provider.Start(ctx); err != nil {
+                return nil, err
+        }
+
+        // Simple memory queue used for demonstration
+        q := providers.NewMemoryQueue(5)
+        ch := make(chan string, 1)
+        go func() {
+                for {
+                        msg, err := q.Consume(ctx)
+                        if err != nil {
+                                return
+                        }
+                        ch <- msg.Body
+                }
+        }()
+
+        return &app{loader: loader, metrics: provider, messages: ch}, nil
+}
+
+// run publishes a message to the queue and prints the loaded configuration.
+func run(ctx context.Context, a *app) error {
+        cfg, err := a.loader.Load()
+        if err != nil {
+                return err
+        }
+        fmt.Printf("config: %v\n", cfg)
+
+        counter := a.metrics.Counter("processed_messages_total")
+        queue := providers.NewMemoryQueue(5)
+        _ = queue.Publish(ctx, &providers.Message{Body: "hello"})
+        select {
+        case msg := <-a.messages:
+                fmt.Println("received:", msg)
+                counter.Inc()
+        case <-time.After(time.Second):
+                fmt.Println("no message received")
+        }
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+        defer cancel()
+        a, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, a); err != nil {
+                panic(err)
+        }
 }

--- a/examples/getting-started/first-app/README.md
+++ b/examples/getting-started/first-app/README.md
@@ -1,7 +1,31 @@
 <!-- file: examples/getting-started/first-app/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: ab1fcfcc-224b-4696-a486-f3f3e5f5f027 -->
 
 # First App Example
 
-Placeholder for building a simple gcommon application.
+This tutorial walks through building a tiny HTTP service instrumented with
+Prometheus metrics using gcommon. It responds to requests on `/hello` and
+exposes metrics on `/metrics`.
+
+## Steps
+
+1. Start the application:
+
+   ```bash
+   go run .
+   ```
+
+2. Visit [http://localhost:8080/hello](http://localhost:8080/hello) to trigger a
+   request. Each request increments a counter.
+
+3. View metrics at
+   [http://localhost:8080/metrics](http://localhost:8080/metrics).
+
+## What You Learned
+
+- Initializing the Prometheus metrics provider
+- Creating and incrementing a counter
+- Exposing metrics through an HTTP handler
+
+Continue with the other examples to see additional modules in action.

--- a/examples/getting-started/first-app/main.go
+++ b/examples/getting-started/first-app/main.go
@@ -1,33 +1,70 @@
 // file: examples/getting-started/first-app/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a2eaf657-6cd4-4015-88b7-456534fdd008
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "net/http"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/metrics"
+        prom "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
 )
 
-// TODO: Complete first-app example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for first-app
-	return nil
+// server wraps the HTTP server and metrics provider so that setup and run can
+// share state in a minimal way without introducing global variables.
+type server struct {
+        provider metrics.Provider
+        counter  metrics.Counter
 }
 
-func run(ctx context.Context) error {
-	// TODO: run first-app logic
-	fmt.Println("TODO: run first-app")
-	return nil
+// setup initializes a Prometheus metrics provider and creates a counter for HTTP
+// requests. The provider also exposes an HTTP handler at `/metrics` for scraping
+// by Prometheus.
+func setup(ctx context.Context) (*server, error) {
+        provider, err := prom.NewProvider(metrics.Config{})
+        if err != nil {
+                return nil, err
+        }
+        if err := provider.Start(ctx); err != nil {
+                return nil, err
+        }
+        s := &server{provider: provider, counter: provider.Counter("requests_total")}
+        return s, nil
+}
+
+// run starts a simple HTTP server with a single endpoint. Each request
+// increments the metrics counter to demonstrate instrumentation.
+func run(ctx context.Context, s *server) error {
+        mux := http.NewServeMux()
+        mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+                s.counter.Inc()
+                fmt.Fprintln(w, "hello from gcommon")
+        })
+        mux.Handle("/metrics", s.provider.Handler())
+
+        srv := &http.Server{Addr: ":8080", Handler: mux}
+
+        go func() {
+                <-ctx.Done()
+                _ = srv.Shutdown(context.Background())
+        }()
+
+        return srv.ListenAndServe()
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+
+        srv, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, srv); err != nil && err != http.ErrServerClosed {
+                panic(err)
+        }
 }

--- a/examples/modules/config/basic-config/README.md
+++ b/examples/modules/config/basic-config/README.md
@@ -1,7 +1,22 @@
 <!-- file: examples/modules/config/basic-config/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: eef0c368-52cf-4a49-b4b9-c6f9ebde09c4 -->
 
 # Basic Config Example
 
-Placeholder for Basic Config example.
+Demonstrates using the configuration merger with default settings. This is the
+simplest configuration scenario and forms the basis for more advanced examples.
+
+## Running
+
+```bash
+go run .
+```
+
+The program prints the merged configuration map. Modify defaults in `main.go`
+to see different output.
+
+## Related Examples
+
+- [File Config](../file-config/README.md)
+- [Environment Config](../env-config/README.md)

--- a/examples/modules/config/basic-config/main.go
+++ b/examples/modules/config/basic-config/main.go
@@ -1,33 +1,43 @@
 // file: examples/modules/config/basic-config/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: ed8e57b1-20b5-4cd1-b9a8-4d2f9b12ff5a
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
 )
 
-// TODO: Complete basic-config example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for basic-config
-	return nil
+// setup returns a configuration merger using default values embedded in code.
+// Additional sources can be layered on top in more advanced examples.
+func setup(ctx context.Context) (*config.Merger, error) {
+        defaults := map[string]interface{}{
+                "port": 8080,
+                "env":  "development",
+        }
+        merger := config.NewMerger(defaults)
+        return merger, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run basic-config logic
-	fmt.Println("TODO: run basic-config")
-	return nil
+// run retrieves the final configuration map and prints it.
+func run(ctx context.Context, merger *config.Merger) error {
+        final := merger.Merge()
+        fmt.Printf("final config: %v\n", final)
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        merger, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, merger); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/config/dynamic-config/README.md
+++ b/examples/modules/config/dynamic-config/README.md
@@ -1,7 +1,17 @@
 <!-- file: examples/modules/config/dynamic-config/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 67f1ac5d-d636-4159-933d-8224d0e36030 -->
 
 # Dynamic Config Example
 
-Placeholder for Dynamic Config example.
+Uses the `Watcher` to monitor a configuration file and react to changes at
+runtime. When `config.yaml` is modified, the updated map is printed to the
+console.
+
+## Run
+
+```bash
+go run .
+```
+
+Edit `config.yaml` in another terminal to observe change notifications.

--- a/examples/modules/config/dynamic-config/main.go
+++ b/examples/modules/config/dynamic-config/main.go
@@ -1,33 +1,48 @@
 // file: examples/modules/config/dynamic-config/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: afadb93b-48ce-446c-82e2-e951a01f7ef2
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
+        "github.com/jdfalk/gcommon/pkg/config/sources"
 )
 
-// TODO: Complete dynamic-config example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for dynamic-config
-	return nil
+// setup creates a watcher that reloads configuration when the underlying file
+// changes. For simplicity this example uses a temporary file.
+func setup(ctx context.Context) (*config.Watcher, error) {
+        file := sources.FileSource{Path: "config.yaml"}
+        loader := config.NewLoader(nil, config.ConfigSource(file))
+        watcher := config.NewWatcher(loader, time.Second)
+        return watcher, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run dynamic-config logic
-	fmt.Println("TODO: run dynamic-config")
-	return nil
+// run starts the watcher and prints configuration updates until the context is
+// canceled.
+func run(ctx context.Context, watcher *config.Watcher) error {
+        updates := watcher.Start(ctx)
+        go func() {
+                for cfg := range updates {
+                        fmt.Printf("updated config: %v\n", cfg)
+                }
+        }()
+        <-ctx.Done()
+        return watcher.Stop(context.Background())
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+        watcher, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, watcher); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/config/env-config/README.md
+++ b/examples/modules/config/env-config/README.md
@@ -1,7 +1,22 @@
 <!-- file: examples/modules/config/env-config/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: cd76db96-f4d4-4101-89f5-054aaebe2e26 -->
 
 # Env Config Example
 
-Placeholder for Env Config example.
+Loads configuration from environment variables using the `EnvSource`. Variables
+must be prefixed with `APP_` to be recognized.
+
+## Run
+
+```bash
+export APP_GREETING=world
+go run .
+```
+
+The output shows a map containing `{"GREETING": "world"}`.
+
+## Related Examples
+
+- [Basic Config](../basic-config/README.md)
+- [Dynamic Config](../dynamic-config/README.md)

--- a/examples/modules/config/env-config/main.go
+++ b/examples/modules/config/env-config/main.go
@@ -1,33 +1,46 @@
 // file: examples/modules/config/env-config/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 162bfea1-d138-49f1-91b0-6132fe2e9e91
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "os"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
+        "github.com/jdfalk/gcommon/pkg/config/sources"
 )
 
-// TODO: Complete env-config example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for env-config
-	return nil
+// setup configures a loader that reads environment variables prefixed with
+// `APP_`.
+func setup(ctx context.Context) (*config.Loader, error) {
+        env := sources.EnvSource{Prefix: "APP_"}
+        loader := config.NewLoader(nil, config.ConfigSource(env))
+        return loader, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run env-config logic
-	fmt.Println("TODO: run env-config")
-	return nil
+// run demonstrates reading environment variables via the configuration loader.
+func run(ctx context.Context, loader *config.Loader) error {
+        _ = os.Setenv("APP_GREETING", "hello")
+        cfg, err := loader.Load()
+        if err != nil {
+                return err
+        }
+        fmt.Printf("environment config: %v\n", cfg)
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        loader, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, loader); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/config/file-config/README.md
+++ b/examples/modules/config/file-config/README.md
@@ -1,7 +1,23 @@
 <!-- file: examples/modules/config/file-config/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 737a2a6b-5333-4a6d-ae2c-400a2e3f5a09 -->
 
 # File Config Example
 
-Placeholder for File Config example.
+Demonstrates loading configuration from a YAML file using gcommon's loader.
+Defaults defined in code are merged with file values.
+
+## Sample `config.yaml`
+
+```yaml
+timeout: 10
+```
+
+## Run
+
+```bash
+go run .
+```
+
+The program prints the merged configuration showing that values from the file
+override defaults.

--- a/examples/modules/config/file-config/main.go
+++ b/examples/modules/config/file-config/main.go
@@ -1,33 +1,47 @@
 // file: examples/modules/config/file-config/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0d9d21f6-2818-47ce-84f7-40c736b13de2
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/config"
+        "github.com/jdfalk/gcommon/pkg/config/sources"
 )
 
-// TODO: Complete file-config example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for file-config
-	return nil
+// setup creates a loader that reads configuration from `config.yaml` and merges
+// it with defaults.
+func setup(ctx context.Context) (*config.Merger, error) {
+        defaults := map[string]interface{}{"timeout": 5}
+        file := sources.FileSource{Path: "config.yaml"}
+        loader := config.NewLoader(nil, config.ConfigSource(file))
+        cfg, err := loader.Load()
+        if err != nil {
+                return nil, err
+        }
+        merger := config.NewMerger(defaults, cfg)
+        return merger, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run file-config logic
-	fmt.Println("TODO: run file-config")
-	return nil
+// run prints the merged configuration demonstrating that file values override
+// defaults.
+func run(ctx context.Context, merger *config.Merger) error {
+        fmt.Printf("merged: %v\n", merger.Merge())
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        merger, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, merger); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/metrics/basic-metrics/README.md
+++ b/examples/modules/metrics/basic-metrics/README.md
@@ -1,7 +1,22 @@
 <!-- file: examples/modules/metrics/basic-metrics/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 76303b64-b72f-4857-86f7-8b9220beacdb -->
 
 # Basic Metrics Example
 
-Placeholder for Basic Metrics example.
+Introduces the metrics provider by creating a counter and a gauge. Values are
+updated and printed to verify basic functionality.
+
+## Run
+
+```bash
+go run .
+```
+
+Expected output:
+
+```
+counter=1 gauge=21.5
+```
+
+Use this as a foundation for more advanced metrics examples.

--- a/examples/modules/metrics/basic-metrics/main.go
+++ b/examples/modules/metrics/basic-metrics/main.go
@@ -1,33 +1,57 @@
 // file: examples/modules/metrics/basic-metrics/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 085a36c1-0992-4b71-be20-339d80353c42
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/metrics"
+        prom "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
 )
 
-// TODO: Complete basic-metrics example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for basic-metrics
-	return nil
+// metricsApp holds the provider and example metrics used in this demo.
+type metricsApp struct {
+        provider metrics.Provider
+        counter  metrics.Counter
+        gauge    metrics.Gauge
 }
 
-func run(ctx context.Context) error {
-	// TODO: run basic-metrics logic
-	fmt.Println("TODO: run basic-metrics")
-	return nil
+// setup initializes the Prometheus provider and creates two basic metrics.
+func setup(ctx context.Context) (*metricsApp, error) {
+        provider, err := prom.NewProvider(metrics.Config{})
+        if err != nil {
+                return nil, err
+        }
+        if err := provider.Start(ctx); err != nil {
+                return nil, err
+        }
+        return &metricsApp{
+                provider: provider,
+                counter:  provider.Counter("requests_total"),
+                gauge:    provider.Gauge("temperature_celsius"),
+        }, nil
+}
+
+// run increments the counter and sets a gauge value, then prints the values.
+func run(ctx context.Context, app *metricsApp) error {
+        app.counter.Inc()
+        app.gauge.Set(21.5)
+        fmt.Printf("counter=%v gauge=%v\n", app.counter.Value(), app.gauge.Value())
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        app, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, app); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/queue/basic-queue/README.md
+++ b/examples/modules/queue/basic-queue/README.md
@@ -1,7 +1,16 @@
 <!-- file: examples/modules/queue/basic-queue/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 326ab0d3-b07e-440f-9089-43bcd995bf41 -->
 
 # Basic Queue Example
 
-Placeholder for Basic Queue example.
+Shows how to publish and consume a message using the in-memory queue provider.
+
+## Run
+
+```bash
+go run .
+```
+
+The program publishes a message and immediately consumes it, printing the body
+to the console.

--- a/examples/modules/queue/basic-queue/main.go
+++ b/examples/modules/queue/basic-queue/main.go
@@ -1,33 +1,50 @@
 // file: examples/modules/queue/basic-queue/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f7b5c457-5a6f-418a-936d-ce03d61051eb
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
-// TODO: Complete basic-queue example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for basic-queue
-	return nil
+// queueApp holds the in-memory queue used in this basic example.
+type queueApp struct {
+        q providers.Queue
 }
 
-func run(ctx context.Context) error {
-	// TODO: run basic-queue logic
-	fmt.Println("TODO: run basic-queue")
-	return nil
+// setup initializes a memory-backed queue with capacity for ten messages.
+func setup(ctx context.Context) (*queueApp, error) {
+        q := providers.NewMemoryQueue(10)
+        return &queueApp{q: q}, nil
+}
+
+// run publishes and consumes a single message.
+func run(ctx context.Context, app *queueApp) error {
+        msg := &providers.Message{Body: "hello queue"}
+        if err := app.q.Publish(ctx, msg); err != nil {
+                return err
+        }
+        received, err := app.q.Consume(ctx)
+        if err != nil {
+                return err
+        }
+        fmt.Printf("received message: %s\n", received.Body)
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        app, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, app); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/queue/job-scheduler/README.md
+++ b/examples/modules/queue/job-scheduler/README.md
@@ -1,7 +1,17 @@
 <!-- file: examples/modules/queue/job-scheduler/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 63faf064-81eb-466b-812b-c28bff33e628 -->
 
 # Job Scheduler Example
 
-Placeholder for Job Scheduler example.
+Uses the `jobs.Scheduler` to execute a task in the future. A job is scheduled to
+run one second after startup and prints a message when executed.
+
+## Run
+
+```bash
+go run .
+```
+
+The program waits briefly for the job to complete and then outputs the job's
+completion status.

--- a/examples/modules/queue/job-scheduler/main.go
+++ b/examples/modules/queue/job-scheduler/main.go
@@ -1,33 +1,60 @@
 // file: examples/modules/queue/job-scheduler/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d47db8d-acf5-4664-abb8-7f3003d389fb
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/queue/jobs"
+        queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
 )
 
-// TODO: Complete job-scheduler example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for job-scheduler
-	return nil
+// schedulerApp wraps the job scheduler used in this example.
+type schedulerApp struct {
+        s *jobs.Scheduler
 }
 
-func run(ctx context.Context) error {
-	// TODO: run job-scheduler logic
-	fmt.Println("TODO: run job-scheduler")
-	return nil
+// setup creates a new scheduler instance.
+func setup(ctx context.Context) (*schedulerApp, error) {
+        return &schedulerApp{s: jobs.NewScheduler()}, nil
+}
+
+// run schedules a job to execute after one second and waits for completion.
+func run(ctx context.Context, app *schedulerApp) error {
+        job := &jobs.Job{
+                ID:      "demo", 
+                Message: &queuepb.Message{Body: "payload"},
+                RunAt:   time.Now().Add(time.Second),
+                Handler: func(ctx context.Context, j *jobs.Job) error {
+                        fmt.Println("executing job:", j.Message.Body)
+                        return nil
+                },
+        }
+        if err := app.s.ScheduleJob(ctx, job); err != nil {
+                return err
+        }
+        // Wait for job completion
+        time.Sleep(1500 * time.Millisecond)
+        status, err := app.s.GetJobStatus(ctx, "demo")
+        if err != nil {
+                return err
+        }
+        fmt.Printf("job completed: %v\n", status.Completed)
+        return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+        app, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, app); err != nil {
+                panic(err)
+        }
 }

--- a/examples/modules/queue/worker-pool/README.md
+++ b/examples/modules/queue/worker-pool/README.md
@@ -1,7 +1,22 @@
 <!-- file: examples/modules/queue/worker-pool/README.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: a795cc9a-a669-44d8-8783-6bc62f9520cc -->
 
 # Worker Pool Example
 
-Placeholder for Worker Pool example.
+Demonstrates processing messages concurrently using multiple goroutines. Messages
+are published to an in-memory queue and workers consume them in parallel.
+
+## Run
+
+```bash
+go run .
+```
+
+You should see output similar to:
+
+```
+worker 0 processed job-0
+worker 1 processed job-1
+...
+```

--- a/examples/modules/queue/worker-pool/main.go
+++ b/examples/modules/queue/worker-pool/main.go
@@ -1,33 +1,66 @@
 // file: examples/modules/queue/worker-pool/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 917ed822-710c-48b4-b1b0-309696429460
 
 package main
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
+        "sync"
+        "time"
+
+        "github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
-// TODO: Complete worker-pool example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for worker-pool
-	return nil
+// poolApp demonstrates a simple worker pool consuming messages concurrently.
+type poolApp struct {
+        q providers.Queue
 }
 
-func run(ctx context.Context) error {
-	// TODO: run worker-pool logic
-	fmt.Println("TODO: run worker-pool")
-	return nil
+// setup creates a memory queue and publishes a few messages to be processed.
+func setup(ctx context.Context) (*poolApp, error) {
+        q := providers.NewMemoryQueue(100)
+        for i := 0; i < 5; i++ {
+                _ = q.Publish(ctx, &providers.Message{Body: fmt.Sprintf("job-%d", i)})
+        }
+        return &poolApp{q: q}, nil
+}
+
+// run starts a fixed number of workers that consume messages from the queue.
+func run(ctx context.Context, app *poolApp) error {
+        var wg sync.WaitGroup
+        workers := 3
+        for i := 0; i < workers; i++ {
+                wg.Add(1)
+                go func(id int) {
+                        defer wg.Done()
+                        for {
+                                msg, err := app.q.Consume(ctx)
+                                if err != nil {
+                                        return
+                                }
+                                fmt.Printf("worker %d processed %s\n", id, msg.Body)
+                        }
+                }(i)
+        }
+
+        // Allow workers time to process then cancel
+        time.Sleep(500 * time.Millisecond)
+        cancelCtx, cancel := context.WithCancel(ctx)
+        cancel()
+        wg.Wait()
+        return app.q.Close(cancelCtx)
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
-		panic(err)
-	}
-	if err := run(ctx); err != nil {
-		panic(err)
-	}
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        app, err := setup(ctx)
+        if err != nil {
+                panic(err)
+        }
+        if err := run(ctx, app); err != nil {
+                panic(err)
+        }
 }

--- a/issue_updates.json
+++ b/issue_updates.json
@@ -17,4 +17,11 @@
     "body": "Implement SessionConfig, SessionData messages and session CRUD request/response protobufs.",
     "labels": ["module:web", "type:protobuf", "enhancement"]
   }
+  ,
+  {
+    "action": "create",
+    "title": "Examples: add module tutorials",
+    "body": "Add example programs and tutorial documentation for config, queue, and metrics modules (Task 11).",
+    "labels": ["documentation", "examples"]
+  }
 ]


### PR DESCRIPTION
## Summary
- add getting-started tutorials with configuration and metrics usage
- provide module examples for config, queue, and metrics
- track new examples issue and queue documentation updates via doc-update system

## Testing
- `go test ./...` *(fails: cannot use metrics.Tag as Option in pkg/metrics/prometheus/utils.go)*

------
https://chatgpt.com/codex/tasks/task_e_68992dcd21548321afe204ce69b2b878