### PR TITLE
fix: allow issue updates without GH token

### DIFF
--- a/.github/doc-updates/ad00a159-982a-4c06-a4f8-c3d1bf03e1a6.json
+++ b/.github/doc-updates/ad00a159-982a-4c06-a4f8-c3d1bf03e1a6.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Fixed create-issue-update script requiring GH_TOKEN or git remote",
+  "guid": "ad00a159-982a-4c06-a4f8-c3d1bf03e1a6",
+  "created_at": "2025-08-11T02:11:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/4d473dd4-75cb-47e8-95ae-28deea3d650c.json
+++ b/.github/issue-updates/4d473dd4-75cb-47e8-95ae-28deea3d650c.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Fix create-issue-update GH_TOKEN requirement",
+  "body": "Ensure script works without GH_TOKEN or remote",
+  "labels": ["maintenance"],
+  "guid": "4d473dd4-75cb-47e8-95ae-28deea3d650c",
+  "legacy_guid": "create-fix-create-issue-update-gh-token-requirement-2025-08-11",
+  "created_at": "2025-08-11T02:11:20.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}


### PR DESCRIPTION
## Summary
- allow issue update library to skip GitHub API check when GH_TOKEN or remote is missing
- record issue and changelog entries for GH_TOKEN requirement fix

## Issues Addressed
### fix(scripts): allow issue updates without GH token
**Description:** updated issue update library to bypass GitHub API calls when credentials or remote are absent and added tracking metadata

**Files Modified:**
- [`scripts/create-issue-update-library.sh`](./scripts/create-issue-update-library.sh) - skip GitHub check when token or repo missing
- [`.github/issue-updates/4d473dd4-75cb-47e8-95ae-28deea3d650c.json`](./.github/issue-updates/4d473dd4-75cb-47e8-95ae-28deea3d650c.json) - record issue for script fix
- [`.github/doc-updates/ad00a159-982a-4c06-a4f8-c3d1bf03e1a6.json`](./.github/doc-updates/ad00a159-982a-4c06-a4f8-c3d1bf03e1a6.json) - add changelog entry for fix

## Testing
- `shellcheck scripts/create-issue-update-library.sh` *(fails: SC2155 warnings)*
- `./scripts/create-issue-update.sh create "Fix create-issue-update GH_TOKEN requirement" "Ensure script works without GH_TOKEN or remote" "maintenance"`

## Breaking Changes
- None

## Additional Notes
- None


------
https://chatgpt.com/codex/tasks/task_e_689943b0a9748321b36a8b9b363fb572