### PR TITLE
fix: update collectors for new OTEL APIs and pin otlptranslator

### DIFF
--- a/.github/doc-updates/829773e3-eae6-4263-b1c3-056383c3e637.json
+++ b/.github/doc-updates/829773e3-eae6-4263-b1c3-056383c3e637.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Pin otlptranslator dependency and update collectors to new OTel APIs",
+  "guid": "829773e3-eae6-4263-b1c3-056383c3e637",
+  "created_at": "2025-08-11T02:14:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/examples/getting-started/common-patterns/main.go
+++ b/examples/getting-started/common-patterns/main.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: examples/getting-started/common-patterns/main.go
 // version: 1.1.0
 // guid: 30361479-35e5-4d3f-b9a8-b990d37a2ae3
@@ -5,85 +7,85 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "time"
+	"context"
+	"fmt"
+	"time"
 
-        "github.com/jdfalk/gcommon/pkg/config"
-        "github.com/jdfalk/gcommon/pkg/config/sources"
-        "github.com/jdfalk/gcommon/pkg/metrics"
-        prom "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
-        "github.com/jdfalk/gcommon/pkg/queue/providers"
+	"github.com/jdfalk/gcommon/pkg/config"
+	"github.com/jdfalk/gcommon/pkg/config/sources"
+	"github.com/jdfalk/gcommon/pkg/metrics"
+	prom "github.com/jdfalk/gcommon/pkg/metrics/prometheus"
+	"github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
 // app encapsulates commonly used components that appear across many examples:
 // configuration loading, metrics collection, and queue publishing.
 type app struct {
-        loader   *config.Loader
-        metrics  metrics.Provider
-        messages chan string
+	loader   *config.Loader
+	metrics  metrics.Provider
+	messages chan string
 }
 
 // setup wires together configuration, metrics, and a memory queue provider.
 func setup(ctx context.Context) (*app, error) {
-        // Load configuration from environment with APP_ prefix
-        env := sources.EnvSource{Prefix: "APP_"}
-        loader := config.NewLoader(nil, config.ConfigSource(env))
+	// Load configuration from environment with APP_ prefix
+	env := sources.EnvSource{Prefix: "APP_"}
+	loader := config.NewLoader(nil, config.ConfigSource(env))
 
-        // Metrics provider for instrumentation
-        provider, err := prom.NewProvider(metrics.Config{})
-        if err != nil {
-                return nil, err
-        }
-        if err := provider.Start(ctx); err != nil {
-                return nil, err
-        }
+	// Metrics provider for instrumentation
+	provider, err := prom.NewProvider(metrics.Config{})
+	if err != nil {
+		return nil, err
+	}
+	if err := provider.Start(ctx); err != nil {
+		return nil, err
+	}
 
-        // Simple memory queue used for demonstration
-        q := providers.NewMemoryQueue(5)
-        ch := make(chan string, 1)
-        go func() {
-                for {
-                        msg, err := q.Consume(ctx)
-                        if err != nil {
-                                return
-                        }
-                        ch <- msg.Body
-                }
-        }()
+	// Simple memory queue used for demonstration
+	q := providers.NewMemoryQueue(5)
+	ch := make(chan string, 1)
+	go func() {
+		for {
+			msg, err := q.Consume(ctx)
+			if err != nil {
+				return
+			}
+			ch <- msg.Body
+		}
+	}()
 
-        return &app{loader: loader, metrics: provider, messages: ch}, nil
+	return &app{loader: loader, metrics: provider, messages: ch}, nil
 }
 
 // run publishes a message to the queue and prints the loaded configuration.
 func run(ctx context.Context, a *app) error {
-        cfg, err := a.loader.Load()
-        if err != nil {
-                return err
-        }
-        fmt.Printf("config: %v\n", cfg)
+	cfg, err := a.loader.Load()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("config: %v\n", cfg)
 
-        counter := a.metrics.Counter("processed_messages_total")
-        queue := providers.NewMemoryQueue(5)
-        _ = queue.Publish(ctx, &providers.Message{Body: "hello"})
-        select {
-        case msg := <-a.messages:
-                fmt.Println("received:", msg)
-                counter.Inc()
-        case <-time.After(time.Second):
-                fmt.Println("no message received")
-        }
-        return nil
+	counter := a.metrics.Counter("processed_messages_total")
+	queue := providers.NewMemoryQueue(5)
+	_ = queue.Publish(ctx, &providers.Message{Body: "hello"})
+	select {
+	case msg := <-a.messages:
+		fmt.Println("received:", msg)
+		counter.Inc()
+	case <-time.After(time.Second):
+		fmt.Println("no message received")
+	}
+	return nil
 }
 
 func main() {
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
-        a, err := setup(ctx)
-        if err != nil {
-                panic(err)
-        }
-        if err := run(ctx, a); err != nil {
-                panic(err)
-        }
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	a, err := setup(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := run(ctx, a); err != nil {
+		panic(err)
+	}
 }

--- a/examples/modules/config/dynamic-config/main.go
+++ b/examples/modules/config/dynamic-config/main.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: examples/modules/config/dynamic-config/main.go
 // version: 1.1.0
 // guid: afadb93b-48ce-446c-82e2-e951a01f7ef2
@@ -5,44 +7,44 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "time"
+	"context"
+	"fmt"
+	"time"
 
-        "github.com/jdfalk/gcommon/pkg/config"
-        "github.com/jdfalk/gcommon/pkg/config/sources"
+	"github.com/jdfalk/gcommon/pkg/config"
+	"github.com/jdfalk/gcommon/pkg/config/sources"
 )
 
 // setup creates a watcher that reloads configuration when the underlying file
 // changes. For simplicity this example uses a temporary file.
 func setup(ctx context.Context) (*config.Watcher, error) {
-        file := sources.FileSource{Path: "config.yaml"}
-        loader := config.NewLoader(nil, config.ConfigSource(file))
-        watcher := config.NewWatcher(loader, time.Second)
-        return watcher, nil
+	file := sources.FileSource{Path: "config.yaml"}
+	loader := config.NewLoader(nil, config.ConfigSource(file))
+	watcher := config.NewWatcher(loader, time.Second)
+	return watcher, nil
 }
 
 // run starts the watcher and prints configuration updates until the context is
 // canceled.
 func run(ctx context.Context, watcher *config.Watcher) error {
-        updates := watcher.Start(ctx)
-        go func() {
-                for cfg := range updates {
-                        fmt.Printf("updated config: %v\n", cfg)
-                }
-        }()
-        <-ctx.Done()
-        return watcher.Stop(context.Background())
+	updates := watcher.Start(ctx)
+	go func() {
+		for cfg := range updates {
+			fmt.Printf("updated config: %v\n", cfg)
+		}
+	}()
+	<-ctx.Done()
+	return watcher.Stop(context.Background())
 }
 
 func main() {
-        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-        defer cancel()
-        watcher, err := setup(ctx)
-        if err != nil {
-                panic(err)
-        }
-        if err := run(ctx, watcher); err != nil {
-                panic(err)
-        }
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	watcher, err := setup(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := run(ctx, watcher); err != nil {
+		panic(err)
+	}
 }

--- a/examples/modules/queue/basic-queue/main.go
+++ b/examples/modules/queue/basic-queue/main.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: examples/modules/queue/basic-queue/main.go
 // version: 1.1.0
 // guid: f7b5c457-5a6f-418a-936d-ce03d61051eb
@@ -5,46 +7,46 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "time"
+	"context"
+	"fmt"
+	"time"
 
-        "github.com/jdfalk/gcommon/pkg/queue/providers"
+	"github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
 // queueApp holds the in-memory queue used in this basic example.
 type queueApp struct {
-        q providers.Queue
+	q providers.Queue
 }
 
 // setup initializes a memory-backed queue with capacity for ten messages.
 func setup(ctx context.Context) (*queueApp, error) {
-        q := providers.NewMemoryQueue(10)
-        return &queueApp{q: q}, nil
+	q := providers.NewMemoryQueue(10)
+	return &queueApp{q: q}, nil
 }
 
 // run publishes and consumes a single message.
 func run(ctx context.Context, app *queueApp) error {
-        msg := &providers.Message{Body: "hello queue"}
-        if err := app.q.Publish(ctx, msg); err != nil {
-                return err
-        }
-        received, err := app.q.Consume(ctx)
-        if err != nil {
-                return err
-        }
-        fmt.Printf("received message: %s\n", received.Body)
-        return nil
+	msg := &providers.Message{Body: "hello queue"}
+	if err := app.q.Publish(ctx, msg); err != nil {
+		return err
+	}
+	received, err := app.q.Consume(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("received message: %s\n", received.Body)
+	return nil
 }
 
 func main() {
-        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-        defer cancel()
-        app, err := setup(ctx)
-        if err != nil {
-                panic(err)
-        }
-        if err := run(ctx, app); err != nil {
-                panic(err)
-        }
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	app, err := setup(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := run(ctx, app); err != nil {
+		panic(err)
+	}
 }

--- a/examples/modules/queue/job-scheduler/main.go
+++ b/examples/modules/queue/job-scheduler/main.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: examples/modules/queue/job-scheduler/main.go
 // version: 1.1.0
 // guid: 1d47db8d-acf5-4664-abb8-7f3003d389fb
@@ -5,56 +7,56 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "time"
+	"context"
+	"fmt"
+	"time"
 
-        "github.com/jdfalk/gcommon/pkg/queue/jobs"
-        queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
+	"github.com/jdfalk/gcommon/pkg/queue/jobs"
+	queuepb "github.com/jdfalk/gcommon/pkg/queue/proto"
 )
 
 // schedulerApp wraps the job scheduler used in this example.
 type schedulerApp struct {
-        s *jobs.Scheduler
+	s *jobs.Scheduler
 }
 
 // setup creates a new scheduler instance.
 func setup(ctx context.Context) (*schedulerApp, error) {
-        return &schedulerApp{s: jobs.NewScheduler()}, nil
+	return &schedulerApp{s: jobs.NewScheduler()}, nil
 }
 
 // run schedules a job to execute after one second and waits for completion.
 func run(ctx context.Context, app *schedulerApp) error {
-        job := &jobs.Job{
-                ID:      "demo", 
-                Message: &queuepb.Message{Body: "payload"},
-                RunAt:   time.Now().Add(time.Second),
-                Handler: func(ctx context.Context, j *jobs.Job) error {
-                        fmt.Println("executing job:", j.Message.Body)
-                        return nil
-                },
-        }
-        if err := app.s.ScheduleJob(ctx, job); err != nil {
-                return err
-        }
-        // Wait for job completion
-        time.Sleep(1500 * time.Millisecond)
-        status, err := app.s.GetJobStatus(ctx, "demo")
-        if err != nil {
-                return err
-        }
-        fmt.Printf("job completed: %v\n", status.Completed)
-        return nil
+	job := &jobs.Job{
+		ID:      "demo",
+		Message: &queuepb.Message{Body: "payload"},
+		RunAt:   time.Now().Add(time.Second),
+		Handler: func(ctx context.Context, j *jobs.Job) error {
+			fmt.Println("executing job:", j.Message.Body)
+			return nil
+		},
+	}
+	if err := app.s.ScheduleJob(ctx, job); err != nil {
+		return err
+	}
+	// Wait for job completion
+	time.Sleep(1500 * time.Millisecond)
+	status, err := app.s.GetJobStatus(ctx, "demo")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("job completed: %v\n", status.Completed)
+	return nil
 }
 
 func main() {
-        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-        defer cancel()
-        app, err := setup(ctx)
-        if err != nil {
-                panic(err)
-        }
-        if err := run(ctx, app); err != nil {
-                panic(err)
-        }
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	app, err := setup(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := run(ctx, app); err != nil {
+		panic(err)
+	}
 }

--- a/examples/modules/queue/worker-pool/main.go
+++ b/examples/modules/queue/worker-pool/main.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: examples/modules/queue/worker-pool/main.go
 // version: 1.1.0
 // guid: 917ed822-710c-48b4-b1b0-309696429460
@@ -5,62 +7,62 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "sync"
-        "time"
+	"context"
+	"fmt"
+	"sync"
+	"time"
 
-        "github.com/jdfalk/gcommon/pkg/queue/providers"
+	"github.com/jdfalk/gcommon/pkg/queue/providers"
 )
 
 // poolApp demonstrates a simple worker pool consuming messages concurrently.
 type poolApp struct {
-        q providers.Queue
+	q providers.Queue
 }
 
 // setup creates a memory queue and publishes a few messages to be processed.
 func setup(ctx context.Context) (*poolApp, error) {
-        q := providers.NewMemoryQueue(100)
-        for i := 0; i < 5; i++ {
-                _ = q.Publish(ctx, &providers.Message{Body: fmt.Sprintf("job-%d", i)})
-        }
-        return &poolApp{q: q}, nil
+	q := providers.NewMemoryQueue(100)
+	for i := 0; i < 5; i++ {
+		_ = q.Publish(ctx, &providers.Message{Body: fmt.Sprintf("job-%d", i)})
+	}
+	return &poolApp{q: q}, nil
 }
 
 // run starts a fixed number of workers that consume messages from the queue.
 func run(ctx context.Context, app *poolApp) error {
-        var wg sync.WaitGroup
-        workers := 3
-        for i := 0; i < workers; i++ {
-                wg.Add(1)
-                go func(id int) {
-                        defer wg.Done()
-                        for {
-                                msg, err := app.q.Consume(ctx)
-                                if err != nil {
-                                        return
-                                }
-                                fmt.Printf("worker %d processed %s\n", id, msg.Body)
-                        }
-                }(i)
-        }
+	var wg sync.WaitGroup
+	workers := 3
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				msg, err := app.q.Consume(ctx)
+				if err != nil {
+					return
+				}
+				fmt.Printf("worker %d processed %s\n", id, msg.Body)
+			}
+		}(i)
+	}
 
-        // Allow workers time to process then cancel
-        time.Sleep(500 * time.Millisecond)
-        cancelCtx, cancel := context.WithCancel(ctx)
-        cancel()
-        wg.Wait()
-        return app.q.Close(cancelCtx)
+	// Allow workers time to process then cancel
+	time.Sleep(500 * time.Millisecond)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	wg.Wait()
+	return app.q.Close(cancelCtx)
 }
 
 func main() {
-        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-        defer cancel()
-        app, err := setup(ctx)
-        if err != nil {
-                panic(err)
-        }
-        if err := run(ctx, app); err != nil {
-                panic(err)
-        }
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	app, err := setup(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := run(ctx, app); err != nil {
+		panic(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/otlptranslator v0.0.2 // indirect
+	github.com/prometheus/otlptranslator v0.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2VzE=
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
-github.com/prometheus/otlptranslator v0.0.2 h1:+1CdeLVrRQ6Psmhnobldo0kTp96Rj80DRXRd5OSnMEQ=
-github.com/prometheus/otlptranslator v0.0.2/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
+github.com/prometheus/otlptranslator v0.0.1 h1:C4HDe7bEfM6O/+9cz7l5Y12sWL9BN/QsMb9Le4/WHmA=
+github.com/prometheus/otlptranslator v0.0.1/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/monitoring/collectors/logs.go
+++ b/monitoring/collectors/logs.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"sync"
 	"time"
 )

--- a/monitoring/collectors/metrics.go
+++ b/monitoring/collectors/metrics.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 // MetricsCollector provides an abstraction around collecting application and
@@ -41,8 +42,9 @@ func NewMetricsCollector() (*MetricsCollector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create prometheus exporter: %w", err)
 	}
-	otel.SetMeterProvider(exp.MeterProvider())
-	m := otel.Meter("gcommon/monitoring")
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exp))
+	otel.SetMeterProvider(provider)
+	m := provider.Meter("gcommon/monitoring")
 	mc := &MetricsCollector{
 		registry:   reg,
 		meter:      m,

--- a/monitoring/collectors/traces.go
+++ b/monitoring/collectors/traces.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -36,6 +37,7 @@ func NewTracesCollector(serviceName, jaegerEndpoint string) (*TracesCollector, e
 		return nil, fmt.Errorf("create jaeger exporter: %w", err)
 	}
 	res, err := resource.Merge(resource.Default(), resource.NewWithAttributes(
+		"",
 		attribute.String("service.name", serviceName),
 	))
 	if err != nil {
@@ -61,7 +63,7 @@ func (t *TracesCollector) StartSpan(ctx context.Context, name string, attrs ...a
 func (t *TracesCollector) EndSpan(span trace.Span, err error) {
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(trace.Status{Code: trace.StatusCodeError, Description: err.Error()})
+		span.SetStatus(codes.Error, err.Error())
 	}
 	span.End()
 }

--- a/pkg/config/examples/dynamic.go
+++ b/pkg/config/examples/dynamic.go
@@ -1,7 +1,8 @@
+//go:build ignore
+
 // file: pkg/config/examples/dynamic.go
 // version: 1.0.0
 // guid: 44444444-5555-6666-7777-dddddddddddd
-//go:build ignore
 
 package main
 

--- a/pkg/config/examples/grpc_server.go
+++ b/pkg/config/examples/grpc_server.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: pkg/config/examples/grpc_server.go
 // version: 1.0.0
 // guid: dddddddd-dddd-dddd-dddd-dddddddddddd

--- a/pkg/config/examples/hierarchical.go
+++ b/pkg/config/examples/hierarchical.go
@@ -1,7 +1,8 @@
+//go:build ignore
+
 // file: pkg/config/examples/hierarchical.go
 // version: 1.0.0
 // guid: 33333333-4444-5555-6666-cccccccccccc
-//go:build ignore
 
 package main
 

--- a/pkg/config/examples/production.go
+++ b/pkg/config/examples/production.go
@@ -1,7 +1,8 @@
+//go:build ignore
+
 // file: pkg/config/examples/production.go
 // version: 1.0.0
 // guid: 55555555-6666-7777-8888-eeeeeeeeeeee
-//go:build ignore
 
 package main
 

--- a/pkg/config/examples/simple.go
+++ b/pkg/config/examples/simple.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // file: pkg/config/examples/simple.go
 // version: 1.0.0
 // guid: cccccccc-cccc-cccc-cccc-cccccccccccc

--- a/pkg/config/grpc/server.go
+++ b/pkg/config/grpc/server.go
@@ -5,7 +5,6 @@
 package grpc
 
 import (
-	"github.com/jdfalk/gcommon/pkg/config"
 	configpb "github.com/jdfalk/gcommon/pkg/config/proto"
 	"google.golang.org/grpc"
 )
@@ -22,7 +21,7 @@ import (
 // TODO: Allow injecting existing grpc.Server
 // TODO: End TODO list
 
-func NewServer(cfgSvc config.ConfigService, adminSvc config.ConfigAdminService) *grpc.Server {
+func NewServer(cfgSvc configpb.ConfigServiceServer, adminSvc configpb.ConfigAdminServiceServer) *grpc.Server {
 	s := grpc.NewServer()
 	if cfgSvc != nil {
 		configpb.RegisterConfigServiceServer(s, cfgSvc)

--- a/pkg/metrics/prometheus/utils.go
+++ b/pkg/metrics/prometheus/utils.go
@@ -465,34 +465,33 @@ func CreateHTTPServerMetrics(provider metrics.Provider, serviceName string, defa
 	return &HTTPServerMetrics{
 		RequestsTotal: provider.Counter(
 			prefix+"http_requests_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of HTTP requests"),
 		),
 
 		RequestDurationSeconds: provider.Histogram(
 			prefix+"http_request_duration_seconds",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("HTTP request duration in seconds"),
 			metrics.WithBuckets(LatencyBuckets()),
 		),
 
 		ResponseSizeBytes: provider.Histogram(
 			prefix+"http_response_size_bytes",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("HTTP response size in bytes"),
 			metrics.WithBuckets(SizeBuckets()),
 		),
 
 		RequestSizeBytes: provider.Histogram(
 			prefix+"http_request_size_bytes",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("HTTP request size in bytes"),
 			metrics.WithBuckets(SizeBuckets()),
 		),
 
 		InFlightRequests: provider.Gauge(
 			prefix+"http_in_flight_requests",
-			[]metrics.Tag{},
 			metrics.WithDescription("Current number of in-flight HTTP requests"),
 		),
 	}
@@ -547,32 +546,32 @@ func CreateDatabaseMetrics(provider metrics.Provider, serviceName string, defaul
 	return &DatabaseMetrics{
 		OperationsTotal: provider.Counter(
 			prefix+"db_operations_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of database operations"),
 		),
 
 		OperationErrors: provider.Counter(
 			prefix+"db_operation_errors_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of database operation errors"),
 		),
 
 		OperationDurationSeconds: provider.Histogram(
 			prefix+"db_operation_duration_seconds",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Database operation duration in seconds"),
 			metrics.WithBuckets(LatencyBuckets()),
 		),
 
 		ConnectionsOpen: provider.Gauge(
 			prefix+"db_connections_open",
-			[]metrics.Tag{{Key: "database", Value: ""}},
+			metrics.WithTags(metrics.Tag{Key: "database", Value: ""}),
 			metrics.WithDescription("Number of open database connections"),
 		),
 
 		ConnectionsMax: provider.Gauge(
 			prefix+"db_connections_max",
-			[]metrics.Tag{{Key: "database", Value: ""}},
+			metrics.WithTags(metrics.Tag{Key: "database", Value: ""}),
 			metrics.WithDescription("Maximum number of open database connections"),
 		),
 	}
@@ -626,38 +625,38 @@ func CreateCacheMetrics(provider metrics.Provider, serviceName string, defaultLa
 	return &CacheMetrics{
 		OperationsTotal: provider.Counter(
 			prefix+"cache_operations_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of cache operations"),
 		),
 
 		Hits: provider.Counter(
 			prefix+"cache_hits_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of cache hits"),
 		),
 
 		Misses: provider.Counter(
 			prefix+"cache_misses_total",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Total number of cache misses"),
 		),
 
 		OperationDurationSeconds: provider.Histogram(
 			prefix+"cache_operation_duration_seconds",
-			labelNames,
+			metrics.WithTags(labelNames...),
 			metrics.WithDescription("Cache operation duration in seconds"),
 			metrics.WithBuckets([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5}),
 		),
 
 		Size: provider.Gauge(
 			prefix+"cache_size",
-			[]metrics.Tag{{Key: "cache", Value: ""}},
+			metrics.WithTags(metrics.Tag{Key: "cache", Value: ""}),
 			metrics.WithDescription("Current number of items in cache"),
 		),
 
 		MemoryUsageBytes: provider.Gauge(
 			prefix+"cache_memory_usage_bytes",
-			[]metrics.Tag{{Key: "cache", Value: ""}},
+			metrics.WithTags(metrics.Tag{Key: "cache", Value: ""}),
 			metrics.WithDescription("Current memory usage of cache in bytes"),
 		),
 	}


### PR DESCRIPTION
## Summary
- align Prometheus metrics utilities with Option-based tag API
- update monitoring collectors for recent OpenTelemetry changes and skip outdated examples
- pin github.com/prometheus/otlptranslator to v0.0.1 to resolve exporter build errors

## Testing
- `go test ./monitoring/collectors`
- `go test ./pkg/metrics/prometheus`
- `go test ./pkg/config/grpc`
- `go test ./...` *(fails: undefined dbpb types in pkg/db/grpc)*

------
https://chatgpt.com/codex/tasks/task_e_6899439f26588321876c2ccaa2bc9a50