### PR TITLE
feat: scaffold multi-language client SDKs

### DIFF
--- a/.github/doc-updates/1ca173dd-2239-466d-bc6a-7d5ba33dd6d1.json
+++ b/.github/doc-updates/1ca173dd-2239-466d-bc6a-7d5ba33dd6d1.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Client SDKs\\n\\nTODO: Add content for this section",
+  "guid": "1ca173dd-2239-466d-bc6a-7d5ba33dd6d1",
+  "created_at": "2025-08-11T01:16:49Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d835b4ae-8167-4e2a-9a2c-4f9e58bc0e14.json
+++ b/.github/doc-updates/d835b4ae-8167-4e2a-9a2c-4f9e58bc0e14.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add skeletons for multi-language client SDKs",
+  "guid": "d835b4ae-8167-4e2a-9a2c-4f9e58bc0e14",
+  "created_at": "2025-08-11T01:16:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f81b37b9-f29b-416d-9320-51630699d678.json
+++ b/.github/doc-updates/f81b37b9-f29b-416d-9320-51630699d678.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Implement full functionality for generated client SDKs",
+  "guid": "f81b37b9-f29b-416d-9320-51630699d678",
+  "created_at": "2025-08-11T01:16:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/5162b6a2-3288-4979-8239-c578e63c083c.json
+++ b/.github/issue-updates/5162b6a2-3288-4979-8239-c578e63c083c.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Feature: Add client SDK skeletons",
+  "body": "Create multi-language client SDK directories with placeholder implementations",
+  "labels": ["type:feature", "sdk"],
+  "guid": "5162b6a2-3288-4979-8239-c578e63c083c",
+  "legacy_guid": "create-feature-add-client-sdk-skeletons-2025-08-11",
+  "created_at": "2025-08-11T01:16:36.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/sdks/.gitignore
+++ b/sdks/.gitignore
@@ -1,7 +1,16 @@
 # file: sdks/.gitignore
-# version: 1.0.0
+# version: 1.1.0
 # guid: 1b8d87e0-2c93-4a74-b5f2-1d594de2fc80
 
-# Ignore all generated SDK files
-*
+# Allow SDK source files while ignoring build artifacts
+# TODO: refine ignore patterns as SDK implementations evolve
+
+dist/
+node_modules/
+bin/
+obj/
+target/
+*.pyc
+__pycache__/
+
 !.gitignore

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,0 +1,66 @@
+<!-- file: sdks/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 48586fe3-6bcd-42b4-8c36-778bb707bb02 -->
+
+# SDKs Overview
+
+TODO: This file provides an overview of all client SDKs.
+
+## Structure
+
+- TODO: Describe Go SDK structure
+- TODO: Describe Python SDK structure
+- TODO: Describe TypeScript SDK structure
+- TODO: Describe Java SDK structure
+- TODO: Describe C# SDK structure
+
+## Implementation Notes
+
+- TODO: Discuss authentication strategies across SDKs
+- TODO: Explain error handling conventions
+- TODO: Outline testing requirements
+- TODO: Provide contribution guidelines
+- TODO: Include release process
+
+## Future Work
+
+- TODO: Add Rust SDK
+- TODO: Add language-specific optimizations
+- TODO: Automate code generation
+- TODO: Improve documentation coverage
+- TODO: Create integration tests
+- TODO: Publish packages to registries
+- TODO: Provide versioning strategy
+- TODO: Ensure API parity across languages
+- TODO: Implement CI pipelines for SDKs
+- TODO: Add code examples for each service
+- TODO: Handle backward compatibility concerns
+- TODO: Expand authentication mechanisms
+- TODO: Standardize logging approaches
+- TODO: Establish performance benchmarks
+- TODO: Include security best practices
+- TODO: Add contribution templates
+- TODO: Build release tooling
+- TODO: Set up package signing
+- TODO: Define deprecation policy
+- TODO: Document packaging guidelines
+- TODO: Create user guides
+- TODO: Provide troubleshooting tips
+- TODO: Track feature parity
+- TODO: Add code generation metrics
+- TODO: Maintain SDK changelog
+- TODO: Manage semantic versioning
+- TODO: Offer migration guides
+- TODO: Provide sample applications
+- TODO: Incorporate community feedback
+- TODO: Localize documentation
+- TODO: Support multiple transport protocols
+- TODO: Ensure cross-platform compatibility
+- TODO: Provide automated setup scripts
+- TODO: Integrate with build tools
+- TODO: Offer sandbox environment
+- TODO: Clarify support channels
+- TODO: Publish roadmap
+- TODO: Showcase best practices
+- TODO: Host regular updates
+- TODO: Encourage contributions

--- a/sdks/csharp/auth/Auth.cs
+++ b/sdks/csharp/auth/Auth.cs
@@ -1,0 +1,28 @@
+// file: sdks/csharp/auth/Auth.cs
+// version: 1.0.0
+// guid: 962e27bf-321b-4837-af5b-0637f23c761b
+
+namespace Sdks.Csharp.Auth;
+
+/// <summary>
+/// Authentication helpers.
+/// </summary>
+public class Auth
+{
+    private string? _token;
+
+    public string GetToken()
+    {
+        // TODO: implement token retrieval
+        return _token ?? string.Empty;
+    }
+
+    public void Refresh()
+    {
+        // TODO: refresh token
+    }
+
+    // TODO: add OAuth2 support
+    // TODO: handle JWT validation
+    // TODO: support API keys
+}

--- a/sdks/csharp/client/Client.cs
+++ b/sdks/csharp/client/Client.cs
@@ -1,0 +1,34 @@
+// file: sdks/csharp/client/Client.cs
+// version: 1.0.0
+// guid: 77f9226d-73fb-4d6f-8c13-c74252fbe606
+
+namespace Sdks.Csharp.Client;
+
+/// <summary>
+/// Client for gcommon services.
+/// TODO: implement connection handling.
+/// </summary>
+public class Client
+{
+    // TODO: add fields
+
+    public Client()
+    {
+        // TODO: initialize client
+    }
+
+    public void Connect()
+    {
+        // TODO: connect to services
+    }
+
+    public void Close()
+    {
+        // TODO: close connection
+    }
+
+    // TODO: add service accessors
+    // TODO: implement authentication
+    // TODO: add retry logic
+    // TODO: document methods
+}

--- a/sdks/csharp/docs/README.md
+++ b/sdks/csharp/docs/README.md
@@ -1,0 +1,15 @@
+<!-- file: sdks/csharp/docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 527835e9-0740-40a9-9346-d7c9f1ccae96 -->
+
+# C# Client SDK
+
+TODO: Provide documentation for C# SDK.
+
+- TODO: Installation steps
+- TODO: Usage examples
+- TODO: Authentication
+- TODO: Error handling
+- TODO: Testing
+
+> TODO: Add more detailed guidance.

--- a/sdks/csharp/examples/Example.cs
+++ b/sdks/csharp/examples/Example.cs
@@ -1,0 +1,21 @@
+// file: sdks/csharp/examples/Example.cs
+// version: 1.0.0
+// guid: 96508978-96d9-47af-a9b9-7e55fb99f69c
+
+using Sdks.Csharp.Client;
+
+namespace Sdks.Csharp.Examples;
+
+public static class Example
+{
+    public static void Run()
+    {
+        var client = new Client();
+        client.Connect();
+        // TODO: call service methods
+        client.Close();
+    }
+
+    // TODO: add authentication example
+    // TODO: show error handling
+}

--- a/sdks/csharp/models/Model.cs
+++ b/sdks/csharp/models/Model.cs
@@ -1,0 +1,24 @@
+// file: sdks/csharp/models/Model.cs
+// version: 1.0.0
+// guid: 9c5098d9-e197-4691-9f6b-d52a99bc8990
+
+namespace Sdks.Csharp.Models;
+
+/// <summary>
+/// Example data model.
+/// TODO: define properties and validation.
+/// </summary>
+public class Model
+{
+    public int Value { get; set; } = 0;
+
+    public bool Validate()
+    {
+        // TODO: implement validation logic
+        return true;
+    }
+
+    // TODO: add serialization support
+    // TODO: implement equality checks
+    // TODO: document usage
+}

--- a/sdks/csharp/services/Service.cs
+++ b/sdks/csharp/services/Service.cs
@@ -1,0 +1,30 @@
+// file: sdks/csharp/services/Service.cs
+// version: 1.0.0
+// guid: 2beebf59-6769-48de-8748-1b240967ecb0
+
+using Sdks.Csharp.Client;
+
+namespace Sdks.Csharp.Services;
+
+/// <summary>
+/// Example service wrapper.
+/// </summary>
+public class Service
+{
+    private readonly Client _client;
+
+    public Service(Client client)
+    {
+        _client = client;
+    }
+
+    public void Call()
+    {
+        // TODO: implement RPC call
+    }
+
+    // TODO: add additional methods
+    // TODO: handle errors
+    // TODO: include retries
+    // TODO: add documentation
+}

--- a/sdks/csharp/tests/ClientTests.cs
+++ b/sdks/csharp/tests/ClientTests.cs
@@ -1,0 +1,24 @@
+// file: sdks/csharp/tests/ClientTests.cs
+// version: 1.0.0
+// guid: 063707b3-f325-4976-a300-969c0d0deba5
+
+using Sdks.Csharp.Client;
+using Xunit;
+
+namespace Sdks.Csharp.Tests;
+
+public class ClientTests
+{
+    [Fact]
+    public void ClientStub()
+    {
+        var client = new Client();
+        client.Connect();
+        // TODO: invoke client methods
+        client.Close();
+    }
+
+    // TODO: add more tests
+    // TODO: cover error cases
+    // TODO: include integration tests
+}

--- a/sdks/go/auth/auth.go
+++ b/sdks/go/auth/auth.go
@@ -1,0 +1,34 @@
+// file: sdks/go/auth/auth.go
+// version: 1.0.0
+// guid: 773d891d-d86d-48dc-8ebe-832cb8d76a16
+
+package auth
+
+// TokenProvider manages authentication tokens.
+type TokenProvider struct {
+	// TODO: store token and expiration
+}
+
+// NewTokenProvider creates a new provider.
+func NewTokenProvider() *TokenProvider {
+	// TODO: accept parameters
+	return &TokenProvider{}
+}
+
+// Token returns a valid token.
+func (p *TokenProvider) Token() (string, error) {
+	// TODO: implement token retrieval
+	return "", nil
+}
+
+// Refresh updates the token when expired.
+func (p *TokenProvider) Refresh() error {
+	// TODO: implement refresh logic
+	return nil
+}
+
+// TODO: Integrate with OAuth2 flows
+// TODO: Handle JWT validation
+// TODO: Support API key authentication
+// TODO: Add thread-safe caching
+// TODO: Provide hooks for custom auth

--- a/sdks/go/client/client.go
+++ b/sdks/go/client/client.go
@@ -1,0 +1,37 @@
+// file: sdks/go/client/client.go
+// version: 1.0.0
+// guid: 487069ac-a243-403f-abdc-f6d1a5c71b9e
+
+package client
+
+import "context"
+
+// Client provides access to gcommon services.
+type Client struct {
+	// TODO: add fields for connection and configuration
+}
+
+// New creates a new Client.
+func New(ctx context.Context) (*Client, error) {
+	// TODO: initialize client with context configuration
+	return &Client{}, nil
+}
+
+// Connect establishes connection to gcommon services.
+func (c *Client) Connect(ctx context.Context) error {
+	// TODO: implement connection logic
+	return nil
+}
+
+// Close gracefully closes connection.
+func (c *Client) Close() error {
+	// TODO: implement close logic
+	return nil
+}
+
+// TODO: Add service accessors and helper methods
+// TODO: Implement retry strategies
+// TODO: Add authentication middleware
+// TODO: Document each exported method
+// TODO: Ensure thread safety
+// TODO: Add logging hooks

--- a/sdks/go/docs/README.md
+++ b/sdks/go/docs/README.md
@@ -1,0 +1,15 @@
+<!-- file: sdks/go/docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 42c3567f-8d5f-4cb0-a02a-7fa648a2b696 -->
+
+# Go Client SDK
+
+TODO: This documentation needs to be completed.
+
+- TODO: Describe installation steps
+- TODO: Provide usage examples
+- TODO: Explain authentication
+- TODO: Document error handling
+- TODO: List available services
+
+> TODO: Add more detailed sections.

--- a/sdks/go/examples/example.go
+++ b/sdks/go/examples/example.go
@@ -1,0 +1,31 @@
+// file: sdks/go/examples/example.go
+// version: 1.0.0
+// guid: b67a74bd-2a69-4090-9fca-4fea4b346bea
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	clientpkg "gcommon/sdks/go/client"
+)
+
+// Basic demonstrates simple client usage.
+func Basic() {
+	ctx := context.Background()
+	client, err := clientpkg.New(ctx)
+	if err != nil {
+		fmt.Println("TODO: handle error", err)
+		return
+	}
+	defer client.Close()
+
+	// TODO: demonstrate calling a service
+	fmt.Println("TODO: call service method")
+}
+
+// TODO: Provide additional examples
+// TODO: Add authentication example
+// TODO: Include error handling sample
+// TODO: Show streaming RPC usage
+// TODO: Write documentation references

--- a/sdks/go/models/model.go
+++ b/sdks/go/models/model.go
@@ -1,0 +1,23 @@
+// file: sdks/go/models/model.go
+// version: 1.0.0
+// guid: e4db7683-75cc-4d5a-977b-25b84c6382f5
+
+package models
+
+// ExampleModel represents a data structure used by the SDK.
+type ExampleModel struct {
+	// TODO: define model fields
+}
+
+// Validate ensures ExampleModel is valid.
+func (e *ExampleModel) Validate() error {
+	// TODO: implement validation logic
+	return nil
+}
+
+// TODO: Add serialization helpers
+// TODO: Support deep copy operations
+// TODO: Implement equality checks
+// TODO: Document field constraints
+// TODO: Consider JSON tags
+// TODO: Implement custom marshaling

--- a/sdks/go/services/service.go
+++ b/sdks/go/services/service.go
@@ -1,0 +1,30 @@
+// file: sdks/go/services/service.go
+// version: 1.0.0
+// guid: a22ea40f-9133-4e8d-ac59-4fa3ab3aee34
+
+package services
+
+import "context"
+
+// ExampleService interacts with a gcommon service.
+type ExampleService struct {
+	// TODO: store client reference
+}
+
+// NewExampleService creates a new service wrapper.
+func NewExampleService() *ExampleService {
+	// TODO: accept configuration parameters
+	return &ExampleService{}
+}
+
+// Call performs a sample request.
+func (s *ExampleService) Call(ctx context.Context) error {
+	// TODO: implement RPC invocation
+	return nil
+}
+
+// TODO: Add additional service methods
+// TODO: Implement error mapping
+// TODO: Add retry logic
+// TODO: Include timeout handling
+// TODO: Provide unit tests

--- a/sdks/go/tests/client_test.go
+++ b/sdks/go/tests/client_test.go
@@ -1,0 +1,24 @@
+// file: sdks/go/tests/client_test.go
+// version: 1.0.0
+// guid: 5ae1809d-c692-4784-8a1b-f1c602167fd9
+
+package tests
+
+import "testing"
+
+// TestClientStub uses AAA pattern.
+func TestClientStub(t *testing.T) {
+	// Arrange
+	// TODO: set up client
+
+	// Act
+	// TODO: invoke client method
+
+	// Assert
+	t.Skip("TODO: implement client tests")
+}
+
+// TODO: Add integration tests
+// TODO: Cover error scenarios
+// TODO: Provide benchmarks
+// TODO: Include authentication tests

--- a/sdks/java/auth/Auth.java
+++ b/sdks/java/auth/Auth.java
@@ -1,0 +1,29 @@
+// file: sdks/java/auth/Auth.java
+// version: 1.0.0
+// guid: 00cff2fe-2fc4-429f-bf34-f8185c7171c0
+
+package sdks.java.auth;
+
+/**
+ * Authentication helpers.
+ */
+public class Auth {
+  private String token;
+
+  public Auth() {
+    this.token = ""; // TODO: initialize token
+  }
+
+  public String getToken() {
+    // TODO: return valid token
+    return token;
+  }
+
+  public void refresh() {
+    // TODO: refresh token
+  }
+
+  // TODO: add OAuth2 support
+  // TODO: handle JWTs
+  // TODO: support API keys
+}

--- a/sdks/java/client/Client.java
+++ b/sdks/java/client/Client.java
@@ -1,0 +1,32 @@
+// file: sdks/java/client/Client.java
+// version: 1.0.0
+// guid: 1c50789a-5197-4ca7-ad44-50161e321a21
+
+package sdks.java.client;
+
+/**
+ * Client for gcommon services.
+ *
+ * TODO: Implement connection management and service stubs.
+ */
+public class Client {
+  // TODO: add fields
+
+  public Client() {
+    // TODO: initialize client
+  }
+
+  public void connect() {
+    // TODO: implement connection logic
+  }
+
+  public void close() {
+    // TODO: implement close logic
+  }
+
+  // TODO: add service accessor methods
+  // TODO: implement authentication support
+  // TODO: handle retries and timeouts
+  // TODO: document methods
+  // TODO: add logging
+}

--- a/sdks/java/docs/README.md
+++ b/sdks/java/docs/README.md
@@ -1,0 +1,15 @@
+<!-- file: sdks/java/docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7238c03f-73c4-49b4-9144-d60fdc68ae8d -->
+
+# Java Client SDK
+
+TODO: Provide detailed documentation for Java SDK.
+
+- TODO: Installation guide
+- TODO: Usage examples
+- TODO: Authentication
+- TODO: Error handling
+- TODO: Testing
+
+> TODO: Expand with more content.

--- a/sdks/java/examples/Example.java
+++ b/sdks/java/examples/Example.java
@@ -1,0 +1,22 @@
+// file: sdks/java/examples/Example.java
+// version: 1.0.0
+// guid: 490c2ad4-bbb1-477f-8d36-41ced52c3041
+
+package sdks.java.examples;
+
+import sdks.java.client.Client;
+
+/**
+ * Example usage for Java SDK.
+ */
+public class Example {
+  public static void main(String[] args) {
+    Client client = new Client();
+    client.connect();
+    // TODO: call service methods
+    client.close();
+  }
+
+  // TODO: add asynchronous example
+  // TODO: show authentication usage
+}

--- a/sdks/java/models/Model.java
+++ b/sdks/java/models/Model.java
@@ -1,0 +1,30 @@
+// file: sdks/java/models/Model.java
+// version: 1.0.0
+// guid: f921380c-746c-4ee4-a891-a5d66960deff
+
+package sdks.java.models;
+
+/**
+ * Example data model.
+ *
+ * TODO: Define fields and methods.
+ */
+public class Model {
+  private int value;
+
+  public Model() {
+    this.value = 0; // TODO: customize default
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public void setValue(int value) {
+    this.value = value; // TODO: validate input
+  }
+
+  // TODO: add serialization helpers
+  // TODO: implement equality
+  // TODO: add builder pattern
+}

--- a/sdks/java/services/Service.java
+++ b/sdks/java/services/Service.java
@@ -1,0 +1,27 @@
+// file: sdks/java/services/Service.java
+// version: 1.0.0
+// guid: 41f8d6a4-54ec-4752-beb1-c6c2b35f0728
+
+package sdks.java.services;
+
+import sdks.java.client.Client;
+
+/**
+ * Example service wrapper.
+ */
+public class Service {
+  private final Client client;
+
+  public Service(Client client) {
+    this.client = client;
+  }
+
+  public void call() {
+    // TODO: implement RPC call
+  }
+
+  // TODO: add additional methods
+  // TODO: map errors to exceptions
+  // TODO: implement retries
+  // TODO: document usage
+}

--- a/sdks/java/tests/ClientTest.java
+++ b/sdks/java/tests/ClientTest.java
@@ -1,0 +1,25 @@
+// file: sdks/java/tests/ClientTest.java
+// version: 1.0.0
+// guid: 6f9d2fdf-152a-41ca-8f0b-df9bd746fbe0
+
+package sdks.java.tests;
+
+import org.junit.jupiter.api.Test;
+import sdks.java.client.Client;
+
+/**
+ * Tests for Client.
+ */
+public class ClientTest {
+  @Test
+  public void testStub() {
+    Client client = new Client();
+    client.connect();
+    // TODO: invoke client methods
+    client.close();
+  }
+
+  // TODO: add more tests
+  // TODO: cover error cases
+  // TODO: include integration tests
+}

--- a/sdks/python/auth/auth.py
+++ b/sdks/python/auth/auth.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# file: sdks/python/auth/auth.py
+# version: 1.0.0
+# guid: 58742820-6551-47e8-89bc-db88993ca7e0
+"""Authentication utilities for Python SDK."""
+from __future__ import annotations
+
+import datetime as _dt
+
+
+class TokenProvider:
+    """Token provider for authentication.
+
+    TODO: Implement OAuth2 and JWT handling.
+    """
+
+    def __init__(self) -> None:
+        self._token: str | None = None
+        self._expires: _dt.datetime | None = None
+
+    async def token(self) -> str:
+        """Return a valid token."""
+        # TODO: implement retrieval logic
+        return ""
+
+    async def refresh(self) -> None:
+        """Refresh the token."""
+        # TODO: implement refresh logic
+        return None
+
+    # TODO: Add API key support
+    # TODO: Handle automatic refresh
+    # TODO: Provide thread safety

--- a/sdks/python/client/client.py
+++ b/sdks/python/client/client.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# file: sdks/python/client/client.py
+# version: 1.0.0
+# guid: 4f216115-2495-4e02-8a2d-ec427217e97b
+"""Client module for gcommon Python SDK.
+
+TODO: Implement full client functionality.
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+
+class Client:
+    """Represents a gcommon service client.
+
+    TODO: Add connection handling and configuration.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the client."""
+        # TODO: initialize client resources
+
+    async def connect(self) -> None:
+        """Connect to the service."""
+        # TODO: implement async connection logic
+
+    async def close(self) -> None:
+        """Close the client connection."""
+        # TODO: implement close logic
+
+    async def call_service(self, name: str, data: Any) -> Any:
+        """Call a gcommon service.
+
+        Args:
+            name: Service name.
+            data: Payload data.
+        """
+        # TODO: implement RPC invocation
+        return None
+
+    # TODO: Add authentication helpers
+    # TODO: Implement retry mechanism
+    # TODO: Provide streaming support
+    # TODO: Handle errors with custom exceptions
+    # TODO: Include comprehensive logging

--- a/sdks/python/docs/README.md
+++ b/sdks/python/docs/README.md
@@ -1,0 +1,15 @@
+<!-- file: sdks/python/docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9e71fe6e-a036-472d-ad1d-d830d232bd83 -->
+
+# Python Client SDK
+
+TODO: Documentation for Python SDK is pending.
+
+- TODO: Installation instructions
+- TODO: Usage examples
+- TODO: Authentication details
+- TODO: Error handling
+- TODO: Testing guidance
+
+> TODO: Expand this document with comprehensive guides.

--- a/sdks/python/examples/example.py
+++ b/sdks/python/examples/example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# file: sdks/python/examples/example.py
+# version: 1.0.0
+# guid: 123ebb6a-9965-4e86-b3e2-d660c184b64f
+"""Example usage for gcommon Python SDK."""
+from __future__ import annotations
+
+import asyncio
+
+from sdks.python.client.client import Client
+
+
+async def basic_example() -> None:
+    """Run a basic example."""
+    client = Client()
+    await client.connect()
+    try:
+        # TODO: call service methods
+        print("TODO: call service method")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(basic_example())

--- a/sdks/python/models/model.py
+++ b/sdks/python/models/model.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# file: sdks/python/models/model.py
+# version: 1.0.0
+# guid: 362d70d6-02c6-4e07-8651-99d5df9dd0d3
+"""Data models for gcommon Python SDK."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ExampleModel:
+    """Example data model.
+
+    TODO: Define fields with proper types and defaults.
+    """
+
+    value: int = 0
+
+    def validate(self) -> None:
+        """Validate the model."""
+        # TODO: implement validation logic
+        return None
+
+    # TODO: Add serialization support
+    # TODO: Implement conversion methods
+    # TODO: Document field behaviors
+    # TODO: Add equality comparison helpers

--- a/sdks/python/services/service.py
+++ b/sdks/python/services/service.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# file: sdks/python/services/service.py
+# version: 1.0.0
+# guid: c9782c55-99c7-489f-b188-8eec742f46df
+"""Service wrappers for gcommon Python SDK."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class ExampleService:
+    """Example service wrapper.
+
+    TODO: Provide real RPC implementations.
+    """
+
+    def __init__(self) -> None:
+        # TODO: receive client reference
+        return None
+
+    async def call(self, data: Any) -> Any:
+        """Perform a sample RPC call."""
+        # TODO: implement service call
+        return None
+
+    # TODO: Add streaming support
+    # TODO: Implement error translation
+    # TODO: Provide retries
+    # TODO: Include metrics hooks

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# file: sdks/python/tests/test_client.py
+# version: 1.0.0
+# guid: 8b4e833a-be6d-461a-8587-dd427a680f37
+"""Tests for Python client."""
+from __future__ import annotations
+
+import pytest
+
+from sdks.python.client.client import Client
+
+
+@pytest.mark.asyncio
+async def test_client_stub() -> None:
+    """Test client placeholder."""
+    client = Client()
+    await client.connect()
+    try:
+        # TODO: invoke client call
+        assert True
+    finally:
+        await client.close()
+
+
+# TODO: Add more tests
+# TODO: Cover error cases
+# TODO: Include integration scenarios

--- a/sdks/typescript/auth/auth.ts
+++ b/sdks/typescript/auth/auth.ts
@@ -1,0 +1,21 @@
+// file: sdks/typescript/auth/auth.ts
+// version: 1.0.0
+// guid: c037a23e-db76-49ea-ac87-86045feee0ed
+
+export class TokenProvider {
+  private token: string | null = null;
+
+  async getToken(): Promise<string> {
+    // TODO: implement token retrieval
+    return this.token ?? '';
+  }
+
+  async refresh(): Promise<void> {
+    // TODO: refresh token
+  }
+
+  // TODO: Support OAuth2
+  // TODO: Handle JWT validation
+  // TODO: Provide API key auth
+  // TODO: Add automatic refresh
+}

--- a/sdks/typescript/client/client.ts
+++ b/sdks/typescript/client/client.ts
@@ -1,0 +1,29 @@
+// file: sdks/typescript/client/client.ts
+// version: 1.0.0
+// guid: 75c87cb1-3d78-4dd9-bb0d-e90ec4e454e0
+
+export class Client {
+  // TODO: Add configuration fields
+  constructor() {
+    // TODO: initialize client settings
+  }
+
+  async connect(): Promise<void> {
+    // TODO: establish connection
+  }
+
+  async close(): Promise<void> {
+    // TODO: close connection
+  }
+
+  async callService(name: string, data: unknown): Promise<unknown> {
+    // TODO: implement RPC call
+    return null;
+  }
+
+  // TODO: Add authentication helpers
+  // TODO: Implement retry logic
+  // TODO: Provide streaming support
+  // TODO: Handle errors with custom types
+  // TODO: Include logging hooks
+}

--- a/sdks/typescript/docs/README.md
+++ b/sdks/typescript/docs/README.md
@@ -1,0 +1,15 @@
+<!-- file: sdks/typescript/docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5c388dff-311d-46b5-b0a5-836691b01004 -->
+
+# TypeScript Client SDK
+
+TODO: Write comprehensive documentation.
+
+- TODO: Setup instructions
+- TODO: Usage examples
+- TODO: Authentication flow
+- TODO: Error handling
+- TODO: Testing approach
+
+> TODO: Expand with more details.

--- a/sdks/typescript/examples/example.ts
+++ b/sdks/typescript/examples/example.ts
@@ -1,0 +1,20 @@
+// file: sdks/typescript/examples/example.ts
+// version: 1.0.0
+// guid: 7db6e576-14c7-4a69-a71d-abbdd60fbd4e
+
+import { Client } from '../client/client';
+
+export async function basicExample(): Promise<void> {
+  const client = new Client();
+  await client.connect();
+  try {
+    // TODO: invoke service calls
+    console.log('TODO: call service method');
+  } finally {
+    await client.close();
+  }
+}
+
+// TODO: Add authentication example
+// TODO: Demonstrate error handling
+// TODO: Show streaming usage

--- a/sdks/typescript/models/model.ts
+++ b/sdks/typescript/models/model.ts
@@ -1,0 +1,17 @@
+// file: sdks/typescript/models/model.ts
+// version: 1.0.0
+// guid: 6e866da9-dfde-48f0-b6aa-334a7dfccc3c
+
+export interface ExampleModel {
+  // TODO: define model properties
+  value: number;
+}
+
+export function validate(model: ExampleModel): boolean {
+  // TODO: implement validation logic
+  return true;
+}
+
+// TODO: Add serialization helpers
+// TODO: Provide conversion functions
+// TODO: Document model usage

--- a/sdks/typescript/services/service.ts
+++ b/sdks/typescript/services/service.ts
@@ -1,0 +1,23 @@
+// file: sdks/typescript/services/service.ts
+// version: 1.0.0
+// guid: 16593558-ea1b-497b-9e7d-9547c7f5f04b
+
+import { Client } from '../client/client';
+
+export class ExampleService {
+  private client: Client;
+
+  constructor(client: Client) {
+    this.client = client;
+  }
+
+  async call(data: unknown): Promise<unknown> {
+    // TODO: implement RPC call via client
+    return null;
+  }
+
+  // TODO: Add more service methods
+  // TODO: Map errors to exceptions
+  // TODO: Support retries
+  // TODO: Document usage
+}

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -1,0 +1,16 @@
+// file: sdks/typescript/tests/client.test.ts
+// version: 1.0.0
+// guid: ba3153bc-572d-4084-81ac-63c194ea95f9
+
+import { Client } from '../client/client';
+
+test('client stub', async () => {
+  const client = new Client();
+  await client.connect();
+  // TODO: invoke client methods
+  await client.close();
+});
+
+// TODO: Add more tests
+// TODO: Cover error cases
+// TODO: Include integration tests


### PR DESCRIPTION
## Summary
- add placeholder client SDKs for Go, Python, TypeScript, Java, and C#
- document SDK layout and allow source tracking
- record issue and documentation updates for SDK scaffolding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...` *(fails: package gcommon/sdks/go/client is not in std)*
- `python -m pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689943dd9c288321b50499ac75459306