### PR TITLE
feat(log): standardize module logging

### DIFF
--- a/.github/doc-updates/89620380-78d2-4d89-ac70-f86e3326712a.json
+++ b/.github/doc-updates/89620380-78d2-4d89-ac70-f86e3326712a.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add logging wrappers for config, queue, and auth modules for standardized logging",
+  "guid": "89620380-78d2-4d89-ac70-f86e3326712a",
+  "created_at": "2025-08-11T01:33:11Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f0f948de-3f9c-47ca-af1f-03d19b79d023.json
+++ b/.github/doc-updates/f0f948de-3f9c-47ca-af1f-03d19b79d023.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Evaluate advanced log filtering capabilities",
+  "guid": "f0f948de-3f9c-47ca-af1f-03d19b79d023",
+  "created_at": "2025-08-11T01:33:19Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/6fff4f61-da8d-46db-acf6-c51b20735509.json
+++ b/.github/issue-updates/6fff4f61-da8d-46db-acf6-c51b20735509.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Standardize logging across modules",
+  "body": "Implement logging wrappers and structured logging across config, queue, and auth modules to ensure consistent log patterns and correlation.",
+  "labels": ["enhancement", "module:log", "module:config", "module:queue", "module:auth"],
+  "guid": "6fff4f61-da8d-46db-acf6-c51b20735509",
+  "legacy_guid": "create-standardize-logging-across-modules-2025-08-11",
+  "created_at": "2025-08-11T01:17:58.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/auth/logging.go
+++ b/pkg/auth/logging.go
@@ -1,0 +1,117 @@
+// file: pkg/auth/logging.go
+// version: 1.0.0
+// guid: 1df353d9-e33d-432b-aec7-4f7f496163ff
+
+package auth
+
+import (
+	"context"
+
+	proto "github.com/jdfalk/gcommon/pkg/auth/proto"
+	"github.com/jdfalk/gcommon/pkg/log"
+)
+
+// LoggedAuthProvider wraps AuthProvider with logging.
+type LoggedAuthProvider struct {
+	p      AuthProvider
+	logger log.Logger
+}
+
+// NewLoggedAuthProvider creates a LoggedAuthProvider.
+func NewLoggedAuthProvider(p AuthProvider, l log.Logger) *LoggedAuthProvider {
+	return &LoggedAuthProvider{p: p, logger: l}
+}
+
+// Authenticate logs authentication attempts.
+func (l *LoggedAuthProvider) Authenticate(ctx context.Context, req *proto.AuthenticateRequest) (*proto.AuthenticateResponse, error) {
+	l.logger.InfoContext(ctx, "auth authenticate")
+	resp, err := l.p.Authenticate(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth authenticate failed", log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth authenticate success")
+	return resp, nil
+}
+
+// ValidateToken logs token validations.
+func (l *LoggedAuthProvider) ValidateToken(ctx context.Context, req *proto.ValidateTokenRequest) (*proto.ValidateTokenResponse, error) {
+	l.logger.InfoContext(ctx, "auth validate token")
+	resp, err := l.p.ValidateToken(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth validate token failed", log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth validate token success")
+	return resp, nil
+}
+
+// RefreshToken logs token refresh operations.
+func (l *LoggedAuthProvider) RefreshToken(ctx context.Context, req *proto.RefreshTokenRequest) (*proto.RefreshTokenResponse, error) {
+	l.logger.InfoContext(ctx, "auth refresh token")
+	resp, err := l.p.RefreshToken(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth refresh token failed", log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth refresh token success")
+	return resp, nil
+}
+
+// RevokeToken logs token revocations.
+func (l *LoggedAuthProvider) RevokeToken(ctx context.Context, req *proto.RevokeTokenRequest) (*proto.RevokeTokenResponse, error) {
+	l.logger.InfoContext(ctx, "auth revoke token")
+	resp, err := l.p.RevokeToken(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth revoke token failed", log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth revoke token success")
+	return resp, nil
+}
+
+// LoggedAuthorizationProvider wraps AuthorizationProvider with logging.
+type LoggedAuthorizationProvider struct {
+	p      AuthorizationProvider
+	logger log.Logger
+}
+
+// NewLoggedAuthorizationProvider creates a LoggedAuthorizationProvider.
+func NewLoggedAuthorizationProvider(p AuthorizationProvider, l log.Logger) *LoggedAuthorizationProvider {
+	return &LoggedAuthorizationProvider{p: p, logger: l}
+}
+
+// Authorize logs authorization decisions.
+func (l *LoggedAuthorizationProvider) Authorize(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	l.logger.InfoContext(ctx, "auth authorize", log.Field{Key: "resource", Value: req.GetResource()})
+	resp, err := l.p.Authorize(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth authorize failed", log.Field{Key: "resource", Value: req.GetResource()}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth authorize success", log.Field{Key: "resource", Value: req.GetResource()})
+	return resp, nil
+}
+
+// EvaluatePolicy logs policy evaluations.
+func (l *LoggedAuthorizationProvider) EvaluatePolicy(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	l.logger.InfoContext(ctx, "auth evaluate policy", log.Field{Key: "resource", Value: req.GetResource()})
+	resp, err := l.p.EvaluatePolicy(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "auth evaluate policy failed", log.Field{Key: "resource", Value: req.GetResource()}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "auth evaluate policy success", log.Field{Key: "resource", Value: req.GetResource()})
+	return resp, nil
+}
+
+// CreatePolicy logs policy creation.
+func (l *LoggedAuthorizationProvider) CreatePolicy(ctx context.Context, policy *proto.SecurityPolicy) error {
+	l.logger.InfoContext(ctx, "auth create policy")
+	if err := l.p.CreatePolicy(ctx, policy); err != nil {
+		l.logger.ErrorContext(ctx, "auth create policy failed", log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "auth create policy success")
+	return nil
+}

--- a/pkg/auth/logging_test.go
+++ b/pkg/auth/logging_test.go
@@ -1,0 +1,170 @@
+// file: pkg/auth/logging_test.go
+// version: 1.0.0
+// guid: 93a82613-9462-4261-a660-7ee16fee3758
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	proto "github.com/jdfalk/gcommon/pkg/auth/proto"
+	"github.com/jdfalk/gcommon/pkg/log/testlogger"
+)
+
+// stubAuthProvider implements AuthProvider with no-op logic.
+type stubAuthProvider struct{}
+
+func (s *stubAuthProvider) Authenticate(ctx context.Context, req *proto.AuthenticateRequest) (*proto.AuthenticateResponse, error) {
+	return &proto.AuthenticateResponse{}, nil
+}
+func (s *stubAuthProvider) ValidateToken(ctx context.Context, req *proto.ValidateTokenRequest) (*proto.ValidateTokenResponse, error) {
+	return &proto.ValidateTokenResponse{}, nil
+}
+func (s *stubAuthProvider) RefreshToken(ctx context.Context, req *proto.RefreshTokenRequest) (*proto.RefreshTokenResponse, error) {
+	return &proto.RefreshTokenResponse{}, nil
+}
+func (s *stubAuthProvider) RevokeToken(ctx context.Context, req *proto.RevokeTokenRequest) (*proto.RevokeTokenResponse, error) {
+	return &proto.RevokeTokenResponse{}, nil
+}
+
+// stubAuthzProvider implements AuthorizationProvider with no-op logic.
+type stubAuthzProvider struct{}
+
+func (s *stubAuthzProvider) Authorize(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	return &proto.AuthorizeResponse{}, nil
+}
+func (s *stubAuthzProvider) EvaluatePolicy(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	return &proto.AuthorizeResponse{}, nil
+}
+func (s *stubAuthzProvider) CreatePolicy(ctx context.Context, policy *proto.SecurityPolicy) error {
+	return nil
+}
+
+func TestLoggedAuthProvider_Authenticate(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthProvider(&stubAuthProvider{}, l)
+	_, err := p.Authenticate(context.Background(), &proto.AuthenticateRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(l.Entries()))
+	}
+	if l.Entries()[0].Message != "auth authenticate" {
+		t.Fatalf("unexpected message: %+v", l.Entries()[0])
+	}
+}
+
+func TestLoggedAuthorizationProvider_Authorize(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthorizationProvider(&stubAuthzProvider{}, l)
+	_, err := p.Authorize(context.Background(), &proto.AuthorizeRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(l.Entries()))
+	}
+	if l.Entries()[0].Message != "auth authorize" {
+		t.Fatalf("unexpected message: %+v", l.Entries()[0])
+	}
+}
+
+// errAuthProvider returns errors for all methods.
+type errAuthProvider struct{}
+
+func (errAuthProvider) Authenticate(ctx context.Context, req *proto.AuthenticateRequest) (*proto.AuthenticateResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (errAuthProvider) ValidateToken(ctx context.Context, req *proto.ValidateTokenRequest) (*proto.ValidateTokenResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (errAuthProvider) RefreshToken(ctx context.Context, req *proto.RefreshTokenRequest) (*proto.RefreshTokenResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (errAuthProvider) RevokeToken(ctx context.Context, req *proto.RevokeTokenRequest) (*proto.RevokeTokenResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+
+// errAuthzProvider returns errors for all methods.
+type errAuthzProvider struct{}
+
+func (errAuthzProvider) Authorize(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (errAuthzProvider) EvaluatePolicy(ctx context.Context, req *proto.AuthorizeRequest) (*proto.AuthorizeResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (errAuthzProvider) CreatePolicy(ctx context.Context, policy *proto.SecurityPolicy) error {
+	return fmt.Errorf("fail")
+}
+
+func TestLoggedAuthProvider_OtherMethods(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthProvider(&stubAuthProvider{}, l)
+	if _, err := p.ValidateToken(context.Background(), &proto.ValidateTokenRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := p.RefreshToken(context.Background(), &proto.RefreshTokenRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := p.RevokeToken(context.Background(), &proto.RevokeTokenRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(l.Entries()))
+	}
+}
+
+func TestLoggedAuthProvider_Errors(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthProvider(errAuthProvider{}, l)
+	if _, err := p.Authenticate(context.Background(), &proto.AuthenticateRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := p.ValidateToken(context.Background(), &proto.ValidateTokenRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := p.RefreshToken(context.Background(), &proto.RefreshTokenRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := p.RevokeToken(context.Background(), &proto.RevokeTokenRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(l.Entries()) != 8 {
+		t.Fatalf("expected 8 entries, got %d", len(l.Entries()))
+	}
+}
+
+func TestLoggedAuthorizationProvider_OtherMethods(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthorizationProvider(&stubAuthzProvider{}, l)
+	if _, err := p.EvaluatePolicy(context.Background(), &proto.AuthorizeRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := p.CreatePolicy(context.Background(), &proto.SecurityPolicy{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(l.Entries()))
+	}
+}
+
+func TestLoggedAuthorizationProvider_Errors(t *testing.T) {
+	l := testlogger.New()
+	p := NewLoggedAuthorizationProvider(errAuthzProvider{}, l)
+	if _, err := p.Authorize(context.Background(), &proto.AuthorizeRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := p.EvaluatePolicy(context.Background(), &proto.AuthorizeRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := p.CreatePolicy(context.Background(), &proto.SecurityPolicy{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(l.Entries()) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(l.Entries()))
+	}
+}

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,0 +1,114 @@
+// file: pkg/config/logging.go
+// version: 1.0.0
+// guid: 016b30e1-ec33-4273-84f8-fec3bffb6714
+
+package config
+
+import (
+	"context"
+
+	configpb "github.com/jdfalk/gcommon/pkg/config/proto"
+	"github.com/jdfalk/gcommon/pkg/log"
+)
+
+// LoggedProvider wraps a Provider adding structured logging for all operations.
+type LoggedProvider struct {
+	provider Provider
+	logger   log.Logger
+}
+
+// NewLoggedProvider creates a new LoggedProvider.
+func NewLoggedProvider(p Provider, l log.Logger) *LoggedProvider {
+	return &LoggedProvider{provider: p, logger: l}
+}
+
+// Get retrieves a configuration value and logs the operation.
+func (l *LoggedProvider) Get(key string) (interface{}, error) {
+	l.logger.Info("config get", log.Field{Key: "key", Value: key})
+	v, err := l.provider.Get(key)
+	if err != nil {
+		l.logger.Error("config get failed", log.Field{Key: "key", Value: key}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.Info("config get success", log.Field{Key: "key", Value: key})
+	return v, nil
+}
+
+// Set stores a configuration value and logs the result.
+func (l *LoggedProvider) Set(key string, value interface{}) error {
+	l.logger.Info("config set", log.Field{Key: "key", Value: key})
+	if err := l.provider.Set(key, value); err != nil {
+		l.logger.Error("config set failed", log.Field{Key: "key", Value: key}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.Info("config set success", log.Field{Key: "key", Value: key})
+	return nil
+}
+
+// Watch registers a callback and logs registration errors.
+func (l *LoggedProvider) Watch(key string, callback func(interface{})) error {
+	l.logger.Info("config watch", log.Field{Key: "key", Value: key})
+	if err := l.provider.Watch(key, callback); err != nil {
+		l.logger.Error("config watch failed", log.Field{Key: "key", Value: key}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.Info("config watch registered", log.Field{Key: "key", Value: key})
+	return nil
+}
+
+// Close closes the provider and logs any error.
+func (l *LoggedProvider) Close() error {
+	l.logger.Info("config provider close")
+	if err := l.provider.Close(); err != nil {
+		l.logger.Error("config provider close failed", log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.Info("config provider closed")
+	return nil
+}
+
+// LoggedConfigService adds logging to ConfigService operations.
+type LoggedConfigService struct {
+	svc    ConfigService
+	logger log.Logger
+}
+
+// NewLoggedConfigService wraps a ConfigService with logging.
+func NewLoggedConfigService(svc ConfigService, l log.Logger) *LoggedConfigService {
+	return &LoggedConfigService{svc: svc, logger: l}
+}
+
+// Get retrieves configuration via gRPC and logs the request.
+func (l *LoggedConfigService) Get(ctx context.Context, req *configpb.GetConfigRequest) (*configpb.GetConfigResponse, error) {
+	l.logger.InfoContext(ctx, "config service get", log.Field{Key: "key", Value: req.GetKey()})
+	resp, err := l.svc.Get(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "config service get failed", log.Field{Key: "key", Value: req.GetKey()}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "config service get success", log.Field{Key: "key", Value: req.GetKey()})
+	return resp, nil
+}
+
+// Set updates configuration and logs the operation.
+func (l *LoggedConfigService) Set(ctx context.Context, req *configpb.SetConfigRequest) (*configpb.SetConfigResponse, error) {
+	l.logger.InfoContext(ctx, "config service set", log.Field{Key: "key", Value: req.GetKey()})
+	resp, err := l.svc.Set(ctx, req)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "config service set failed", log.Field{Key: "key", Value: req.GetKey()}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "config service set success", log.Field{Key: "key", Value: req.GetKey()})
+	return resp, nil
+}
+
+// Watch streams configuration updates and logs start and errors.
+func (l *LoggedConfigService) Watch(req *configpb.WatchConfigRequest, stream configpb.ConfigService_WatchServer) error {
+	l.logger.Info("config service watch", log.Field{Key: "key", Value: req.GetKeyPattern()})
+	if err := l.svc.Watch(req, stream); err != nil {
+		l.logger.Error("config service watch failed", log.Field{Key: "key", Value: req.GetKeyPattern()}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.Info("config service watch completed", log.Field{Key: "key", Value: req.GetKeyPattern()})
+	return nil
+}

--- a/pkg/config/logging_test.go
+++ b/pkg/config/logging_test.go
@@ -1,0 +1,140 @@
+// file: pkg/config/logging_test.go
+// version: 1.0.0
+// guid: f5706d15-ade4-4b62-a335-d331cdd894a4
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	configpb "github.com/jdfalk/gcommon/pkg/config/proto"
+	"github.com/jdfalk/gcommon/pkg/log/testlogger"
+)
+
+// stubProvider is a simple in-memory provider for testing.
+type stubProvider struct {
+	store map[string]interface{}
+}
+
+func (s *stubProvider) Get(key string) (interface{}, error)          { return s.store[key], nil }
+func (s *stubProvider) Set(key string, value interface{}) error      { s.store[key] = value; return nil }
+func (s *stubProvider) Watch(key string, cb func(interface{})) error { return nil }
+func (s *stubProvider) Close() error                                 { return nil }
+
+// stubService implements ConfigService using a Provider.
+type stubService struct{ p Provider }
+
+func (s *stubService) Get(ctx context.Context, req *configpb.GetConfigRequest) (*configpb.GetConfigResponse, error) {
+	return &configpb.GetConfigResponse{}, nil
+}
+func (s *stubService) Set(ctx context.Context, req *configpb.SetConfigRequest) (*configpb.SetConfigResponse, error) {
+	return &configpb.SetConfigResponse{}, nil
+}
+func (s *stubService) Watch(req *configpb.WatchConfigRequest, stream configpb.ConfigService_WatchServer) error {
+	return nil
+}
+
+func TestLoggedProvider_GetSet(t *testing.T) {
+	p := &stubProvider{store: map[string]interface{}{"a": "1"}}
+	tl := testlogger.New()
+	lp := NewLoggedProvider(p, tl)
+
+	if _, err := lp.Get("a"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := lp.Set("b", "2"); err != nil {
+		t.Fatalf("unexpected set error: %v", err)
+	}
+
+	entries := tl.Entries()
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	if entries[0].Message != "config get" || entries[2].Message != "config set" {
+		t.Fatalf("unexpected messages: %+v", entries)
+	}
+}
+
+func TestLoggedConfigService_GetSet(t *testing.T) {
+	p := &stubProvider{store: map[string]interface{}{"a": "1"}}
+	svc := &stubService{p: p}
+	tl := testlogger.New()
+	ls := NewLoggedConfigService(svc, tl)
+
+	if _, err := ls.Get(context.Background(), &configpb.GetConfigRequest{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := ls.Set(context.Background(), &configpb.SetConfigRequest{}); err != nil {
+		t.Fatalf("unexpected set error: %v", err)
+	}
+
+	entries := tl.Entries()
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	if entries[0].Message != "config service get" || entries[2].Message != "config service set" {
+		t.Fatalf("unexpected messages: %+v", entries)
+	}
+}
+
+// errProvider returns errors for all methods.
+type errProvider struct{}
+
+func (errProvider) Get(key string) (interface{}, error)          { return nil, fmt.Errorf("fail") }
+func (errProvider) Set(key string, value interface{}) error      { return fmt.Errorf("fail") }
+func (errProvider) Watch(key string, cb func(interface{})) error { return fmt.Errorf("fail") }
+func (errProvider) Close() error                                 { return fmt.Errorf("fail") }
+
+// errService wraps a Provider but returns errors.
+type errService struct{ p Provider }
+
+func (e errService) Get(ctx context.Context, req *configpb.GetConfigRequest) (*configpb.GetConfigResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (e errService) Set(ctx context.Context, req *configpb.SetConfigRequest) (*configpb.SetConfigResponse, error) {
+	return nil, fmt.Errorf("fail")
+}
+func (e errService) Watch(req *configpb.WatchConfigRequest, stream configpb.ConfigService_WatchServer) error {
+	return fmt.Errorf("fail")
+}
+
+func TestLoggedProvider_Error(t *testing.T) {
+	tl := testlogger.New()
+	lp := NewLoggedProvider(errProvider{}, tl)
+	if _, err := lp.Get("x"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := lp.Set("x", "1"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := lp.Watch("x", func(interface{}) {}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := lp.Close(); err == nil {
+		t.Fatalf("expected error")
+	}
+	entries := tl.Entries()
+	if len(entries) != 8 {
+		t.Fatalf("expected 8 entries, got %d", len(entries))
+	}
+}
+
+func TestLoggedConfigService_Error(t *testing.T) {
+	tl := testlogger.New()
+	ls := NewLoggedConfigService(errService{}, tl)
+	if _, err := ls.Get(context.Background(), &configpb.GetConfigRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := ls.Set(context.Background(), &configpb.SetConfigRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := ls.Watch(&configpb.WatchConfigRequest{}, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+	entries := tl.Entries()
+	if len(entries) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(entries))
+	}
+}

--- a/pkg/log/testlogger/testlogger.go
+++ b/pkg/log/testlogger/testlogger.go
@@ -1,0 +1,109 @@
+// file: pkg/log/testlogger/testlogger.go
+// version: 1.0.0
+// guid: 12c89763-a62a-4ce2-9cf4-f89ba0cbf7e7
+
+package testlogger
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+)
+
+// Entry represents a recorded log entry for verification in tests.
+type Entry struct {
+	Level   log.Level
+	Message string
+	Fields  []log.Field
+}
+
+// Logger implements log.Logger and records all log entries.
+type Logger struct {
+	mu      sync.Mutex
+	entries *[]Entry
+	base    []log.Field
+	level   log.Level
+}
+
+// New creates a new test logger with DebugLevel by default.
+func New() *Logger {
+	e := []Entry{}
+	return &Logger{level: log.DebugLevel, entries: &e}
+}
+
+// Entries returns a copy of all recorded log entries.
+func (l *Logger) Entries() []Entry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]Entry, len(*l.entries))
+	copy(out, *l.entries)
+	return out
+}
+
+// record adds a log entry if the level is enabled.
+func (l *Logger) record(level log.Level, msg string, fields []log.Field) {
+	if level < l.level {
+		return
+	}
+	l.mu.Lock()
+	combined := append(append([]log.Field(nil), l.base...), fields...)
+	*l.entries = append(*l.entries, Entry{Level: level, Message: msg, Fields: combined})
+	l.mu.Unlock()
+}
+
+// Debug logs a debug message.
+func (l *Logger) Debug(msg string, fields ...log.Field) { l.record(log.DebugLevel, msg, fields) }
+
+// DebugContext logs a debug message with context.
+func (l *Logger) DebugContext(ctx context.Context, msg string, fields ...log.Field) {
+	l.Debug(msg, fields...)
+}
+
+// Info logs an info message.
+func (l *Logger) Info(msg string, fields ...log.Field) { l.record(log.InfoLevel, msg, fields) }
+
+// InfoContext logs an info message with context.
+func (l *Logger) InfoContext(ctx context.Context, msg string, fields ...log.Field) {
+	l.Info(msg, fields...)
+}
+
+// Warn logs a warning message.
+func (l *Logger) Warn(msg string, fields ...log.Field) { l.record(log.WarnLevel, msg, fields) }
+
+// WarnContext logs a warning message with context.
+func (l *Logger) WarnContext(ctx context.Context, msg string, fields ...log.Field) {
+	l.Warn(msg, fields...)
+}
+
+// Error logs an error message.
+func (l *Logger) Error(msg string, fields ...log.Field) { l.record(log.ErrorLevel, msg, fields) }
+
+// ErrorContext logs an error message with context.
+func (l *Logger) ErrorContext(ctx context.Context, msg string, fields ...log.Field) {
+	l.Error(msg, fields...)
+}
+
+// Fatal logs a fatal message. The test logger does not exit.
+func (l *Logger) Fatal(msg string, fields ...log.Field) { l.record(log.FatalLevel, msg, fields) }
+
+// FatalContext logs a fatal message with context.
+func (l *Logger) FatalContext(ctx context.Context, msg string, fields ...log.Field) {
+	l.Fatal(msg, fields...)
+}
+
+// With returns a new logger carrying additional base fields.
+func (l *Logger) With(fields ...log.Field) log.Logger {
+	nl := *l
+	nl.base = append(append([]log.Field(nil), l.base...), fields...)
+	return &nl
+}
+
+// WithContext returns the same logger for context compatibility.
+func (l *Logger) WithContext(ctx context.Context) log.Logger { return l }
+
+// SetLevel sets the active log level.
+func (l *Logger) SetLevel(level log.Level) { l.level = level }
+
+// GetLevel returns the current log level.
+func (l *Logger) GetLevel() log.Level { return l.level }

--- a/pkg/log/tracing/tracing.go
+++ b/pkg/log/tracing/tracing.go
@@ -1,0 +1,52 @@
+// file: pkg/log/tracing/tracing.go
+// version: 1.0.0
+// guid: 378b3c31-793c-4f26-b5d7-40f41fe8f209
+
+package tracing
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jdfalk/gcommon/pkg/log"
+	"github.com/jdfalk/gcommon/pkg/log/middleware"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "github.com/jdfalk/gcommon/pkg/log/tracing"
+
+// StartSpan starts a new trace span, attaches a correlation ID, and returns a logger
+// enriched with trace information.
+func StartSpan(ctx context.Context, logger log.Logger, name string) (context.Context, trace.Span, log.Logger) {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, name)
+	cid := uuid.New().String()
+	ctx = context.WithValue(ctx, middleware.CorrelationIDKey, cid)
+	span.SetAttributes(attribute.String("correlation_id", cid))
+	l := logger.With(
+		log.Field{Key: "trace_id", Value: span.SpanContext().TraceID().String()},
+		log.Field{Key: "span_id", Value: span.SpanContext().SpanID().String()},
+		log.Field{Key: "correlation_id", Value: cid},
+	)
+	return ctx, span, l
+}
+
+// EndSpan ends the span and records an error if present.
+func EndSpan(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+	}
+	span.End()
+}
+
+// LoggerFromContext returns a logger enriched with the correlation ID from context if present.
+func LoggerFromContext(ctx context.Context, logger log.Logger) log.Logger {
+	if v := ctx.Value(middleware.CorrelationIDKey); v != nil {
+		if id, ok := v.(string); ok {
+			return logger.With(log.Field{Key: "correlation_id", Value: id})
+		}
+	}
+	return logger
+}

--- a/pkg/log/tracing/tracing_test.go
+++ b/pkg/log/tracing/tracing_test.go
@@ -1,0 +1,59 @@
+// file: pkg/log/tracing/tracing_test.go
+// version: 1.0.0
+// guid: 2d8b204a-bde3-4f6d-9e91-673a0dada252
+
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/log/middleware"
+	"github.com/jdfalk/gcommon/pkg/log/testlogger"
+)
+
+func TestStartSpan(t *testing.T) {
+	tl := testlogger.New()
+	ctx, span, l := StartSpan(context.Background(), tl, "op")
+	if span == nil {
+		t.Fatal("span is nil")
+	}
+	if ctx.Value(middleware.CorrelationIDKey) == nil {
+		t.Fatal("correlation id missing")
+	}
+	l.Info("hello")
+	EndSpan(span, nil)
+	entries := tl.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	foundTrace := false
+	for _, f := range entries[0].Fields {
+		if f.Key == "trace_id" {
+			foundTrace = true
+		}
+	}
+	if !foundTrace {
+		t.Fatalf("trace_id field missing: %+v", entries[0])
+	}
+}
+
+func TestLoggerFromContext(t *testing.T) {
+	tl := testlogger.New()
+	ctx := context.WithValue(context.Background(), middleware.CorrelationIDKey, "cid")
+	l := LoggerFromContext(ctx, tl)
+	l.Info("msg")
+	entries := tl.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	found := false
+	for _, f := range entries[0].Fields {
+		if f.Key == "correlation_id" && f.Value == "cid" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("correlation_id not found in fields: %+v", entries[0])
+	}
+}

--- a/pkg/queue/logging.go
+++ b/pkg/queue/logging.go
@@ -1,0 +1,123 @@
+// file: pkg/queue/logging.go
+// version: 1.0.0
+// guid: 065436e2-471f-463d-8920-ead7fe587544
+
+package queue
+
+import (
+	"context"
+
+	"github.com/jdfalk/gcommon/pkg/log"
+	"github.com/jdfalk/gcommon/pkg/queue/jobs"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+// LoggedQueue wraps a Queue and logs operations.
+type LoggedQueue struct {
+	q      Queue
+	logger log.Logger
+}
+
+// NewLoggedQueue creates a LoggedQueue.
+func NewLoggedQueue(q Queue, l log.Logger) *LoggedQueue { return &LoggedQueue{q: q, logger: l} }
+
+// Publish logs message publishing.
+func (l *LoggedQueue) Publish(ctx context.Context, message *queuepb.QueueMessage) error {
+	l.logger.InfoContext(ctx, "queue publish", log.Field{Key: "id", Value: message.GetId()})
+	if err := l.q.Publish(ctx, message); err != nil {
+		l.logger.ErrorContext(ctx, "queue publish failed", log.Field{Key: "id", Value: message.GetId()}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "queue publish success", log.Field{Key: "id", Value: message.GetId()})
+	return nil
+}
+
+// Subscribe logs subscription registration.
+func (l *LoggedQueue) Subscribe(ctx context.Context, handler MessageHandler) error {
+	l.logger.InfoContext(ctx, "queue subscribe")
+	if err := l.q.Subscribe(ctx, handler); err != nil {
+		l.logger.ErrorContext(ctx, "queue subscribe failed", log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "queue subscribe success")
+	return nil
+}
+
+// CreateQueue logs queue creation.
+func (l *LoggedQueue) CreateQueue(ctx context.Context, cfg *queuepb.QueueConfig) error {
+	l.logger.InfoContext(ctx, "queue create", log.Field{Key: "name", Value: cfg.GetName()})
+	if err := l.q.CreateQueue(ctx, cfg); err != nil {
+		l.logger.ErrorContext(ctx, "queue create failed", log.Field{Key: "name", Value: cfg.GetName()}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "queue create success", log.Field{Key: "name", Value: cfg.GetName()})
+	return nil
+}
+
+// DeleteQueue logs queue deletion.
+func (l *LoggedQueue) DeleteQueue(ctx context.Context, name string) error {
+	l.logger.InfoContext(ctx, "queue delete", log.Field{Key: "name", Value: name})
+	if err := l.q.DeleteQueue(ctx, name); err != nil {
+		l.logger.ErrorContext(ctx, "queue delete failed", log.Field{Key: "name", Value: name}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "queue delete success", log.Field{Key: "name", Value: name})
+	return nil
+}
+
+// GetQueueInfo logs queue info retrieval.
+func (l *LoggedQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
+	l.logger.InfoContext(ctx, "queue info", log.Field{Key: "name", Value: name})
+	info, err := l.q.GetQueueInfo(ctx, name)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "queue info failed", log.Field{Key: "name", Value: name}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "queue info success", log.Field{Key: "name", Value: name})
+	return info, nil
+}
+
+// LoggedScheduler wraps a Scheduler and logs job scheduling.
+type LoggedScheduler struct {
+	s      Scheduler
+	logger log.Logger
+}
+
+// NewLoggedScheduler creates a LoggedScheduler.
+func NewLoggedScheduler(s Scheduler, l log.Logger) *LoggedScheduler {
+	return &LoggedScheduler{s: s, logger: l}
+}
+
+// ScheduleJob logs job scheduling events.
+func (l *LoggedScheduler) ScheduleJob(ctx context.Context, job *jobs.Job) error {
+	l.logger.InfoContext(ctx, "schedule job", log.Field{Key: "id", Value: job.ID})
+	if err := l.s.ScheduleJob(ctx, job); err != nil {
+		l.logger.ErrorContext(ctx, "schedule job failed", log.Field{Key: "id", Value: job.ID}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "schedule job success", log.Field{Key: "id", Value: job.ID})
+	return nil
+}
+
+// CancelJob logs job cancellation.
+func (l *LoggedScheduler) CancelJob(ctx context.Context, jobID string) error {
+	l.logger.InfoContext(ctx, "cancel job", log.Field{Key: "id", Value: jobID})
+	if err := l.s.CancelJob(ctx, jobID); err != nil {
+		l.logger.ErrorContext(ctx, "cancel job failed", log.Field{Key: "id", Value: jobID}, log.Field{Key: "error", Value: err.Error()})
+		return err
+	}
+	l.logger.InfoContext(ctx, "cancel job success", log.Field{Key: "id", Value: jobID})
+	return nil
+}
+
+// GetJobStatus logs job status retrieval.
+func (l *LoggedScheduler) GetJobStatus(ctx context.Context, jobID string) (*jobs.JobStatus, error) {
+	l.logger.InfoContext(ctx, "job status", log.Field{Key: "id", Value: jobID})
+	st, err := l.s.GetJobStatus(ctx, jobID)
+	if err != nil {
+		l.logger.ErrorContext(ctx, "job status failed", log.Field{Key: "id", Value: jobID}, log.Field{Key: "error", Value: err.Error()})
+		return nil, err
+	}
+	l.logger.InfoContext(ctx, "job status success", log.Field{Key: "id", Value: jobID})
+	return st, nil
+}

--- a/pkg/queue/logging_test.go
+++ b/pkg/queue/logging_test.go
@@ -1,0 +1,147 @@
+// file: pkg/queue/logging_test.go
+// version: 1.0.0
+// guid: 669fbf93-9433-450a-ad9b-5cf611cf0b8b
+
+package queue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/log/testlogger"
+	"github.com/jdfalk/gcommon/pkg/queue/jobs"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+)
+
+// stubQueue implements Queue with no-op methods for testing.
+type stubQueue struct{}
+
+func (s *stubQueue) Publish(ctx context.Context, m *queuepb.QueueMessage) error      { return nil }
+func (s *stubQueue) Subscribe(ctx context.Context, h MessageHandler) error           { return nil }
+func (s *stubQueue) CreateQueue(ctx context.Context, cfg *queuepb.QueueConfig) error { return nil }
+func (s *stubQueue) DeleteQueue(ctx context.Context, name string) error              { return nil }
+func (s *stubQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
+	return &queuepb.QueueInfo{}, nil
+}
+
+// stubScheduler implements Scheduler with no-op methods.
+type stubScheduler struct{}
+
+func (s *stubScheduler) ScheduleJob(ctx context.Context, job *jobs.Job) error { return nil }
+func (s *stubScheduler) CancelJob(ctx context.Context, jobID string) error    { return nil }
+func (s *stubScheduler) GetJobStatus(ctx context.Context, jobID string) (*jobs.JobStatus, error) {
+	return &jobs.JobStatus{ID: jobID}, nil
+}
+
+func TestLoggedQueue_Publish(t *testing.T) {
+	l := testlogger.New()
+	q := NewLoggedQueue(&stubQueue{}, l)
+	msg := &queuepb.QueueMessage{}
+	msg.SetId("1")
+	if err := q.Publish(context.Background(), msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(l.Entries()))
+	}
+	if l.Entries()[0].Message != "queue publish" {
+		t.Fatalf("unexpected message: %+v", l.Entries()[0])
+	}
+}
+
+func TestLoggedScheduler_ScheduleJob(t *testing.T) {
+	l := testlogger.New()
+	s := NewLoggedScheduler(&stubScheduler{}, l)
+	job := &jobs.Job{ID: "job1"}
+	if err := s.ScheduleJob(context.Background(), job); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(l.Entries()))
+	}
+	if l.Entries()[0].Message != "schedule job" {
+		t.Fatalf("unexpected message: %+v", l.Entries()[0])
+	}
+}
+
+// errQueue returns errors for all methods.
+type errQueue struct{}
+
+func (errQueue) Publish(ctx context.Context, m *queuepb.QueueMessage) error {
+	return fmt.Errorf("fail")
+}
+func (errQueue) Subscribe(ctx context.Context, h MessageHandler) error { return fmt.Errorf("fail") }
+func (errQueue) CreateQueue(ctx context.Context, cfg *queuepb.QueueConfig) error {
+	return fmt.Errorf("fail")
+}
+func (errQueue) DeleteQueue(ctx context.Context, name string) error { return fmt.Errorf("fail") }
+func (errQueue) GetQueueInfo(ctx context.Context, name string) (*queuepb.QueueInfo, error) {
+	return nil, fmt.Errorf("fail")
+}
+
+// errScheduler returns errors for all operations.
+type errScheduler struct{}
+
+func (errScheduler) ScheduleJob(ctx context.Context, job *jobs.Job) error { return fmt.Errorf("fail") }
+func (errScheduler) CancelJob(ctx context.Context, jobID string) error    { return fmt.Errorf("fail") }
+func (errScheduler) GetJobStatus(ctx context.Context, jobID string) (*jobs.JobStatus, error) {
+	return nil, fmt.Errorf("fail")
+}
+
+func TestLoggedQueue_Errors(t *testing.T) {
+	l := testlogger.New()
+	q := NewLoggedQueue(errQueue{}, l)
+	if err := q.Publish(context.Background(), func() *queuepb.QueueMessage { m := &queuepb.QueueMessage{}; m.SetId("1"); return m }()); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := q.Subscribe(context.Background(), func(context.Context, *queuepb.QueueMessage) error { return nil }); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := q.CreateQueue(context.Background(), func() *queuepb.QueueConfig { c := &queuepb.QueueConfig{}; c.SetName("n"); return c }()); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := q.DeleteQueue(context.Background(), "n"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := q.GetQueueInfo(context.Background(), "n"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(l.Entries()) != 10 {
+		t.Fatalf("expected 10 entries, got %d", len(l.Entries()))
+	}
+}
+
+func TestLoggedScheduler_Errors(t *testing.T) {
+	l := testlogger.New()
+	s := NewLoggedScheduler(errScheduler{}, l)
+	if err := s.ScheduleJob(context.Background(), &jobs.Job{ID: "1"}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := s.CancelJob(context.Background(), "1"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := s.GetJobStatus(context.Background(), "1"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(l.Entries()) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(l.Entries()))
+	}
+}
+
+func TestLoggedQueue_CreateDeleteInfo(t *testing.T) {
+	l := testlogger.New()
+	q := NewLoggedQueue(&stubQueue{}, l)
+	if err := q.CreateQueue(context.Background(), func() *queuepb.QueueConfig { c := &queuepb.QueueConfig{}; c.SetName("q"); return c }()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := q.DeleteQueue(context.Background(), "q"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := q.GetQueueInfo(context.Background(), "q"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries()) != 6 {
+		t.Fatalf("expected 6 log entries, got %d", len(l.Entries()))
+	}
+}


### PR DESCRIPTION
## Summary
- add shared test logger and tracing helpers for consistent log instrumentation
- wrap config, queue, and auth modules with structured logging implementations
- document logging standardization and track follow-up TODO

## Testing
- `go test ./pkg/log/...`
- `go test ./pkg/config ./pkg/queue ./pkg/auth`


------
https://chatgpt.com/codex/tasks/task_e_689943aaba3483218e049e22ccd4b599