### PR TITLE
feat: implement organization service layer and gRPC managers

### DIFF
--- a/.github/doc-updates/789e8b36-e23f-47ee-ac86-c4f4cebce2d3.json
+++ b/.github/doc-updates/789e8b36-e23f-47ee-ac86-c4f4cebce2d3.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "append",
+  "content": "Organization module service layer implemented",
+  "guid": "789e8b36-e23f-47ee-ac86-c4f4cebce2d3",
+  "created_at": "2025-08-11T15:40:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/cc79951b-7434-4ebd-8f79-7a3fb0f50779.json
+++ b/.github/doc-updates/cc79951b-7434-4ebd-8f79-7a3fb0f50779.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Implemented organization module service layer with gRPC services",
+  "guid": "cc79951b-7434-4ebd-8f79-7a3fb0f50779",
+  "created_at": "2025-08-11T15:40:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e67b4b91-2428-4f8e-93d4-2a4ecaa39234.json
+++ b/.github/doc-updates/e67b4b91-2428-4f8e-93d4-2a4ecaa39234.json
@@ -1,0 +1,16 @@
+{
+  "file": "tasks/07-organization-module-implementation.md",
+  "mode": "append",
+  "content": "Implementation complete: see pkg/organization/manager.go, pkg/organization/grpc/org_service.go",
+  "guid": "e67b4b91-2428-4f8e-93d4-2a4ecaa39234",
+  "created_at": "2025-08-11T15:43:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/3d36913e-7ae9-4338-9698-b27dde7caf4e.json
+++ b/.github/issue-updates/3d36913e-7ae9-4338-9698-b27dde7caf4e.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Organization module service layer",
+  "body": "Implement organization and hierarchy managers, gRPC services, and multi-tenancy.",
+  "labels": ["module:organization"],
+  "guid": "3d36913e-7ae9-4338-9698-b27dde7caf4e",
+  "legacy_guid": "create-organization-module-service-layer-2025-08-11",
+  "created_at": "2025-08-11T15:31:01.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/organization/examples/multi_tenant.go
+++ b/pkg/organization/examples/multi_tenant.go
@@ -1,8 +1,32 @@
 // file: pkg/organization/examples/multi_tenant.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 51e90824-0beb-4d35-bd8d-cd3c8c8385f2
 
 package examples
 
-// This package will contain examples for using the organization module.
-// multi_tenant.go demonstrates multi-tenant setup (placeholder).
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/gcommon/pkg/organization"
+	"github.com/jdfalk/gcommon/pkg/organization/grpc"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// ExampleMultiTenant demonstrates tenant creation and isolation configuration.
+func ExampleMultiTenant() {
+	ctx := context.Background()
+	services := organization.NewServices()
+	tenantSvc := grpc.NewTenantService(services.Tenant)
+
+	t := (&orgpb.Tenant_builder{Id: gproto.String("tenant1"), Name: gproto.String("Tenant One")}).Build()
+	_, _ = tenantSvc.CreateTenant(ctx, (&orgpb.CreateTenantRequest_builder{Tenant: t}).Build())
+
+	iso := (&orgpb.TenantIsolation_builder{TenantId: gproto.String("tenant1")}).Build()
+	_, _ = tenantSvc.ConfigureTenantIsolation(ctx, (&orgpb.ConfigureTenantIsolationRequest_builder{TenantId: gproto.String("tenant1"), Isolation: iso}).Build())
+
+	resp, _ := tenantSvc.GetTenantIsolation(ctx, (&orgpb.GetTenantIsolationRequest_builder{TenantId: gproto.String("tenant1")}).Build())
+	fmt.Printf("has isolation: %v\n", resp.GetIsolation() != nil)
+	// Output: has isolation: true
+}

--- a/pkg/organization/factory.go
+++ b/pkg/organization/factory.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/factory.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b80b967-fa14-4400-8c4e-cd7d63efd1bd
 
 // Package organization exposes constructors for service implementations.
@@ -13,16 +13,20 @@ import (
 
 // Services groups organization service implementations.
 type Services struct {
-	Tenant    TenantManager
-	Hierarchy HierarchyManager
-	Teams     TeamManager
+	Tenant        TenantManager
+	Hierarchy     HierarchyManager
+	Departments   DepartmentManager
+	Teams         TeamManager
+	Organizations OrganizationManager
 }
 
 // NewServices returns initialized organization service implementations.
 func NewServices() *Services {
 	return &Services{
-		Tenant:    tenant.NewManager(),
-		Hierarchy: hierarchy.NewTree(),
-		Teams:     teams.NewManager(),
+		Tenant:        tenant.NewManager(),
+		Hierarchy:     hierarchy.NewTree(),
+		Departments:   hierarchy.NewDepartmentManager(),
+		Teams:         teams.NewManager(),
+		Organizations: NewManager(),
 	}
 }

--- a/pkg/organization/grpc/hierarchy_service.go
+++ b/pkg/organization/grpc/hierarchy_service.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/grpc/hierarchy_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 945d140a-9706-44d2-b754-2e7eb48e2ee0
 
 // Package grpc implements hierarchy gRPC services.
@@ -8,36 +8,70 @@ package grpc
 import (
 	"context"
 
+	"github.com/jdfalk/gcommon/pkg/organization"
 	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 // HierarchyService implements HierarchyServiceServer.
 type HierarchyService struct {
 	orgpb.UnimplementedHierarchyServiceServer
+	dm organization.DepartmentManager
 }
 
-// NewHierarchyService returns a stub HierarchyService.
-// TODO: Implement full hierarchy management.
-func NewHierarchyService() *HierarchyService { return &HierarchyService{} }
-
-func (s *HierarchyService) CreateDepartment(context.Context, *orgpb.CreateDepartmentRequest) (*orgpb.CreateDepartmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "CreateDepartment not implemented")
+// NewHierarchyService returns a HierarchyService using the provided manager.
+func NewHierarchyService(dm organization.DepartmentManager) *HierarchyService {
+	return &HierarchyService{dm: dm}
 }
 
-func (s *HierarchyService) GetDepartment(context.Context, *orgpb.GetDepartmentRequest) (*orgpb.GetDepartmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetDepartment not implemented")
+func (s *HierarchyService) CreateDepartment(ctx context.Context, req *orgpb.CreateDepartmentRequest) (*orgpb.CreateDepartmentResponse, error) {
+	d := req.GetDepartment()
+	if d == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing department")
+	}
+	if err := s.dm.CreateDepartment(ctx, d); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.CreateDepartmentResponse_builder{Department: d, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *HierarchyService) UpdateDepartment(context.Context, *orgpb.UpdateDepartmentRequest) (*orgpb.UpdateDepartmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "UpdateDepartment not implemented")
+func (s *HierarchyService) GetDepartment(ctx context.Context, req *orgpb.GetDepartmentRequest) (*orgpb.GetDepartmentResponse, error) {
+	d, err := s.dm.GetDepartment(ctx, req.GetDepartmentId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.GetDepartmentResponse_builder{Department: d, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *HierarchyService) DeleteDepartment(context.Context, *orgpb.DeleteDepartmentRequest) (*orgpb.DeleteDepartmentResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "DeleteDepartment not implemented")
+func (s *HierarchyService) UpdateDepartment(ctx context.Context, req *orgpb.UpdateDepartmentRequest) (*orgpb.UpdateDepartmentResponse, error) {
+	d := req.GetDepartment()
+	if d == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing department")
+	}
+	if err := s.dm.UpdateDepartment(ctx, d); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.UpdateDepartmentResponse_builder{Department: d, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *HierarchyService) ListDepartments(context.Context, *orgpb.ListDepartmentsRequest) (*orgpb.ListDepartmentsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListDepartments not implemented")
+func (s *HierarchyService) DeleteDepartment(ctx context.Context, req *orgpb.DeleteDepartmentRequest) (*orgpb.DeleteDepartmentResponse, error) {
+	if err := s.dm.DeleteDepartment(ctx, req.GetDepartmentId()); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.DeleteDepartmentResponse_builder{Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+func (s *HierarchyService) ListDepartments(ctx context.Context, req *orgpb.ListDepartmentsRequest) (*orgpb.ListDepartmentsResponse, error) {
+	list, err := s.dm.ListDepartments(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.ListDepartmentsResponse_builder{Departments: list, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }

--- a/pkg/organization/grpc/hierarchy_service_test.go
+++ b/pkg/organization/grpc/hierarchy_service_test.go
@@ -1,0 +1,40 @@
+// file: pkg/organization/grpc/hierarchy_service_test.go
+// version: 1.0.0
+// guid: 7d8e9f0a-1b2c-4d5e-8f6a-7b8c9d0e1f2a
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/organization"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func TestDepartmentLifecycle(t *testing.T) {
+	ctx := context.Background()
+	services := organization.NewServices()
+	svc := NewHierarchyService(services.Departments)
+	dept := (&orgpb.Department_builder{Id: gproto.String("d1"), OrganizationId: gproto.String("o1"), Name: gproto.String("Dept")}).Build()
+	_, err := svc.CreateDepartment(ctx, (&orgpb.CreateDepartmentRequest_builder{Department: dept}).Build())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.GetDepartment(ctx, (&orgpb.GetDepartmentRequest_builder{DepartmentId: gproto.String("d1")}).Build())
+	if err != nil || got.GetDepartment().GetName() != "Dept" {
+		t.Fatalf("get: %v", err)
+	}
+
+	list, err := svc.ListDepartments(ctx, (&orgpb.ListDepartmentsRequest_builder{OrganizationId: gproto.String("o1")}).Build())
+	if err != nil || len(list.GetDepartments()) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list.GetDepartments()))
+	}
+
+	_, err = svc.DeleteDepartment(ctx, (&orgpb.DeleteDepartmentRequest_builder{DepartmentId: gproto.String("d1")}).Build())
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}

--- a/pkg/organization/grpc/org_service.go
+++ b/pkg/organization/grpc/org_service.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/grpc/org_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9fe51dbb-bbe9-40d4-9d9c-dff684494e8d
 
 // Package grpc provides OrganizationService gRPC server implementations.
@@ -8,60 +8,132 @@ package grpc
 import (
 	"context"
 
+	"github.com/jdfalk/gcommon/pkg/organization"
 	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 // OrganizationService implements OrganizationServiceServer.
 type OrganizationService struct {
 	orgpb.UnimplementedOrganizationServiceServer
+	om organization.OrganizationManager
 }
 
-// NewOrganizationService returns a stub OrganizationService.
-// TODO: Implement full organization management logic.
-func NewOrganizationService() *OrganizationService { return &OrganizationService{} }
-
-func (s *OrganizationService) CreateOrganization(context.Context, *orgpb.CreateOrganizationRequest) (*orgpb.CreateOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "CreateOrganization not implemented")
+// NewOrganizationService returns an OrganizationService using the provided manager.
+func NewOrganizationService(om organization.OrganizationManager) *OrganizationService {
+	return &OrganizationService{om: om}
 }
 
-func (s *OrganizationService) GetOrganization(context.Context, *orgpb.GetOrganizationRequest) (*orgpb.GetOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetOrganization not implemented")
+func (s *OrganizationService) CreateOrganization(ctx context.Context, req *orgpb.CreateOrganizationRequest) (*orgpb.CreateOrganizationResponse, error) {
+	org := req.GetOrganization()
+	if org == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing organization")
+	}
+	if err := s.om.CreateOrganization(ctx, org); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.CreateOrganizationResponse_builder{Organization: org, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) UpdateOrganization(context.Context, *orgpb.UpdateOrganizationRequest) (*orgpb.UpdateOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "UpdateOrganization not implemented")
+func (s *OrganizationService) GetOrganization(ctx context.Context, req *orgpb.GetOrganizationRequest) (*orgpb.GetOrganizationResponse, error) {
+	org, err := s.om.GetOrganization(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.GetOrganizationResponse_builder{Organization: org, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) DeleteOrganization(context.Context, *orgpb.DeleteOrganizationRequest) (*orgpb.DeleteOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "DeleteOrganization not implemented")
+func (s *OrganizationService) UpdateOrganization(ctx context.Context, req *orgpb.UpdateOrganizationRequest) (*orgpb.UpdateOrganizationResponse, error) {
+	org := req.GetOrganization()
+	if org == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing organization")
+	}
+	if err := s.om.UpdateOrganization(ctx, org); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.UpdateOrganizationResponse_builder{Organization: org, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) ListOrganizations(context.Context, *orgpb.ListOrganizationsRequest) (*orgpb.ListOrganizationsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListOrganizations not implemented")
+func (s *OrganizationService) DeleteOrganization(ctx context.Context, req *orgpb.DeleteOrganizationRequest) (*orgpb.DeleteOrganizationResponse, error) {
+	if err := s.om.DeleteOrganization(ctx, req.GetOrganizationId()); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.DeleteOrganizationResponse_builder{Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) AddMember(context.Context, *orgpb.AddMemberRequest) (*orgpb.AddMemberResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "AddMember not implemented")
+func (s *OrganizationService) ListOrganizations(ctx context.Context, req *orgpb.ListOrganizationsRequest) (*orgpb.ListOrganizationsResponse, error) {
+	orgs, err := s.om.ListOrganizations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.ListOrganizationsResponse_builder{Organizations: orgs, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) RemoveMember(context.Context, *orgpb.RemoveMemberRequest) (*orgpb.RemoveMemberResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "RemoveMember not implemented")
+func (s *OrganizationService) AddMember(ctx context.Context, req *orgpb.AddMemberRequest) (*orgpb.AddMemberResponse, error) {
+	m := req.GetMember()
+	if m == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing member")
+	}
+	if err := s.om.AddMember(ctx, req.GetOrganizationId(), m); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.AddMemberResponse_builder{Member: m, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) UpdateMember(context.Context, *orgpb.UpdateMemberRequest) (*orgpb.UpdateMemberResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "UpdateMember not implemented")
+func (s *OrganizationService) RemoveMember(ctx context.Context, req *orgpb.RemoveMemberRequest) (*orgpb.RemoveMemberResponse, error) {
+	if err := s.om.RemoveMember(ctx, req.GetOrganizationId(), req.GetMemberId()); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.RemoveMemberResponse_builder{Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) ListMembers(context.Context, *orgpb.ListMembersRequest) (*orgpb.ListMembersResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListMembers not implemented")
+func (s *OrganizationService) UpdateMember(ctx context.Context, req *orgpb.UpdateMemberRequest) (*orgpb.UpdateMemberResponse, error) {
+	m := req.GetMember()
+	if m == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing member")
+	}
+	if err := s.om.UpdateMember(ctx, req.GetOrganizationId(), m); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.UpdateMemberResponse_builder{Member: m, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) GetOrganizationSettings(context.Context, *orgpb.GetOrganizationSettingsRequest) (*orgpb.GetOrganizationSettingsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetOrganizationSettings not implemented")
+func (s *OrganizationService) ListMembers(ctx context.Context, req *orgpb.ListMembersRequest) (*orgpb.ListMembersResponse, error) {
+	members, err := s.om.ListMembers(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.ListMembersResponse_builder{Members: members, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }
 
-func (s *OrganizationService) UpdateOrganizationSettings(context.Context, *orgpb.UpdateOrganizationSettingsRequest) (*orgpb.UpdateOrganizationSettingsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "UpdateOrganizationSettings not implemented")
+func (s *OrganizationService) GetOrganizationSettings(ctx context.Context, req *orgpb.GetOrganizationSettingsRequest) (*orgpb.GetOrganizationSettingsResponse, error) {
+	settings, err := s.om.GetSettings(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.GetOrganizationSettingsResponse_builder{Settings: settings, Success: gproto.Bool(true)}).Build()
+	return resp, nil
+}
+
+func (s *OrganizationService) UpdateOrganizationSettings(ctx context.Context, req *orgpb.UpdateOrganizationSettingsRequest) (*orgpb.UpdateOrganizationSettingsResponse, error) {
+	settings := req.GetSettings()
+	if settings == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing settings")
+	}
+	if err := s.om.UpdateSettings(ctx, settings); err != nil {
+		return nil, err
+	}
+	resp := (&orgpb.UpdateOrganizationSettingsResponse_builder{Settings: settings, Success: gproto.Bool(true)}).Build()
+	return resp, nil
 }

--- a/pkg/organization/grpc/org_service_test.go
+++ b/pkg/organization/grpc/org_service_test.go
@@ -1,0 +1,46 @@
+// file: pkg/organization/grpc/org_service_test.go
+// version: 1.0.0
+// guid: 6c7d8e9f-0a1b-4c2d-8e3f-4a5b6c7d8e9f
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/organization"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func TestOrganizationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	services := organization.NewServices()
+	svc := NewOrganizationService(services.Organizations)
+	org := (&orgpb.Organization_builder{Id: gproto.String("o1"), Name: gproto.String("Org")}).Build()
+	_, err := svc.CreateOrganization(ctx, (&orgpb.CreateOrganizationRequest_builder{Organization: org}).Build())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.GetOrganization(ctx, (&orgpb.GetOrganizationRequest_builder{OrganizationId: gproto.String("o1")}).Build())
+	if err != nil || got.GetOrganization().GetName() != "Org" {
+		t.Fatalf("get: %v", err)
+	}
+
+	members := (&orgpb.OrganizationMember_builder{Id: gproto.String("m1"), OrganizationId: gproto.String("o1"), UserId: gproto.String("u1")}).Build()
+	_, err = svc.AddMember(ctx, (&orgpb.AddMemberRequest_builder{OrganizationId: gproto.String("o1"), Member: members}).Build())
+	if err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	list, err := svc.ListMembers(ctx, (&orgpb.ListMembersRequest_builder{OrganizationId: gproto.String("o1")}).Build())
+	if err != nil || len(list.GetMembers()) != 1 {
+		t.Fatalf("list members: %v len=%d", err, len(list.GetMembers()))
+	}
+
+	_, err = svc.DeleteOrganization(ctx, (&orgpb.DeleteOrganizationRequest_builder{OrganizationId: gproto.String("o1")}).Build())
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}

--- a/pkg/organization/grpc/tenant_service.go
+++ b/pkg/organization/grpc/tenant_service.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/grpc/tenant_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e6c8dd36-ef60-4f63-b41d-7e29b84b86e4
 
 // Package grpc provides gRPC service implementations for the organization module.
@@ -7,7 +7,9 @@ package grpc
 
 import (
 	"context"
+	"sync"
 
+	commonpb "github.com/jdfalk/gcommon/pkg/common/proto"
 	"github.com/jdfalk/gcommon/pkg/organization"
 	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
 	"google.golang.org/grpc/codes"
@@ -18,12 +20,21 @@ import (
 // TenantService implements the generated gRPC server for tenant operations.
 type TenantService struct {
 	orgpb.UnimplementedTenantServiceServer
-	tm organization.TenantManager
+	tm         organization.TenantManager
+	mu         sync.RWMutex
+	isolations map[string]*orgpb.TenantIsolation
+	quotas     map[string]*orgpb.TenantQuota
+	usage      map[string][]*commonpb.KeyValue
 }
 
 // NewTenantService returns a TenantService with the provided manager.
 func NewTenantService(tm organization.TenantManager) *TenantService {
-	return &TenantService{tm: tm}
+	return &TenantService{
+		tm:         tm,
+		isolations: make(map[string]*orgpb.TenantIsolation),
+		quotas:     make(map[string]*orgpb.TenantQuota),
+		usage:      make(map[string][]*commonpb.KeyValue),
+	}
 }
 
 // CreateTenant handles tenant creation.
@@ -81,19 +92,56 @@ func (s *TenantService) ListTenants(ctx context.Context, req *orgpb.ListTenantsR
 	return resp, nil
 }
 
-// Remaining RPCs are unimplemented.
-func (s *TenantService) ConfigureTenantIsolation(context.Context, *orgpb.ConfigureTenantIsolationRequest) (*orgpb.ConfigureTenantIsolationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+// ConfigureTenantIsolation sets isolation configuration for a tenant.
+func (s *TenantService) ConfigureTenantIsolation(ctx context.Context, req *orgpb.ConfigureTenantIsolationRequest) (*orgpb.ConfigureTenantIsolationResponse, error) {
+	iso := req.GetIsolation()
+	id := req.GetTenantId()
+	if id == "" || iso == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing tenant or isolation")
+	}
+	s.mu.Lock()
+	s.isolations[id] = iso
+	s.mu.Unlock()
+	resp := (&orgpb.ConfigureTenantIsolationResponse_builder{Success: gproto.Bool(true), Isolation: iso}).Build()
+	return resp, nil
 }
 
-func (s *TenantService) GetTenantIsolation(context.Context, *orgpb.GetTenantIsolationRequest) (*orgpb.GetTenantIsolationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+// GetTenantIsolation retrieves stored isolation configuration.
+func (s *TenantService) GetTenantIsolation(ctx context.Context, req *orgpb.GetTenantIsolationRequest) (*orgpb.GetTenantIsolationResponse, error) {
+	id := req.GetTenantId()
+	s.mu.RLock()
+	iso, ok := s.isolations[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, status.Error(codes.NotFound, "isolation not found")
+	}
+	resp := (&orgpb.GetTenantIsolationResponse_builder{Success: gproto.Bool(true), Isolation: iso}).Build()
+	return resp, nil
 }
 
-func (s *TenantService) UpdateTenantQuota(context.Context, *orgpb.UpdateTenantQuotaRequest) (*orgpb.UpdateTenantQuotaResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+// UpdateTenantQuota stores quota configuration.
+func (s *TenantService) UpdateTenantQuota(ctx context.Context, req *orgpb.UpdateTenantQuotaRequest) (*orgpb.UpdateTenantQuotaResponse, error) {
+	id := req.GetTenantId()
+	quota := req.GetQuota()
+	if id == "" || quota == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing tenant or quota")
+	}
+	s.mu.Lock()
+	s.quotas[id] = quota
+	s.mu.Unlock()
+	resp := (&orgpb.UpdateTenantQuotaResponse_builder{Success: gproto.Bool(true), Quota: quota}).Build()
+	return resp, nil
 }
 
-func (s *TenantService) GetTenantUsage(context.Context, *orgpb.GetTenantUsageRequest) (*orgpb.GetTenantUsageResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+// GetTenantUsage returns usage statistics for a tenant.
+func (s *TenantService) GetTenantUsage(ctx context.Context, req *orgpb.GetTenantUsageRequest) (*orgpb.GetTenantUsageResponse, error) {
+	id := req.GetTenantId()
+	s.mu.RLock()
+	stats, ok := s.usage[id]
+	s.mu.RUnlock()
+	if !ok {
+		stats = []*commonpb.KeyValue{}
+	}
+	resp := (&orgpb.GetTenantUsageResponse_builder{Success: gproto.Bool(true), UsageStats: stats}).Build()
+	return resp, nil
 }

--- a/pkg/organization/grpc/tenant_service_test.go
+++ b/pkg/organization/grpc/tenant_service_test.go
@@ -1,0 +1,71 @@
+// file: pkg/organization/grpc/tenant_service_test.go
+// version: 1.0.0
+// guid: 5b6c7d8e-9f01-4a2b-b3c4-d5e6f708192a
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/gcommon/pkg/organization"
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func TestTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	tm := organization.NewServices().Tenant
+	svc := NewTenantService(tm)
+	tenant := (&orgpb.Tenant_builder{Id: gproto.String("t1"), Name: gproto.String("T")}).Build()
+	_, err := svc.CreateTenant(ctx, (&orgpb.CreateTenantRequest_builder{Tenant: tenant}).Build())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	iso := (&orgpb.TenantIsolation_builder{TenantId: gproto.String("t1")}).Build()
+	_, err = svc.ConfigureTenantIsolation(ctx, (&orgpb.ConfigureTenantIsolationRequest_builder{TenantId: gproto.String("t1"), Isolation: iso}).Build())
+	if err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+
+	resp, err := svc.GetTenantIsolation(ctx, (&orgpb.GetTenantIsolationRequest_builder{TenantId: gproto.String("t1")}).Build())
+	if err != nil || resp.GetIsolation() == nil {
+		t.Fatalf("get isolation: %v", err)
+	}
+}
+
+func TestTenantQuota(t *testing.T) {
+	ctx := context.Background()
+	tm := organization.NewServices().Tenant
+	svc := NewTenantService(tm)
+	tenant := (&orgpb.Tenant_builder{Id: gproto.String("t2"), Name: gproto.String("T2")}).Build()
+	_, _ = svc.CreateTenant(ctx, (&orgpb.CreateTenantRequest_builder{Tenant: tenant}).Build())
+
+	quota := (&orgpb.TenantQuota_builder{TenantId: gproto.String("t2"), MaxUsers: gproto.Int32(10)}).Build()
+	_, err := svc.UpdateTenantQuota(ctx, (&orgpb.UpdateTenantQuotaRequest_builder{TenantId: gproto.String("t2"), Quota: quota}).Build())
+	if err != nil {
+		t.Fatalf("update quota: %v", err)
+	}
+
+	resp, err := svc.GetTenantUsage(ctx, (&orgpb.GetTenantUsageRequest_builder{TenantId: gproto.String("t2")}).Build())
+	if err != nil {
+		t.Fatalf("get usage: %v", err)
+	}
+	if len(resp.GetUsageStats()) != 0 {
+		t.Fatalf("expected empty usage stats")
+	}
+}
+
+func TestListTenants(t *testing.T) {
+	ctx := context.Background()
+	svc := NewTenantService(organization.NewServices().Tenant)
+	t1 := (&orgpb.Tenant_builder{Id: gproto.String("lt1"), Name: gproto.String("L1")}).Build()
+	t2 := (&orgpb.Tenant_builder{Id: gproto.String("lt2"), Name: gproto.String("L2")}).Build()
+	_, _ = svc.CreateTenant(ctx, (&orgpb.CreateTenantRequest_builder{Tenant: t1}).Build())
+	_, _ = svc.CreateTenant(ctx, (&orgpb.CreateTenantRequest_builder{Tenant: t2}).Build())
+	resp, err := svc.ListTenants(ctx, (&orgpb.ListTenantsRequest_builder{}).Build())
+	if err != nil || len(resp.GetTenants()) != 2 {
+		t.Fatalf("list tenants: %v len=%d", err, len(resp.GetTenants()))
+	}
+}

--- a/pkg/organization/hierarchy/department_manager.go
+++ b/pkg/organization/hierarchy/department_manager.go
@@ -1,0 +1,116 @@
+// file: pkg/organization/hierarchy/department_manager.go
+// version: 1.0.0
+// guid: 3c4d5e6f-7081-4a92-bc3d-5e6f708192a0
+
+// Package hierarchy provides department management for organizations.
+package hierarchy
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+)
+
+// DepartmentManager manages departments and their hierarchy in memory.
+type DepartmentManager struct {
+	mu          sync.RWMutex
+	departments map[string]*orgpb.Department
+}
+
+// NewDepartmentManager returns an initialized DepartmentManager.
+func NewDepartmentManager() *DepartmentManager {
+	return &DepartmentManager{departments: make(map[string]*orgpb.Department)}
+}
+
+// CreateDepartment adds a department definition.
+func (m *DepartmentManager) CreateDepartment(ctx context.Context, d *orgpb.Department) error {
+	if d == nil || d.GetId() == "" {
+		return errors.New("missing department id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.departments[d.GetId()]; exists {
+		return errors.New("department exists")
+	}
+	m.departments[d.GetId()] = d
+	return nil
+}
+
+// GetDepartment retrieves a department by ID.
+func (m *DepartmentManager) GetDepartment(ctx context.Context, id string) (*orgpb.Department, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	d, ok := m.departments[id]
+	if !ok {
+		return nil, errors.New("department not found")
+	}
+	return d, nil
+}
+
+// UpdateDepartment replaces an existing department.
+func (m *DepartmentManager) UpdateDepartment(ctx context.Context, d *orgpb.Department) error {
+	if d == nil || d.GetId() == "" {
+		return errors.New("missing department id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.departments[d.GetId()]; !ok {
+		return errors.New("department not found")
+	}
+	m.departments[d.GetId()] = d
+	return nil
+}
+
+// DeleteDepartment removes a department.
+func (m *DepartmentManager) DeleteDepartment(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.departments[id]; !ok {
+		return errors.New("department not found")
+	}
+	delete(m.departments, id)
+	return nil
+}
+
+// ListDepartments returns departments for an organization.
+func (m *DepartmentManager) ListDepartments(ctx context.Context, orgID string) ([]*orgpb.Department, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := []*orgpb.Department{}
+	for _, d := range m.departments {
+		if d.GetOrganizationId() == orgID {
+			result = append(result, d)
+		}
+	}
+	return result, nil
+}
+
+// Children returns child departments of the given parent.
+func (m *DepartmentManager) Children(ctx context.Context, parentID string) ([]*orgpb.Department, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := []*orgpb.Department{}
+	for _, d := range m.departments {
+		if d.GetParentDepartmentId() == parentID {
+			result = append(result, d)
+		}
+	}
+	return result, nil
+}
+
+// MoveDepartment changes the parent of a department.
+func (m *DepartmentManager) MoveDepartment(ctx context.Context, id, newParent string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.departments[id]
+	if !ok {
+		return errors.New("department not found")
+	}
+	b := &orgpb.Department_builder{}
+	*b = *d.AsBuilder()
+	b.ParentDepartmentId = &newParent
+	m.departments[id] = b.Build()
+	return nil
+}

--- a/pkg/organization/hierarchy/department_manager_test.go
+++ b/pkg/organization/hierarchy/department_manager_test.go
@@ -1,0 +1,72 @@
+// file: pkg/organization/hierarchy/department_manager_test.go
+// version: 1.0.0
+// guid: 4d5e6f70-8192-4a5b-bc6d-7e8f9012ab34
+
+package hierarchy
+
+import (
+	"context"
+	"testing"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func dept(id, org, parent, name string) *orgpb.Department {
+	return (&orgpb.Department_builder{Id: gproto.String(id), OrganizationId: gproto.String(org), ParentDepartmentId: gproto.String(parent), Name: gproto.String(name)}).Build()
+}
+
+func TestDepartmentLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := NewDepartmentManager()
+
+	d := dept("d1", "o1", "", "Root")
+	if err := m.CreateDepartment(ctx, d); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := m.GetDepartment(ctx, "d1")
+	if err != nil || got.GetName() != "Root" {
+		t.Fatalf("get: %v %v", err, got)
+	}
+
+	d2 := dept("d1", "o1", "", "Renamed")
+	if err := m.UpdateDepartment(ctx, d2); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	list, err := m.ListDepartments(ctx, "o1")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list))
+	}
+
+	if err := m.DeleteDepartment(ctx, "d1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := m.GetDepartment(ctx, "d1"); err == nil {
+		t.Fatalf("expected error after delete")
+	}
+}
+
+func TestHierarchyOperations(t *testing.T) {
+	ctx := context.Background()
+	m := NewDepartmentManager()
+
+	root := dept("root", "o1", "", "Root")
+	_ = m.CreateDepartment(ctx, root)
+	child := dept("child", "o1", "root", "Child")
+	_ = m.CreateDepartment(ctx, child)
+
+	children, err := m.Children(ctx, "root")
+	if err != nil || len(children) != 1 {
+		t.Fatalf("children: %v len=%d", err, len(children))
+	}
+
+	if err := m.MoveDepartment(ctx, "child", ""); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	childMoved, _ := m.GetDepartment(ctx, "child")
+	if childMoved.GetParentDepartmentId() != "" {
+		t.Fatalf("move failed: %s", childMoved.GetParentDepartmentId())
+	}
+}

--- a/pkg/organization/interfaces.go
+++ b/pkg/organization/interfaces.go
@@ -1,5 +1,5 @@
 // file: pkg/organization/interfaces.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 674239c9-d92a-4b83-9ec8-c88c1b3dd040
 
 // Package organization provides service interfaces for managing organizations.
@@ -41,4 +41,28 @@ type TeamManager interface {
 	UpdateMemberRole(ctx context.Context, teamID, userID string, role teams.Role) error
 	Members(ctx context.Context, teamID string) ([]*teams.Member, error)
 	RoleOf(ctx context.Context, teamID, userID string) (teams.Role, error)
+}
+
+// OrganizationManager defines operations for managing organizations and members.
+type OrganizationManager interface {
+	CreateOrganization(ctx context.Context, org *orgpb.Organization) error
+	GetOrganization(ctx context.Context, orgID string) (*orgpb.Organization, error)
+	UpdateOrganization(ctx context.Context, org *orgpb.Organization) error
+	DeleteOrganization(ctx context.Context, orgID string) error
+	ListOrganizations(ctx context.Context) ([]*orgpb.Organization, error)
+	AddMember(ctx context.Context, orgID string, member *orgpb.OrganizationMember) error
+	RemoveMember(ctx context.Context, orgID, memberID string) error
+	UpdateMember(ctx context.Context, orgID string, member *orgpb.OrganizationMember) error
+	ListMembers(ctx context.Context, orgID string) ([]*orgpb.OrganizationMember, error)
+	GetSettings(ctx context.Context, orgID string) (*orgpb.OrganizationSettings, error)
+	UpdateSettings(ctx context.Context, settings *orgpb.OrganizationSettings) error
+}
+
+// DepartmentManager defines hierarchical department operations.
+type DepartmentManager interface {
+	CreateDepartment(ctx context.Context, d *orgpb.Department) error
+	GetDepartment(ctx context.Context, id string) (*orgpb.Department, error)
+	UpdateDepartment(ctx context.Context, d *orgpb.Department) error
+	DeleteDepartment(ctx context.Context, id string) error
+	ListDepartments(ctx context.Context, orgID string) ([]*orgpb.Department, error)
 }

--- a/pkg/organization/manager.go
+++ b/pkg/organization/manager.go
@@ -1,0 +1,240 @@
+// file: pkg/organization/manager.go
+// version: 1.0.0
+// guid: 1f2e3d4c-5b6a-7c8d-9e0f-1a2b3c4d5e6f
+
+// Package organization implements organization and membership management.
+package organization
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// Manager provides in-memory organization storage and membership tracking.
+type Manager struct {
+	mu       sync.RWMutex
+	orgs     map[string]*orgpb.Organization
+	members  map[string]map[string]*orgpb.OrganizationMember // orgID -> memberID -> member
+	settings map[string]*orgpb.OrganizationSettings
+}
+
+// NewManager returns an initialized Manager instance.
+func NewManager() *Manager {
+	return &Manager{
+		orgs:     make(map[string]*orgpb.Organization),
+		members:  make(map[string]map[string]*orgpb.OrganizationMember),
+		settings: make(map[string]*orgpb.OrganizationSettings),
+	}
+}
+
+// CreateOrganization stores a new organization definition.
+func (m *Manager) CreateOrganization(ctx context.Context, org *orgpb.Organization) error {
+	if org == nil || org.GetId() == "" {
+		return errors.New("missing organization id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.orgs[org.GetId()]; exists {
+		return errors.New("organization exists")
+	}
+	m.orgs[org.GetId()] = org
+	return nil
+}
+
+// GetOrganization retrieves an organization by ID.
+func (m *Manager) GetOrganization(ctx context.Context, orgID string) (*orgpb.Organization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	o, ok := m.orgs[orgID]
+	if !ok {
+		return nil, errors.New("organization not found")
+	}
+	return o, nil
+}
+
+// UpdateOrganization replaces an existing organization entry.
+func (m *Manager) UpdateOrganization(ctx context.Context, org *orgpb.Organization) error {
+	if org == nil || org.GetId() == "" {
+		return errors.New("missing organization id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.orgs[org.GetId()]; !ok {
+		return errors.New("organization not found")
+	}
+	m.orgs[org.GetId()] = org
+	return nil
+}
+
+// DeleteOrganization removes an organization and all associated members and settings.
+func (m *Manager) DeleteOrganization(ctx context.Context, orgID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.orgs[orgID]; !ok {
+		return errors.New("organization not found")
+	}
+	delete(m.orgs, orgID)
+	delete(m.members, orgID)
+	delete(m.settings, orgID)
+	return nil
+}
+
+// ListOrganizations returns all stored organizations.
+func (m *Manager) ListOrganizations(ctx context.Context) ([]*orgpb.Organization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*orgpb.Organization, 0, len(m.orgs))
+	for _, o := range m.orgs {
+		result = append(result, o)
+	}
+	return result, nil
+}
+
+// AddMember adds a member to the organization.
+func (m *Manager) AddMember(ctx context.Context, orgID string, member *orgpb.OrganizationMember) error {
+	if member == nil || member.GetId() == "" {
+		return errors.New("missing member id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.orgs[orgID]; !ok {
+		return errors.New("organization not found")
+	}
+	if _, ok := m.members[orgID]; !ok {
+		m.members[orgID] = make(map[string]*orgpb.OrganizationMember)
+	}
+	if _, exists := m.members[orgID][member.GetId()]; exists {
+		return errors.New("member exists")
+	}
+	m.members[orgID][member.GetId()] = member
+	return nil
+}
+
+// RemoveMember deletes a member from the organization.
+func (m *Manager) RemoveMember(ctx context.Context, orgID, memberID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	members, ok := m.members[orgID]
+	if !ok {
+		return errors.New("organization not found")
+	}
+	if _, ok := members[memberID]; !ok {
+		return errors.New("member not found")
+	}
+	delete(members, memberID)
+	return nil
+}
+
+// UpdateMember updates a member's data.
+func (m *Manager) UpdateMember(ctx context.Context, orgID string, member *orgpb.OrganizationMember) error {
+	if member == nil || member.GetId() == "" {
+		return errors.New("missing member id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	members, ok := m.members[orgID]
+	if !ok {
+		return errors.New("organization not found")
+	}
+	if _, ok := members[member.GetId()]; !ok {
+		return errors.New("member not found")
+	}
+	members[member.GetId()] = member
+	return nil
+}
+
+// ListMembers returns all members of an organization.
+func (m *Manager) ListMembers(ctx context.Context, orgID string) ([]*orgpb.OrganizationMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	members, ok := m.members[orgID]
+	if !ok {
+		return nil, errors.New("organization not found")
+	}
+	result := make([]*orgpb.OrganizationMember, 0, len(members))
+	for _, mbr := range members {
+		result = append(result, mbr)
+	}
+	return result, nil
+}
+
+// GetSettings retrieves organization settings if present.
+func (m *Manager) GetSettings(ctx context.Context, orgID string) (*orgpb.OrganizationSettings, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	s, ok := m.settings[orgID]
+	if !ok {
+		return nil, errors.New("settings not found")
+	}
+	return s, nil
+}
+
+// UpdateSettings sets organization settings.
+func (m *Manager) UpdateSettings(ctx context.Context, settings *orgpb.OrganizationSettings) error {
+	if settings == nil || settings.GetOrganizationId() == "" {
+		return errors.New("missing organization id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	orgID := settings.GetOrganizationId()
+	if _, ok := m.orgs[orgID]; !ok {
+		return errors.New("organization not found")
+	}
+	m.settings[orgID] = settings
+	return nil
+}
+
+// CloneOrganization returns a deep copy of the organization with the given ID.
+// This is primarily used in tests to ensure callers do not mutate internal state.
+func (m *Manager) CloneOrganization(ctx context.Context, orgID string) (*orgpb.Organization, error) {
+	org, err := m.GetOrganization(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return gproto.Clone(org).(*orgpb.Organization), nil
+}
+
+// CloneMember returns a deep copy of the organization member.
+func (m *Manager) CloneMember(ctx context.Context, orgID, memberID string) (*orgpb.OrganizationMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	members, ok := m.members[orgID]
+	if !ok {
+		return nil, errors.New("organization not found")
+	}
+	member, ok := members[memberID]
+	if !ok {
+		return nil, errors.New("member not found")
+	}
+	return gproto.Clone(member).(*orgpb.OrganizationMember), nil
+}
+
+// Organizations returns a list of copies of all organizations.
+func (m *Manager) Organizations(ctx context.Context) ([]*orgpb.Organization, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*orgpb.Organization, 0, len(m.orgs))
+	for _, o := range m.orgs {
+		result = append(result, gproto.Clone(o).(*orgpb.Organization))
+	}
+	return result, nil
+}
+
+// MembersMap returns a copy of member maps keyed by organization.
+func (m *Manager) MembersMap(ctx context.Context) (map[string][]*orgpb.OrganizationMember, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make(map[string][]*orgpb.OrganizationMember, len(m.members))
+	for orgID, mset := range m.members {
+		list := make([]*orgpb.OrganizationMember, 0, len(mset))
+		for _, member := range mset {
+			list = append(list, gproto.Clone(member).(*orgpb.OrganizationMember))
+		}
+		result[orgID] = list
+	}
+	return result, nil
+}

--- a/pkg/organization/manager_test.go
+++ b/pkg/organization/manager_test.go
@@ -1,0 +1,113 @@
+// file: pkg/organization/manager_test.go
+// version: 1.0.0
+// guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
+
+package organization
+
+import (
+	"context"
+	"testing"
+
+	orgpb "github.com/jdfalk/gcommon/pkg/organization/proto"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// helper organization object
+func testOrg(id, name string) *orgpb.Organization {
+	return (&orgpb.Organization_builder{Id: gproto.String(id), Name: gproto.String(name)}).Build()
+}
+
+// helper member object
+func testMember(id, orgID, userID string) *orgpb.OrganizationMember {
+	return (&orgpb.OrganizationMember_builder{Id: gproto.String(id), OrganizationId: gproto.String(orgID), UserId: gproto.String(userID)}).Build()
+}
+
+func TestManagerCRUD(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager()
+
+	org := testOrg("org1", "Acme")
+	if err := m.CreateOrganization(ctx, org); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := m.GetOrganization(ctx, "org1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetName() != "Acme" {
+		t.Fatalf("name mismatch: %s", got.GetName())
+	}
+
+	org2 := testOrg("org1", "NewName")
+	if err := m.UpdateOrganization(ctx, org2); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ = m.GetOrganization(ctx, "org1")
+	if got.GetName() != "NewName" {
+		t.Fatalf("update failed: %s", got.GetName())
+	}
+
+	list, err := m.ListOrganizations(ctx)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(list))
+	}
+
+	if err := m.DeleteOrganization(ctx, "org1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := m.GetOrganization(ctx, "org1"); err == nil {
+		t.Fatalf("expected error after delete")
+	}
+}
+
+func TestMemberManagement(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager()
+	org := testOrg("o1", "Org")
+	if err := m.CreateOrganization(ctx, org); err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	mem := testMember("m1", "o1", "u1")
+	if err := m.AddMember(ctx, "o1", mem); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	members, err := m.ListMembers(ctx, "o1")
+	if err != nil || len(members) != 1 {
+		t.Fatalf("list members: %v len=%d", err, len(members))
+	}
+
+	mem2 := testMember("m1", "o1", "u2")
+	if err := m.UpdateMember(ctx, "o1", mem2); err != nil {
+		t.Fatalf("update member: %v", err)
+	}
+	cloned, err := m.CloneMember(ctx, "o1", "m1")
+	if err != nil || cloned.GetUserId() != "u2" {
+		t.Fatalf("clone member: %v uid=%s", err, cloned.GetUserId())
+	}
+
+	if err := m.RemoveMember(ctx, "o1", "m1"); err != nil {
+		t.Fatalf("remove member: %v", err)
+	}
+	if _, err := m.CloneMember(ctx, "o1", "m1"); err == nil {
+		t.Fatalf("expected error after remove")
+	}
+}
+
+func TestSettings(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager()
+	org := testOrg("o1", "Org")
+	_ = m.CreateOrganization(ctx, org)
+
+	s := (&orgpb.OrganizationSettings_builder{OrganizationId: gproto.String("o1")}).Build()
+	if err := m.UpdateSettings(ctx, s); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+	got, err := m.GetSettings(ctx, "o1")
+	if err != nil || got.GetOrganizationId() != "o1" {
+		t.Fatalf("get settings: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add in-memory organization and department managers
- implement gRPC services for organizations, departments, and tenant isolation
- expand examples and comprehensive tests for organization module

## Testing
- `go test ./...` *(fails: package gcommon/sdks/go/client is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_689a0bb41ca88321856bc844955b2f8e