### PR TITLE
feat: add microservice templates and generator

### DIFF
--- a/.github/doc-updates/316dfc02-92ca-4c01-bd5a-64f5df1ceee1.json
+++ b/.github/doc-updates/316dfc02-92ca-4c01-bd5a-64f5df1ceee1.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added microservice templates and generator",
+  "guid": "316dfc02-92ca-4c01-bd5a-64f5df1ceee1",
+  "created_at": "2025-08-11T01:26:54Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/77d08a2a-15f4-42bf-82db-81bca42a424b.json
+++ b/.github/doc-updates/77d08a2a-15f4-42bf-82db-81bca42a424b.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Finalize gateway and worker service templates",
+  "guid": "77d08a2a-15f4-42bf-82db-81bca42a424b",
+  "created_at": "2025-08-11T01:27:01Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f6d03166-ca68-41ab-b139-b6e8558726c2.json
+++ b/.github/doc-updates/f6d03166-ca68-41ab-b139-b6e8558726c2.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Microservice Templates\\nTemplates for common service types are now available with a generation CLI.",
+  "guid": "f6d03166-ca68-41ab-b139-b6e8558726c2",
+  "created_at": "2025-08-11T01:26:58Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/de4af46c-62b0-4034-bb79-a1d526d04753.json
+++ b/.github/issue-updates/de4af46c-62b0-4034-bb79-a1d526d04753.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Implement microservice templates",
+  "body": "Add production-ready microservice templates and generator.",
+  "labels": ["enhancement", "templates"],
+  "guid": "de4af46c-62b0-4034-bb79-a1d526d04753",
+  "legacy_guid": "create-implement-microservice-templates-2025-08-11",
+  "created_at": "2025-08-11T01:26:48.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/cmd/microservice-template/main.go
+++ b/cmd/microservice-template/main.go
@@ -1,0 +1,58 @@
+// file: cmd/microservice-template/main.go
+// version: 1.0.0
+// guid: 8d489f9b-5eed-4b00-98ae-93f4d6ed0478
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	tmpl := flag.String("template", "", "template name")
+	target := flag.String("target", "", "target directory")
+	name := flag.String("name", "", "service name for replacement")
+	flag.Parse()
+
+	if *tmpl == "" || *target == "" || *name == "" {
+		fmt.Println("usage: microservice-template -template <name> -target <dir> -name <service>")
+		os.Exit(1)
+	}
+
+	templateDir := filepath.Join("templates", *tmpl)
+	if err := copyTemplate(templateDir, *target, *tmpl, *name); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func copyTemplate(src, dst, tmplName, svcName string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(dst, strings.ReplaceAll(rel, tmplName, svcName))
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		content := strings.ReplaceAll(string(data), tmplName, svcName)
+		return os.WriteFile(targetPath, []byte(content), info.Mode())
+	})
+}
+
+// CopyFile is exposed for testing.
+func CopyFile(src, dst, tmplName, svcName string) error {
+	return copyTemplate(src, dst, tmplName, svcName)
+}

--- a/cmd/microservice-template/main_test.go
+++ b/cmd/microservice-template/main_test.go
@@ -1,0 +1,23 @@
+// file: cmd/microservice-template/main_test.go
+// version: 1.0.0
+// guid: 5d1bbb30-719e-415b-a87b-45f19fa281b0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyTemplate(t *testing.T) {
+	src := filepath.Join("..", "..", "templates", "basic-api-service")
+	dst := t.TempDir()
+	if err := copyTemplate(src, dst, "basic-api-service", "example-service"); err != nil {
+		t.Fatalf("copyTemplate failed: %v", err)
+	}
+	// Ensure a known file exists in target
+	if _, err := os.Stat(filepath.Join(dst, "main.go")); err != nil {
+		t.Fatalf("expected file not found: %v", err)
+	}
+}

--- a/templates/auth-service/Dockerfile
+++ b/templates/auth-service/Dockerfile
@@ -1,0 +1,15 @@
+# file: templates/auth-service/Dockerfile
+# version: 1.0.0
+# guid: c300ca1e-10a1-4648-bd33-82075a90a1a4
+
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o auth-service ./...
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=builder /app/auth-service /app/
+EXPOSE 8080
+ENTRYPOINT ["/app/auth-service"]
+

--- a/templates/auth-service/Makefile
+++ b/templates/auth-service/Makefile
@@ -1,0 +1,14 @@
+# file: templates/auth-service/Makefile
+# version: 1.0.0
+# guid: c8d3f22b-82d7-4b73-bf6f-bb49a77aa996
+
+.PHONY: build test run
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+run:
+	go run ./...

--- a/templates/auth-service/README.md
+++ b/templates/auth-service/README.md
@@ -1,0 +1,9 @@
+<!-- file: templates/auth-service/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a3fc6e25-5b15-4d57-a613-1f003178bf9f -->
+
+# Auth Service Template
+
+Provides a minimal authentication service skeleton using gcommon modules.
+Includes configuration loading, a basic login endpoint, and container setup.
+

--- a/templates/auth-service/config/config.yaml
+++ b/templates/auth-service/config/config.yaml
@@ -1,0 +1,6 @@
+# file: templates/auth-service/config/config.yaml
+# version: 1.0.0
+# guid: 7000e786-19a2-40bb-b10d-392cf6719db2
+
+http_port: "8080"
+

--- a/templates/auth-service/internal/config/config.go
+++ b/templates/auth-service/internal/config/config.go
@@ -1,0 +1,29 @@
+// file: templates/auth-service/internal/config/config.go
+// version: 1.0.0
+// guid: f3aaad67-6134-489a-ab7a-40d541aaf1c8
+
+package config
+
+import (
+	"github.com/jdfalk/gcommon/pkg/config"
+	"github.com/jdfalk/gcommon/pkg/config/formats"
+	"github.com/jdfalk/gcommon/pkg/config/sources"
+)
+
+type AppConfig struct {
+	HTTPPort string `yaml:"http_port"`
+}
+
+func NewFileSource(path string) config.ConfigSource {
+	return sources.FileSource{Path: path, Decoder: formats.YAMLDecoder{}}
+}
+
+func MustLoad(m *config.Manager) *AppConfig {
+	cfg := &AppConfig{HTTPPort: "8080"}
+	if v, err := m.Get("http_port"); err == nil {
+		if s, ok := v.(string); ok {
+			cfg.HTTPPort = s
+		}
+	}
+	return cfg
+}

--- a/templates/auth-service/internal/server/server.go
+++ b/templates/auth-service/internal/server/server.go
@@ -1,0 +1,31 @@
+// file: templates/auth-service/internal/server/server.go
+// version: 1.0.0
+// guid: 16d821b0-fdf1-457a-b866-80b94570602e
+
+package server
+
+import (
+	"net/http"
+
+	glog "github.com/jdfalk/gcommon/pkg/log"
+	"github.com/jdfalk/gcommon/templates/auth-service/internal/config"
+)
+
+type Server struct {
+	cfg    *config.AppConfig
+	logger glog.Provider
+	mux    *http.ServeMux
+}
+
+func New(cfg *config.AppConfig, l glog.Provider) *Server {
+	s := &Server{cfg: cfg, logger: l, mux: http.NewServeMux()}
+	s.mux.HandleFunc("/login", s.handleLogin)
+	return s
+}
+
+func (s *Server) Handler() http.Handler { return s.mux }
+
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	s.logger.Info("login called")
+	w.WriteHeader(http.StatusOK)
+}

--- a/templates/auth-service/main.go
+++ b/templates/auth-service/main.go
@@ -1,12 +1,27 @@
 // file: templates/auth-service/main.go
-// version: 1.0.0
-// guid: 2f7de4d9-4d93-46e0-9211-974c1ab2ef41
+// version: 1.1.0
+// guid: de7b176e-9ae6-482b-a70b-bf235d437b49
 
-// Package main provides an authentication service template.
 package main
 
-import "log"
+import (
+	"fmt"
+	"net/http"
+
+	gconfig "github.com/jdfalk/gcommon/pkg/config"
+	glog "github.com/jdfalk/gcommon/pkg/log"
+
+	"github.com/jdfalk/gcommon/templates/auth-service/internal/config"
+	"github.com/jdfalk/gcommon/templates/auth-service/internal/server"
+)
 
 func main() {
-	log.Println("auth service starting")
+	cfgMgr := gconfig.NewManager()
+	if err := cfgMgr.Load(config.NewFileSource("config/config.yaml")); err != nil {
+		panic(fmt.Sprintf("config load failed: %v", err))
+	}
+	cfg := config.MustLoad(cfgMgr)
+	logger, _ := glog.NewProvider(glog.Config{Provider: "std"})
+	srv := server.New(cfg, logger)
+	http.ListenAndServe(":"+cfg.HTTPPort, srv.Handler())
 }

--- a/templates/basic-api-service/.github/workflows/ci.yaml
+++ b/templates/basic-api-service/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+# file: templates/basic-api-service/.github/workflows/ci.yaml
+# version: 1.0.0
+# guid: c42436d8-100c-445d-9f51-346cf8973836
+
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...
+

--- a/templates/basic-api-service/Dockerfile
+++ b/templates/basic-api-service/Dockerfile
@@ -1,0 +1,18 @@
+# file: templates/basic-api-service/Dockerfile
+# version: 1.0.0
+# guid: 105de070-cfba-43a4-8db9-3d771073bf3a
+
+# Dockerfile for the basic API service template. This multi-stage build produces
+# a minimal image containing only the compiled binary.
+
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o basic-api-service ./...
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=builder /app/basic-api-service /app/
+EXPOSE 8080 9090
+ENTRYPOINT ["/app/basic-api-service"]
+

--- a/templates/basic-api-service/Makefile
+++ b/templates/basic-api-service/Makefile
@@ -1,0 +1,16 @@
+# file: templates/basic-api-service/Makefile
+# version: 1.0.0
+# guid: e3aee588-08cd-48aa-9183-f3b8925381a5
+
+# Simple Makefile for building and testing the basic API service template.
+
+.PHONY: build test run
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+run:
+	go run ./...

--- a/templates/basic-api-service/README.md
+++ b/templates/basic-api-service/README.md
@@ -1,0 +1,28 @@
+<!-- file: templates/basic-api-service/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1fd546ec-7000-4b7b-a3aa-51e097d15ce3 -->
+
+# Basic API Service Template
+
+This template provides a starting point for building a simple HTTP API using
+[gcommon](https://github.com/jdfalk/gcommon) modules. It demonstrates
+configuration management, structured logging, metrics integration, and basic
+Kubernetes deployment manifests.
+
+## Features
+
+- Configuration loading via gcommon `config` module
+- Structured logging with gcommon `log` module
+- Metrics collection using gcommon `metrics` module
+- Dockerfile and Kubernetes manifests
+- GitHub Actions workflow for CI
+
+## Usage
+
+```bash
+# Generate a new service from this template
+./scripts/generate-microservice.sh basic-api-service ../my-service
+```
+
+After generation, customize the service as needed.
+

--- a/templates/basic-api-service/config/config.yaml
+++ b/templates/basic-api-service/config/config.yaml
@@ -1,0 +1,9 @@
+# file: templates/basic-api-service/config/config.yaml
+# version: 1.0.0
+# guid: dbcedb92-dc6a-4dcd-8d18-3745a61f27de
+
+# Application configuration for the basic API service template.
+# Values here are loaded via the gcommon configuration manager.
+http_port: "8080"
+metrics_port: "9090"
+

--- a/templates/basic-api-service/deploy/deployment.yaml
+++ b/templates/basic-api-service/deploy/deployment.yaml
@@ -1,0 +1,35 @@
+# file: templates/basic-api-service/deploy/deployment.yaml
+# version: 1.0.0
+# guid: b548b39e-818a-438e-ac10-5adc1278728a
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: basic-api-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: basic-api-service
+  template:
+    metadata:
+      labels:
+        app: basic-api-service
+    spec:
+      containers:
+        - name: service
+          image: basic-api-service:latest
+          ports:
+            - containerPort: 8080
+            - containerPort: 9090
+          env:
+            - name: CONFIG_PATH
+              value: /config/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: basic-api-config
+

--- a/templates/basic-api-service/deploy/service.yaml
+++ b/templates/basic-api-service/deploy/service.yaml
@@ -1,0 +1,20 @@
+# file: templates/basic-api-service/deploy/service.yaml
+# version: 1.0.0
+# guid: c410c9dd-cfbe-42af-a089-0a31a59603db
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: basic-api-service
+spec:
+  selector:
+    app: basic-api-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP
+

--- a/templates/basic-api-service/internal/config/config.go
+++ b/templates/basic-api-service/internal/config/config.go
@@ -1,0 +1,43 @@
+// file: templates/basic-api-service/internal/config/config.go
+// version: 1.0.0
+// guid: 4941f8fc-4db8-41cf-9f0d-d074d17cf397
+
+// Package config defines the application configuration structures and helpers
+// for the basic API service template. It demonstrates loading configuration
+// using the gcommon configuration manager and YAML file source.
+package config
+
+import (
+	"github.com/jdfalk/gcommon/pkg/config"
+	"github.com/jdfalk/gcommon/pkg/config/formats"
+	"github.com/jdfalk/gcommon/pkg/config/sources"
+)
+
+// AppConfig contains runtime configuration for the service.
+type AppConfig struct {
+	HTTPPort    string `yaml:"http_port"`
+	MetricsPort string `yaml:"metrics_port"`
+}
+
+// NewFileSource constructs a configuration file source with YAML decoding.
+func NewFileSource(path string) config.ConfigSource {
+	return sources.FileSource{Path: path, Decoder: formats.YAMLDecoder{}}
+}
+
+// MustLoad loads configuration from the manager and returns an AppConfig. If
+// configuration is missing, sensible defaults are returned. In production code,
+// applications should handle errors explicitly rather than relying on defaults.
+func MustLoad(m *config.Manager) *AppConfig {
+	cfg := &AppConfig{HTTPPort: "8080", MetricsPort: "9090"}
+	if v, err := m.Get("http_port"); err == nil {
+		if s, ok := v.(string); ok {
+			cfg.HTTPPort = s
+		}
+	}
+	if v, err := m.Get("metrics_port"); err == nil {
+		if s, ok := v.(string); ok {
+			cfg.MetricsPort = s
+		}
+	}
+	return cfg
+}

--- a/templates/basic-api-service/internal/server/server.go
+++ b/templates/basic-api-service/internal/server/server.go
@@ -1,0 +1,47 @@
+// file: templates/basic-api-service/internal/server/server.go
+// version: 1.0.0
+// guid: 15c27177-23ed-42e3-940a-ed14479d2e7a
+
+// Package server provides HTTP server implementation for the basic API service
+// template. The server exposes a simple health check endpoint and is intended to
+// be extended with real application logic.
+package server
+
+import (
+	"net/http"
+
+	glog "github.com/jdfalk/gcommon/pkg/log"
+	"github.com/jdfalk/gcommon/templates/basic-api-service/internal/config"
+)
+
+// Server wraps the dependencies required to run the HTTP server.
+type Server struct {
+	cfg    *config.AppConfig
+	logger glog.Provider
+	mux    *http.ServeMux
+}
+
+// New creates a new Server instance and configures routes.
+func New(cfg *config.AppConfig, logger glog.Provider) *Server {
+	s := &Server{
+		cfg:    cfg,
+		logger: logger,
+		mux:    http.NewServeMux(),
+	}
+	s.routes()
+	return s
+}
+
+// Handler returns the HTTP handler for serving requests.
+func (s *Server) Handler() http.Handler { return s.mux }
+
+// routes configures HTTP routes for the service.
+func (s *Server) routes() {
+	s.mux.HandleFunc("/healthz", s.handleHealth)
+}
+
+// handleHealth provides a basic health check endpoint.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.logger.Info("health check")
+	_, _ = w.Write([]byte("ok"))
+}

--- a/templates/basic-api-service/main.go
+++ b/templates/basic-api-service/main.go
@@ -1,12 +1,64 @@
 // file: templates/basic-api-service/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0b45f3d2-3f23-4e96-b8f1-339a9d417f77
 
-// Package main provides a basic API service template.
+// Package main provides a basic API service template integrating gcommon modules.
+// The service demonstrates configuration loading, structured logging, metrics
+// initialization, and a simple HTTP server. Developers should expand upon this
+// template to build production-ready services.
 package main
 
-import "log"
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	gconfig "github.com/jdfalk/gcommon/pkg/config"
+	glog "github.com/jdfalk/gcommon/pkg/log"
+	gmetrics "github.com/jdfalk/gcommon/pkg/metrics"
+	_ "github.com/jdfalk/gcommon/pkg/metrics/prometheus" // register Prometheus provider
+
+	"github.com/jdfalk/gcommon/templates/basic-api-service/internal/config"
+	"github.com/jdfalk/gcommon/templates/basic-api-service/internal/server"
+)
 
 func main() {
-	log.Println("basic API service starting")
+	// Initialize configuration manager and load service configuration.
+	cfgMgr := gconfig.NewManager()
+	if err := cfgMgr.Load(config.NewFileSource("config/config.yaml")); err != nil {
+		panic(fmt.Sprintf("failed to load configuration: %v", err))
+	}
+	svcCfg := config.MustLoad(cfgMgr)
+
+	// Initialize structured logger using gcommon's logging provider.
+	logger, err := glog.NewProvider(glog.Config{Provider: "std", Level: "info"})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create logger: %v", err))
+	}
+	defer logger.Close()
+
+	// Initialize metrics provider. Metrics are exposed on a separate port.
+	metricsProvider, err := gmetrics.NewProvider(gmetrics.Config{
+		Provider:  "prometheus",
+		Enabled:   true,
+		Namespace: "basic_api_service",
+	})
+	if err != nil {
+		logger.Error("failed to create metrics provider", glog.Field{Key: "error", Value: err})
+		return
+	}
+	ctx := context.Background()
+	if err := metricsProvider.Start(ctx); err != nil {
+		logger.Error("failed to start metrics provider", glog.Field{Key: "error", Value: err})
+		return
+	}
+	defer metricsProvider.Stop(ctx)
+
+	// Create HTTP server with simple health endpoint.
+	srv := server.New(svcCfg, logger)
+
+	logger.Info("starting HTTP server", glog.Field{Key: "port", Value: svcCfg.HTTPPort})
+	if err := http.ListenAndServe(":"+svcCfg.HTTPPort, srv.Handler()); err != nil {
+		logger.Fatal("server failed", glog.Field{Key: "error", Value: err})
+	}
 }

--- a/templates/basic-api-service/monitoring/prometheus.yaml
+++ b/templates/basic-api-service/monitoring/prometheus.yaml
@@ -1,0 +1,9 @@
+# file: templates/basic-api-service/monitoring/prometheus.yaml
+# version: 1.0.0
+# guid: 490e553c-f63e-4e6b-89e3-0af22bd2529c
+
+scrape_configs:
+  - job_name: basic-api-service
+    static_configs:
+      - targets: ['localhost:9090']
+

--- a/templates/event-driven-service/.github/workflows/ci.yaml
+++ b/templates/event-driven-service/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+# file: templates/event-driven-service/.github/workflows/ci.yaml
+# version: 1.0.0
+# guid: aa1480dd-dea9-4405-a838-fe5282ae80e4
+
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...

--- a/templates/event-driven-service/Dockerfile
+++ b/templates/event-driven-service/Dockerfile
@@ -1,0 +1,14 @@
+# file: templates/event-driven-service/Dockerfile
+# version: 1.0.0
+# guid: ac6d1f39-a9f0-4bde-a059-65930927aa55
+
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o event-driven-service ./...
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=builder /app/event-driven-service /app/
+EXPOSE 9090
+ENTRYPOINT ["/app/event-driven-service"]

--- a/templates/event-driven-service/Makefile
+++ b/templates/event-driven-service/Makefile
@@ -1,0 +1,14 @@
+# file: templates/event-driven-service/Makefile
+# version: 1.0.0
+# guid: ad5fad76-c900-4bcd-8bdc-bcc71db3d75b
+
+.PHONY: build test run
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+run:
+	go run ./...

--- a/templates/event-driven-service/README.md
+++ b/templates/event-driven-service/README.md
@@ -1,0 +1,14 @@
+<!-- file: templates/event-driven-service/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d598b40-43c2-4a94-bf85-c1336cae2ac0 -->
+
+# Event-Driven Service Template
+
+Template showcasing queue-based processing using gcommon's queue module.
+It includes configuration, logging, metrics, and worker skeleton.
+
+## Usage
+
+```bash
+./scripts/generate-microservice.sh event-driven-service ../my-event-service
+```

--- a/templates/event-driven-service/config/config.yaml
+++ b/templates/event-driven-service/config/config.yaml
@@ -1,0 +1,6 @@
+# file: templates/event-driven-service/config/config.yaml
+# version: 1.0.0
+# guid: 0af16973-e1d5-4890-86a3-1e793212f0a3
+
+queue_name: events
+metrics_port: "9090"

--- a/templates/event-driven-service/deploy/deployment.yaml
+++ b/templates/event-driven-service/deploy/deployment.yaml
@@ -1,0 +1,31 @@
+# file: templates/event-driven-service/deploy/deployment.yaml
+# version: 1.0.0
+# guid: 30c1a09f-a403-45da-aa3b-5faad67191f8
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: event-driven-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: event-driven-service
+  template:
+    metadata:
+      labels:
+        app: event-driven-service
+    spec:
+      containers:
+        - name: worker
+          image: event-driven-service:latest
+          env:
+            - name: CONFIG_PATH
+              value: /config/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: event-driven-config

--- a/templates/event-driven-service/deploy/service.yaml
+++ b/templates/event-driven-service/deploy/service.yaml
@@ -1,0 +1,16 @@
+# file: templates/event-driven-service/deploy/service.yaml
+# version: 1.0.0
+# guid: 1986b92b-7063-46c4-8502-17ce6cef6b92
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: event-driven-service
+spec:
+  selector:
+    app: event-driven-service
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP

--- a/templates/event-driven-service/internal/config/config.go
+++ b/templates/event-driven-service/internal/config/config.go
@@ -1,0 +1,35 @@
+// file: templates/event-driven-service/internal/config/config.go
+// version: 1.0.0
+// guid: 63258fac-399c-450d-abdd-97a8153e0c6b
+
+package config
+
+import (
+	"github.com/jdfalk/gcommon/pkg/config"
+	"github.com/jdfalk/gcommon/pkg/config/formats"
+	"github.com/jdfalk/gcommon/pkg/config/sources"
+)
+
+type AppConfig struct {
+	QueueName   string `yaml:"queue_name"`
+	MetricsPort string `yaml:"metrics_port"`
+}
+
+func NewFileSource(path string) config.ConfigSource {
+	return sources.FileSource{Path: path, Decoder: formats.YAMLDecoder{}}
+}
+
+func MustLoad(m *config.Manager) *AppConfig {
+	cfg := &AppConfig{QueueName: "events", MetricsPort: "9090"}
+	if v, err := m.Get("queue_name"); err == nil {
+		if s, ok := v.(string); ok {
+			cfg.QueueName = s
+		}
+	}
+	if v, err := m.Get("metrics_port"); err == nil {
+		if s, ok := v.(string); ok {
+			cfg.MetricsPort = s
+		}
+	}
+	return cfg
+}

--- a/templates/event-driven-service/internal/worker/worker.go
+++ b/templates/event-driven-service/internal/worker/worker.go
@@ -1,0 +1,34 @@
+// file: templates/event-driven-service/internal/worker/worker.go
+// version: 1.0.0
+// guid: ec046bdf-9095-459c-8ee3-5fcb23f2b699
+
+package worker
+
+import (
+	"context"
+
+	glog "github.com/jdfalk/gcommon/pkg/log"
+	gqueue "github.com/jdfalk/gcommon/pkg/queue"
+)
+
+type Worker struct {
+	queue  gqueue.Provider
+	logger glog.Provider
+}
+
+func New(q gqueue.Provider, logger glog.Provider) *Worker {
+	return &Worker{queue: q, logger: logger}
+}
+
+// Start begins consuming messages from the queue. This implementation is a
+// placeholder and should be replaced with real message handling logic.
+func (w *Worker) Start(ctx context.Context) error {
+	ch, err := w.queue.Consume(ctx, "events")
+	if err != nil {
+		return err
+	}
+	for msg := range ch {
+		w.logger.Info("processed message", glog.Field{Key: "msg", Value: string(msg)})
+	}
+	return nil
+}

--- a/templates/event-driven-service/main.go
+++ b/templates/event-driven-service/main.go
@@ -1,12 +1,65 @@
 // file: templates/event-driven-service/main.go
-// version: 1.0.0
-// guid: 5e4d0ec7-7b0d-4a80-b444-2fb9c9923bea
+// version: 1.1.0
+// guid: f2b40dc3-4c58-4dc7-9205-7e2b379def86
 
-// Package main provides an event-driven service template.
+// Package main provides an event-driven service template demonstrating queue
+// consumption using gcommon's queue module. The service initializes
+// configuration, logging, metrics, and starts a background worker that processes
+// messages.
 package main
 
-import "log"
+import (
+	"context"
+	"fmt"
+
+	gconfig "github.com/jdfalk/gcommon/pkg/config"
+	glog "github.com/jdfalk/gcommon/pkg/log"
+	gmetrics "github.com/jdfalk/gcommon/pkg/metrics"
+	_ "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
+	gqueue "github.com/jdfalk/gcommon/pkg/queue"
+
+	"github.com/jdfalk/gcommon/templates/event-driven-service/internal/config"
+	"github.com/jdfalk/gcommon/templates/event-driven-service/internal/worker"
+)
 
 func main() {
-	log.Println("event-driven service starting")
+	cfgMgr := gconfig.NewManager()
+	if err := cfgMgr.Load(config.NewFileSource("config/config.yaml")); err != nil {
+		panic(fmt.Sprintf("failed to load configuration: %v", err))
+	}
+	svcCfg := config.MustLoad(cfgMgr)
+
+	logger, err := glog.NewProvider(glog.Config{Provider: "std", Level: "info"})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create logger: %v", err))
+	}
+	defer logger.Close()
+
+	metricsProvider, err := gmetrics.NewProvider(gmetrics.Config{
+		Provider:  "prometheus",
+		Enabled:   true,
+		Namespace: "event_driven_service",
+	})
+	if err != nil {
+		logger.Error("failed to create metrics provider", glog.Field{Key: "error", Value: err})
+		return
+	}
+	ctx := context.Background()
+	if err := metricsProvider.Start(ctx); err != nil {
+		logger.Error("failed to start metrics provider", glog.Field{Key: "error", Value: err})
+		return
+	}
+	defer metricsProvider.Stop(ctx)
+
+	queueProv, err := gqueue.NewProvider(gqueue.Config{Provider: "memory"})
+	if err != nil {
+		logger.Fatal("queue provider init failed", glog.Field{Key: "error", Value: err})
+	}
+	defer queueProv.Close()
+
+	w := worker.New(queueProv, logger)
+	logger.Info("starting event worker")
+	if err := w.Start(ctx); err != nil {
+		logger.Fatal("worker failed", glog.Field{Key: "error", Value: err})
+	}
 }

--- a/templates/event-driven-service/monitoring/prometheus.yaml
+++ b/templates/event-driven-service/monitoring/prometheus.yaml
@@ -1,0 +1,8 @@
+# file: templates/event-driven-service/monitoring/prometheus.yaml
+# version: 1.0.0
+# guid: f4c586ea-564b-4465-b9b1-d61077d1bb9b
+
+scrape_configs:
+  - job_name: event-driven-service
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- scaffold basic API, event-driven, and auth service templates with config, Docker, and CI files
- add Go-based microservice-template generator
- document templates and update issue tracking

## Testing
- `go test ./...` *(fails: multiple-value labelNamer.Build in otel exporter)*

------
https://chatgpt.com/codex/tasks/task_e_689943ed8b808321ac1a2c9a83c78fc7