### PR TITLE
feat: expand monitoring observability coverage

### DIFF
--- a/.github/doc-updates/5451d23e-273f-42ad-ab55-d1f2b86d014c.json
+++ b/.github/doc-updates/5451d23e-273f-42ad-ab55-d1f2b86d014c.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Monitoring and Observability\\nThis module provides metrics, logging, tracing, alerting, and dashboards for system health.",
+  "guid": "5451d23e-273f-42ad-ab55-d1f2b86d014c",
+  "created_at": "2025-08-11T01:18:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/63fd6629-f5b7-423b-85a6-10ae2a95d54c.json
+++ b/.github/doc-updates/63fd6629-f5b7-423b-85a6-10ae2a95d54c.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Integrate monitoring module with all service modules",
+  "guid": "63fd6629-f5b7-423b-85a6-10ae2a95d54c",
+  "created_at": "2025-08-11T01:18:48Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ba31bab5-8670-4a45-a4c4-98e6aa4f68d1.json
+++ b/.github/doc-updates/ba31bab5-8670-4a45-a4c4-98e6aa4f68d1.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Implemented comprehensive monitoring and observability with collectors, exporters, alerts, and dashboards",
+  "guid": "ba31bab5-8670-4a45-a4c4-98e6aa4f68d1",
+  "created_at": "2025-08-11T01:18:42Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/7e9075a3-e9b5-4d64-b72a-ba9e73688cc0.json
+++ b/.github/issue-updates/7e9075a3-e9b5-4d64-b72a-ba9e73688cc0.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Implement monitoring and observability across modules",
+  "body": "Complete monitoring module with collectors, exporters, alerts, tracing, and dashboards",
+  "labels": ["module:monitoring", "type:feature"],
+  "guid": "7e9075a3-e9b5-4d64-b72a-ba9e73688cc0",
+  "legacy_guid": "create-implement-monitoring-and-observability-across-modules-2025-08-11",
+  "created_at": "2025-08-11T01:18:36.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/examples/production/monitoring/main.go
+++ b/examples/production/monitoring/main.go
@@ -1,5 +1,5 @@
 // file: examples/production/monitoring/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0042c09e-b61b-4268-838f-2d7af81706ea
 
 package main
@@ -7,27 +7,70 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/jdfalk/gcommon/monitoring/collectors"
+	"github.com/jdfalk/gcommon/monitoring/exporters"
 )
 
-// TODO: Complete monitoring example
+// setup configures metrics, logging, and tracing collectors along with a
+// Prometheus exporter. The exporter serves metrics on :9090/metrics. A simple
+// log subscriber prints log entries to standard output.
+func setup(ctx context.Context) (*collectors.MetricsCollector, *collectors.LogsCollector, *collectors.TracesCollector, *exporters.PrometheusExporter, error) {
+	mc, err := collectors.NewMetricsCollector()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	mc.StartRuntimeMetrics(ctx, time.Second)
 
-func setup(ctx context.Context) error {
-	// TODO: implement setup for monitoring
-	return nil
+	promExp := exporters.NewPrometheusExporter(mc.Registry(), ":9090", "/metrics")
+	promExp.Start()
+
+	lc := collectors.NewLogsCollector(100)
+	lc.Start(ctx)
+	sub := lc.Subscribe(100)
+	go func() {
+		for entry := range sub {
+			fmt.Printf("%s [%s] %s\n", entry.Timestamp.Format(time.RFC3339), entry.Level, entry.Message)
+		}
+	}()
+
+	tc, err := collectors.NewTracesCollector("example-service", "http://localhost:14268/api/traces")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	return mc, lc, tc, promExp, nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run monitoring logic
-	fmt.Println("TODO: run monitoring")
+// run demonstrates basic usage of the collectors by recording a metric, a log
+// entry, and a trace span.
+func run(ctx context.Context, mc *collectors.MetricsCollector, lc *collectors.LogsCollector, tc *collectors.TracesCollector) error {
+	counter := mc.RegisterCounter("example_requests_total", "number of example requests")
+	ctx, span := tc.StartSpan(ctx, "run")
+	defer tc.EndSpan(span, nil)
+
+	lc.Emit(collectors.LevelInfo, "starting work", nil)
+	counter.Add(ctx, 1)
+	lc.Emit(collectors.LevelInfo, "work complete", nil)
 	return nil
 }
 
 func main() {
-	ctx := context.Background()
-	if err := setup(ctx); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mc, lc, tc, exp, err := setup(ctx)
+	if err != nil {
 		panic(err)
 	}
-	if err := run(ctx); err != nil {
+	defer exp.Shutdown()
+	defer tc.Shutdown(context.Background())
+
+	if err := run(ctx, mc, lc, tc); err != nil {
 		panic(err)
 	}
+
+	// Allow some time for asynchronous operations to complete before exit.
+	time.Sleep(100 * time.Millisecond)
 }

--- a/monitoring/alerts/combined_test.go
+++ b/monitoring/alerts/combined_test.go
@@ -1,0 +1,44 @@
+// file: monitoring/alerts/combined_test.go
+// version: 1.0.0
+// guid: e7f9a1b2-c3d4-4e5f-a6b7-c8d9e0f1a2b3
+
+package alerts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestCombinedAlerts runs all alert types together to ensure no interference.
+func TestCombinedAlerts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sla := NewSLAAlert(time.Minute, 100)
+	errA := NewErrorAlert(time.Minute, 0)
+	perf := NewPerformanceAlert(time.Minute, 0)
+
+	sla.Record(time.Now(), false)
+	errA.Record(time.Now())
+	perf.Record(1 * time.Millisecond)
+
+	slaFired := make(chan float64, 1)
+	errFired := make(chan float64, 1)
+	perfFired := make(chan time.Duration, 1)
+
+	go sla.Monitor(ctx, 10*time.Millisecond, func(u float64) { slaFired <- u })
+	go errA.Monitor(ctx, 10*time.Millisecond, func(r float64) { errFired <- r })
+	go perf.Monitor(ctx, 10*time.Millisecond, func(d time.Duration) { perfFired <- d })
+
+	timeout := time.After(time.Second)
+	for i := 0; i < 3; i++ {
+		select {
+		case <-slaFired:
+		case <-errFired:
+		case <-perfFired:
+		case <-timeout:
+			t.Fatalf("timeout waiting for alerts")
+		}
+	}
+}

--- a/monitoring/alerts/errors_test.go
+++ b/monitoring/alerts/errors_test.go
@@ -1,0 +1,38 @@
+// file: monitoring/alerts/errors_test.go
+// version: 1.0.0
+// guid: 3f4d6e21-bfd3-44a8-9e5c-93ec5af1fce3
+
+package alerts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestErrorAlertEvaluate verifies error rate calculation.
+func TestErrorAlertEvaluate(t *testing.T) {
+	a := NewErrorAlert(time.Minute, 0.1)
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		a.Record(now)
+	}
+	if !a.Evaluate(now) {
+		t.Fatalf("expected alert to trigger")
+	}
+}
+
+// TestErrorAlertMonitor ensures callback fires when threshold exceeded.
+func TestErrorAlertMonitor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := NewErrorAlert(time.Minute, 0)
+	a.Record(time.Now())
+	fired := make(chan float64, 1)
+	go a.Monitor(ctx, 10*time.Millisecond, func(r float64) { fired <- r })
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatalf("monitor did not fire")
+	}
+}

--- a/monitoring/alerts/performance_test.go
+++ b/monitoring/alerts/performance_test.go
@@ -1,0 +1,38 @@
+// file: monitoring/alerts/performance_test.go
+// version: 1.0.0
+// guid: 6a1d842c-3e55-4efb-9f76-c1ee1bb4b3e4
+
+package alerts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestPerformanceAlertEvaluate verifies percentile logic.
+func TestPerformanceAlertEvaluate(t *testing.T) {
+	a := NewPerformanceAlert(time.Minute, 50*time.Millisecond)
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		a.Record(time.Duration(i) * time.Millisecond)
+	}
+	if !a.Evaluate(now) {
+		t.Fatalf("expected alert to trigger")
+	}
+}
+
+// TestPerformanceAlertMonitor ensures callback triggers when latency too high.
+func TestPerformanceAlertMonitor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := NewPerformanceAlert(time.Minute, 0)
+	a.Record(10 * time.Millisecond)
+	fired := make(chan time.Duration, 1)
+	go a.Monitor(ctx, 10*time.Millisecond, func(d time.Duration) { fired <- d })
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatalf("monitor did not fire")
+	}
+}

--- a/monitoring/alerts/sla_test.go
+++ b/monitoring/alerts/sla_test.go
@@ -1,0 +1,39 @@
+// file: monitoring/alerts/sla_test.go
+// version: 1.0.0
+// guid: 7e6f5b47-9f39-4cfa-8a5d-06b8d1d89888
+
+package alerts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestSLAAlertEvaluate verifies uptime calculation.
+func TestSLAAlertEvaluate(t *testing.T) {
+	a := NewSLAAlert(time.Minute, 90)
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		a.Record(now.Add(-time.Duration(i)*10*time.Second), true)
+	}
+	a.Record(now.Add(-15*time.Second), false)
+	if !a.Evaluate(now) {
+		t.Fatalf("expected SLA alert to trigger")
+	}
+}
+
+// TestSLAAlertMonitor ensures callback is invoked when uptime drops.
+func TestSLAAlertMonitor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := NewSLAAlert(time.Minute, 100)
+	a.Record(time.Now(), false)
+	fired := make(chan float64, 1)
+	go a.Monitor(ctx, 10*time.Millisecond, func(u float64) { fired <- u })
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatalf("monitor did not fire")
+	}
+}

--- a/monitoring/collectors/logs_extended_test.go
+++ b/monitoring/collectors/logs_extended_test.go
@@ -1,0 +1,43 @@
+// file: monitoring/collectors/logs_extended_test.go
+// version: 1.0.0
+// guid: d4e2c3b1-7a8f-49b2-9c3d-4e5f6a7b8c9d
+
+package collectors
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestMultipleSubscribers ensures all subscribers receive logs.
+func TestMultipleSubscribers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := NewLogsCollector(10)
+	lc.Start(ctx)
+	sub1 := lc.Subscribe(1)
+	sub2 := lc.Subscribe(1)
+	lc.Emit(LevelInfo, "message", nil)
+	for i, ch := range []<-chan LogEntry{sub1, sub2} {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d did not receive log", i)
+		}
+	}
+	lc.Close()
+}
+
+// TestCloseBehavior ensures subscribers are closed when collector closes.
+func TestCloseBehavior(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := NewLogsCollector(10)
+	lc.Start(ctx)
+	sub := lc.Subscribe(1)
+	lc.Close()
+	if _, ok := <-sub; ok {
+		t.Fatalf("subscriber channel should be closed")
+	}
+}

--- a/monitoring/collectors/logs_test.go
+++ b/monitoring/collectors/logs_test.go
@@ -1,0 +1,71 @@
+// file: monitoring/collectors/logs_test.go
+// version: 1.0.0
+// guid: 8b821b4a-4e7a-4cf5-9d03-7bc9d95fbd11
+
+package collectors
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+)
+
+// TestLogsCollectorEmit verifies that subscribers receive emitted logs.
+func TestLogsCollectorEmit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := NewLogsCollector(10)
+	lc.Start(ctx)
+	sub := lc.Subscribe(1)
+	lc.Emit(LevelInfo, "hello", nil)
+	select {
+	case entry := <-sub:
+		if entry.Message != "hello" {
+			t.Fatalf("unexpected message: %s", entry.Message)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for log entry")
+	}
+	lc.Close()
+}
+
+// TestLogsCollectorStdLogger ensures standard logger output is captured.
+func TestLogsCollectorStdLogger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := NewLogsCollector(10)
+	lc.Start(ctx)
+	sub := lc.Subscribe(1)
+	logger := lc.StdLogger(LevelError, map[string]any{"component": "test"})
+	logger.Print("failure")
+	select {
+	case entry := <-sub:
+		if entry.Level != LevelError || entry.Message != "failure" {
+			t.Fatalf("unexpected log entry: %+v", entry)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+	lc.Close()
+}
+
+// TestLogsCollectorRedirectStandardLibrary confirms log package output is redirected.
+func TestLogsCollectorRedirectStandardLibrary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := NewLogsCollector(10)
+	lc.Start(ctx)
+	sub := lc.Subscribe(1)
+	lc.RedirectStandardLibrary(LevelWarn)
+	log.Print("warning")
+	select {
+	case entry := <-sub:
+		if entry.Level != LevelWarn || entry.Message != "warning" {
+			t.Fatalf("unexpected entry: %+v", entry)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout")
+	}
+	lc.Close()
+}

--- a/monitoring/collectors/metrics_extended_test.go
+++ b/monitoring/collectors/metrics_extended_test.go
@@ -1,0 +1,73 @@
+// file: monitoring/collectors/metrics_extended_test.go
+// version: 1.0.0
+// guid: c5e3b2d1-8a4b-4f9e-9a6d-7d8c9e0f1a2b
+
+package collectors
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestConcurrentIncrement validates counter correctness under concurrency.
+func TestConcurrentIncrement(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	counter := mc.RegisterCounter("conc_counter", "")
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			counter.Add(context.Background(), 1)
+		}()
+	}
+	wg.Wait()
+	if got := testutil.ToFloat64(counter); got != 50 {
+		t.Fatalf("counter value = %v, want 50", got)
+	}
+}
+
+// TestGaugeConcurrency checks gauge updates from multiple goroutines.
+func TestGaugeConcurrency(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	gauge := mc.RegisterGauge("conc_gauge", "")
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gauge.Add(context.Background(), 1)
+			time.Sleep(1 * time.Millisecond)
+			gauge.Add(context.Background(), -1)
+		}()
+	}
+	wg.Wait()
+	if got := testutil.ToFloat64(gauge); got != 0 {
+		t.Fatalf("gauge value = %v, want 0", got)
+	}
+}
+
+// TestObserveDistribution ensures histogram records multiple values.
+func TestObserveDistribution(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	hist := mc.RegisterHistogram("dist_hist", "", "ms")
+	for i := 0; i < 100; i++ {
+		hist.Record(context.Background(), float64(i))
+	}
+	if count := testutil.CollectAndCount(hist); count == 0 {
+		t.Fatalf("expected histogram values")
+	}
+}

--- a/monitoring/collectors/metrics_test.go
+++ b/monitoring/collectors/metrics_test.go
@@ -1,0 +1,70 @@
+// file: monitoring/collectors/metrics_test.go
+// version: 1.0.0
+// guid: 5c9d4a97-8ae6-41e7-a5f3-9a5e5fd4f111
+
+package collectors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// TestMetricsCollectorCounter verifies counter registration and increment.
+func TestMetricsCollectorCounter(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	counter := mc.RegisterCounter("test_counter", "a test counter")
+	counter.Add(context.Background(), 5)
+	if got := testutil.ToFloat64(counter); got != 5 {
+		t.Fatalf("counter value = %v, want 5", got)
+	}
+}
+
+// TestMetricsCollectorGauge verifies gauge registration and updates.
+func TestMetricsCollectorGauge(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	gauge := mc.RegisterGauge("test_gauge", "a test gauge")
+	gauge.Add(context.Background(), 3)
+	gauge.Add(context.Background(), -1)
+	if got := testutil.ToFloat64(gauge); got != 2 {
+		t.Fatalf("gauge value = %v, want 2", got)
+	}
+}
+
+// TestMetricsCollectorHistogram verifies histogram registration and observation.
+func TestMetricsCollectorHistogram(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	hist := mc.RegisterHistogram("test_hist", "a test histogram", "ms")
+	hist.Record(context.Background(), 10, metric.WithAttributes(attribute.String("type", "test")))
+	if count := testutil.CollectAndCount(hist); count == 0 {
+		t.Fatalf("expected histogram to record value")
+	}
+}
+
+// TestStartRuntimeMetrics ensures runtime metrics are recorded.
+func TestStartRuntimeMetrics(t *testing.T) {
+	mc, err := NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	mc.StartRuntimeMetrics(ctx, 10*time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
+	cancel()
+	if got := testutil.ToFloat64(mc.RegisterGauge("runtime_goroutines", "")); got == 0 {
+		t.Fatalf("runtime_goroutines not recorded")
+	}
+}

--- a/monitoring/collectors/traces_test.go
+++ b/monitoring/collectors/traces_test.go
@@ -1,0 +1,32 @@
+// file: monitoring/collectors/traces_test.go
+// version: 1.0.0
+// guid: 2c7c5a2e-bd4c-43bb-a19e-42e1b8d5c0de
+
+package collectors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// TestTracesCollectorStartEnd ensures spans can be started and ended without error.
+func TestTracesCollectorStartEnd(t *testing.T) {
+	tc, err := NewTracesCollector("test-service", "http://localhost:14268/api/traces")
+	if err != nil {
+		t.Fatalf("NewTracesCollector: %v", err)
+	}
+	defer tc.Shutdown(context.Background())
+
+	ctx, span := tc.StartSpan(context.Background(), "parent", attribute.String("k", "v"))
+	time.Sleep(1 * time.Millisecond)
+	ctx2, child := tc.StartSpan(ctx, "child")
+	time.Sleep(1 * time.Millisecond)
+	tc.EndSpan(child, nil)
+	tc.EndSpan(span, nil)
+	if ctx2 == nil {
+		t.Fatalf("expected non-nil context from child span")
+	}
+}

--- a/monitoring/exporters/elastic_test.go
+++ b/monitoring/exporters/elastic_test.go
@@ -1,0 +1,34 @@
+// file: monitoring/exporters/elastic_test.go
+// version: 1.0.0
+// guid: 41ad2f9c-3b3a-4b8e-b0a4-6a09ae3b5f22
+
+package exporters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestElasticExporter sends a log document to a test server.
+func TestElasticExporter(t *testing.T) {
+	var received LogDocument
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	exp := NewElasticExporter(srv.URL)
+	doc := LogDocument{Timestamp: time.Now(), Level: "INFO", Message: "hello"}
+	if err := exp.ExportLog(context.Background(), doc); err != nil {
+		t.Fatalf("ExportLog: %v", err)
+	}
+	if received.Message != "hello" {
+		t.Fatalf("unexpected message: %s", received.Message)
+	}
+}

--- a/monitoring/exporters/jaeger_test.go
+++ b/monitoring/exporters/jaeger_test.go
@@ -1,0 +1,25 @@
+// file: monitoring/exporters/jaeger_test.go
+// version: 1.0.0
+// guid: 5d7e0c9a-1b2d-4e3f-9a4b-6c7d8e9f0a1b
+
+package exporters
+
+import (
+	"context"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// TestJaegerExporter verifies exporter integration with tracer provider.
+func TestJaegerExporter(t *testing.T) {
+	exp, err := NewJaegerExporter("http://localhost:14268/api/traces")
+	if err != nil {
+		t.Fatalf("NewJaegerExporter: %v", err)
+	}
+	tp := sdktrace.NewTracerProvider()
+	exp.Export(tp)
+	if err := exp.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}

--- a/monitoring/exporters/prometheus_test.go
+++ b/monitoring/exporters/prometheus_test.go
@@ -1,0 +1,64 @@
+// file: monitoring/exporters/prometheus_test.go
+// version: 1.1.0
+// guid: 9d1c5e23-42b1-4e6c-a3a4-1e5b2d4f6e7a
+
+package exporters
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/gcommon/monitoring/collectors"
+	"strings"
+)
+
+// TestPrometheusExporter serves metrics and verifies they are accessible.
+func TestPrometheusExporter(t *testing.T) {
+	mc, err := collectors.NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	counter := mc.RegisterCounter("requests_total", "requests")
+	counter.Add(context.Background(), 1)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	exp := NewPrometheusExporter(mc.Registry(), addr, "/metrics")
+	exp.Start()
+	defer exp.Shutdown()
+
+	// Wait for server to start.
+	time.Sleep(50 * time.Millisecond)
+	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", addr))
+	if err != nil {
+		t.Fatalf("http get: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "requests_total") {
+		t.Fatalf("metrics output missing counter")
+	}
+}
+
+// TestPrometheusExporterShutdown verifies shutdown succeeds even if started on ephemeral port.
+func TestPrometheusExporterShutdown(t *testing.T) {
+	mc, err := collectors.NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	exp := NewPrometheusExporter(mc.Registry(), "127.0.0.1:0", "/metrics")
+	exp.Start()
+	if err := exp.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}

--- a/monitoring/integration_test.go
+++ b/monitoring/integration_test.go
@@ -1,0 +1,103 @@
+// file: monitoring/integration_test.go
+// version: 1.0.0
+// guid: ab1c2d3e-4f5a-678b-9c0d-1e2f3a4b5c6d
+
+package monitoring_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/gcommon/monitoring/alerts"
+	"github.com/jdfalk/gcommon/monitoring/collectors"
+	"github.com/jdfalk/gcommon/monitoring/exporters"
+)
+
+// TestFullMonitoringFlow simulates an end-to-end monitoring scenario using collectors, exporters, and alerts.
+func TestFullMonitoringFlow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Metrics collector and exporter
+	mc, err := collectors.NewMetricsCollector()
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	mc.StartRuntimeMetrics(ctx, time.Millisecond)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+	promExp := exporters.NewPrometheusExporter(mc.Registry(), addr, "/metrics")
+	promExp.Start()
+	defer promExp.Shutdown()
+
+	// Log collector
+	lc := collectors.NewLogsCollector(10)
+	lc.Start(ctx)
+	logSub := lc.Subscribe(1)
+	lc.Emit(collectors.LevelInfo, "boot", nil)
+
+	// Trace collector
+	tc, err := collectors.NewTracesCollector("svc", "http://localhost:14268/api/traces")
+	if err != nil {
+		t.Fatalf("NewTracesCollector: %v", err)
+	}
+	defer tc.Shutdown(context.Background())
+	tCtx, span := tc.StartSpan(ctx, "op")
+	time.Sleep(1 * time.Millisecond)
+	tc.EndSpan(span, nil)
+	if tCtx == nil {
+		t.Fatalf("expected context from span")
+	}
+
+	// Alerts
+	sla := alerts.NewSLAAlert(time.Minute, 100)
+	errA := alerts.NewErrorAlert(time.Minute, 0)
+	perf := alerts.NewPerformanceAlert(time.Minute, 0)
+	sla.Record(time.Now(), false)
+	errA.Record(time.Now())
+	perf.Record(1 * time.Millisecond)
+	slaCh := make(chan float64, 1)
+	errCh := make(chan float64, 1)
+	perfCh := make(chan time.Duration, 1)
+	go sla.Monitor(ctx, 10*time.Millisecond, func(f float64) { slaCh <- f })
+	go errA.Monitor(ctx, 10*time.Millisecond, func(f float64) { errCh <- f })
+	go perf.Monitor(ctx, 10*time.Millisecond, func(d time.Duration) { perfCh <- d })
+
+	// Validate log received
+	select {
+	case entry := <-logSub:
+		if entry.Message != "boot" {
+			t.Fatalf("unexpected log: %+v", entry)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("missing log entry")
+	}
+
+	// Validate metrics endpoint
+	time.Sleep(50 * time.Millisecond)
+	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", addr))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics endpoint: %v %v", resp.StatusCode, err)
+	}
+	resp.Body.Close()
+
+	// Ensure alerts fired
+	timeout := time.After(time.Second)
+	for i := 0; i < 3; i++ {
+		select {
+		case <-slaCh:
+		case <-errCh:
+		case <-perfCh:
+		case <-timeout:
+			t.Fatalf("missing alert")
+		}
+	}
+}

--- a/pkg/log/monitoring/alerts_test.go
+++ b/pkg/log/monitoring/alerts_test.go
@@ -1,0 +1,27 @@
+// file: pkg/log/monitoring/alerts_test.go
+// version: 1.0.0
+// guid: 7c2d5e1a-8f4b-4f17-a1b0-0de712fa3b11
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+)
+
+// TestAlertManager triggers callback when error count exceeds threshold.
+func TestAlertManager(t *testing.T) {
+	fired := make(chan int64, 1)
+	am := NewAlertManager(1, 10*time.Millisecond, func(c int64) { fired <- c })
+	am.Notify(log.ErrorLevel)
+	select {
+	case c := <-fired:
+		if c != 1 {
+			t.Fatalf("expected count 1, got %d", c)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("callback not triggered")
+	}
+}

--- a/pkg/log/monitoring/analysis_test.go
+++ b/pkg/log/monitoring/analysis_test.go
@@ -1,0 +1,25 @@
+// file: pkg/log/monitoring/analysis_test.go
+// version: 1.0.0
+// guid: 33b7c9d5-6f0e-4ac8-9c89-d6c1a4e9f3b0
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+)
+
+// TestAnalyzer verifies counting and searching of log entries.
+func TestAnalyzer(t *testing.T) {
+	entries := []log.LogEntry{{Level: log.InfoLevel, Message: "startup"}, {Level: log.ErrorLevel, Message: "fail"}}
+	a := Analyzer{}
+	counts := a.CountByLevel(entries)
+	if counts[log.InfoLevel] != 1 || counts[log.ErrorLevel] != 1 {
+		t.Fatalf("unexpected counts: %+v", counts)
+	}
+	found := a.Search(entries, "fail")
+	if len(found) != 1 || found[0].Message != "fail" {
+		t.Fatalf("unexpected search result: %+v", found)
+	}
+}

--- a/pkg/log/monitoring/integration_test.go
+++ b/pkg/log/monitoring/integration_test.go
@@ -1,0 +1,40 @@
+// file: pkg/log/monitoring/integration_test.go
+// version: 1.0.0
+// guid: a4b5c6d7-e8f9-40a1-b2c3-d4e5f6a7b8c9
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+// TestLogMonitoringIntegration wires together metrics, alerts, and analysis.
+func TestLogMonitoringIntegration(t *testing.T) {
+	prom.Unregister(logEntries)
+	prom.MustRegister(logEntries)
+
+	fired := make(chan int64, 1)
+	am := NewAlertManager(2, 10*time.Millisecond, func(c int64) { fired <- c })
+
+	entries := []log.LogEntry{}
+	for i := 0; i < 3; i++ {
+		am.Notify(log.ErrorLevel)
+		Observe(log.ErrorLevel)
+		entries = append(entries, log.LogEntry{Level: log.ErrorLevel, Message: "err"})
+	}
+
+	analyzer := Analyzer{}
+	counts := analyzer.CountByLevel(entries)
+	if counts[log.ErrorLevel] != 3 {
+		t.Fatalf("expected 3 error entries, got %d", counts[log.ErrorLevel])
+	}
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatalf("alert manager did not fire")
+	}
+}

--- a/pkg/log/monitoring/metrics_test.go
+++ b/pkg/log/monitoring/metrics_test.go
@@ -1,0 +1,23 @@
+// file: pkg/log/monitoring/metrics_test.go
+// version: 1.0.0
+// guid: 3e0f24c9-64f2-4f4b-93e1-b60e4f3a92b2
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestObserve increments the counter for log entries.
+func TestObserve(t *testing.T) {
+	prom.Unregister(logEntries)
+	prom.MustRegister(logEntries)
+	Observe(log.InfoLevel)
+	if testutil.ToFloat64(logEntries.WithLabelValues(log.InfoLevel.String())) != 1 {
+		t.Fatalf("counter not incremented")
+	}
+}

--- a/security/monitoring/alerts_test.go
+++ b/security/monitoring/alerts_test.go
@@ -1,0 +1,26 @@
+// file: security/monitoring/alerts_test.go
+// version: 1.0.0
+// guid: 8a7e68d0-3b39-4c47-8fd3-5e0c2668e1aa
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDispatcherDispatch verifies subscribers receive alerts.
+func TestDispatcherDispatch(t *testing.T) {
+	d := NewDispatcher()
+	ch := make(chan Alert, 1)
+	d.Subscribe(ch)
+	d.Dispatch("intrusion", "high")
+	select {
+	case a := <-ch:
+		if a.Message != "intrusion" || a.Severity != "high" {
+			t.Fatalf("unexpected alert: %+v", a)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for alert")
+	}
+}

--- a/security/monitoring/anomalies_test.go
+++ b/security/monitoring/anomalies_test.go
@@ -1,0 +1,22 @@
+// file: security/monitoring/anomalies_test.go
+// version: 1.0.0
+// guid: b2d9aef5-3c7e-40e4-8e5d-2a0b741d3c69
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDetectorDetect verifies anomaly detection based on thresholds.
+func TestDetectorDetect(t *testing.T) {
+	r := NewRecorder()
+	r.Record("login", nil)
+	r.Record("login", nil)
+	det := NewDetector(map[string]int{"login": 1}, time.Minute)
+	anomalies := det.Detect(r.List())
+	if len(anomalies) != 1 {
+		t.Fatalf("expected one anomaly, got %d", len(anomalies))
+	}
+}

--- a/security/monitoring/events_test.go
+++ b/security/monitoring/events_test.go
@@ -1,0 +1,21 @@
+// file: security/monitoring/events_test.go
+// version: 1.0.0
+// guid: 1d1f7b2e-7f5c-4e88-8d04-a91ccee4da8d
+
+package monitoring
+
+import "testing"
+
+// TestRecorder verifies event recording and listing.
+func TestRecorder(t *testing.T) {
+	r := NewRecorder()
+	r.Record("login", map[string]string{"user": "alice"})
+	events := r.List()
+	if len(events) != 1 || events[0].Name != "login" {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+	filtered := r.Filter(func(e Event) bool { return e.Metadata["user"] == "alice" })
+	if len(filtered) != 1 {
+		t.Fatalf("expected one filtered event")
+	}
+}

--- a/security/monitoring/integration_test.go
+++ b/security/monitoring/integration_test.go
@@ -1,0 +1,38 @@
+// file: security/monitoring/integration_test.go
+// version: 1.0.0
+// guid: f1a2b3c4-d5e6-47f8-9a0b-1c2d3e4f5a6b
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSecurityMonitoringIntegration exercises recorder, detector, and dispatcher together.
+func TestSecurityMonitoringIntegration(t *testing.T) {
+	rec := NewRecorder()
+	disp := NewDispatcher()
+	det := NewDetector(map[string]int{"login": 2}, time.Minute)
+
+	alertCh := make(chan Alert, 1)
+	disp.Subscribe(alertCh)
+
+	rec.Record("login", map[string]string{"user": "alice"})
+	rec.Record("login", map[string]string{"user": "bob"})
+	rec.Record("login", map[string]string{"user": "charlie"})
+
+	anomalies := det.Detect(rec.List())
+	for range anomalies {
+		disp.Dispatch("anomaly detected", "critical")
+	}
+
+	select {
+	case a := <-alertCh:
+		if a.Severity != "critical" {
+			t.Fatalf("unexpected severity: %s", a.Severity)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no alert received")
+	}
+}


### PR DESCRIPTION
## Summary
- add production monitoring example using metrics, logs, traces, and Prometheus exporter
- add extensive unit tests for collectors, alerts, exporters, and monitoring utilities
- document monitoring feature and track integration TODO

## Testing
- `go test ./security/monitoring ./pkg/log/monitoring`
- `go test ./monitoring/alerts ./monitoring/collectors ./monitoring/exporters` *(fails: multiple-value labelNamer.Build(cfg.namespace) in go.opentelemetry.io/otel/exporters/prometheus)*

------
https://chatgpt.com/codex/tasks/task_e_689943c183ac83218e7882d790574502