### PR TITLE
feat(grpc): add client resilience features

### DIFF
--- a/.github/doc-updates/460434a9-7c7f-409c-84cc-e63c6f015f1c.json
+++ b/.github/doc-updates/460434a9-7c7f-409c-84cc-e63c6f015f1c.json
@@ -1,0 +1,16 @@
+{
+  "file": "tasks/12-grpc-service-consolidation.md",
+  "mode": "append",
+  "content": "## Progress\\n\\n- Advanced client resilience features implemented in [pkg/grpc/client/resilience_future.go](../pkg/grpc/client/resilience_future.go)",
+  "guid": "460434a9-7c7f-409c-84cc-e63c6f015f1c",
+  "created_at": "2025-08-11T15:33:04Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b9a4c163-f814-4d1b-bd99-ae96ff77748e.json
+++ b/.github/doc-updates/b9a4c163-f814-4d1b-bd99-ae96ff77748e.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\\n- Implemented advanced gRPC client resilience with token bucket rate limiting, bulkhead concurrency control, and request hedging.",
+  "guid": "b9a4c163-f814-4d1b-bd99-ae96ff77748e",
+  "created_at": "2025-08-11T15:32:59Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/13a67823-23f9-4cfa-ac16-c45ee7e60c8e.json
+++ b/.github/issue-updates/13a67823-23f9-4cfa-ac16-c45ee7e60c8e.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Add advanced gRPC client resilience features",
+  "body": "Implement token bucket rate limiter, bulkhead limiter, and request hedging in gRPC client with comprehensive tests.",
+  "labels": ["module:grpc", "enhancement"],
+  "guid": "13a67823-23f9-4cfa-ac16-c45ee7e60c8e",
+  "legacy_guid": "create-add-advanced-grpc-client-resilience-features-2025-08-11",
+  "created_at": "2025-08-11T15:32:57.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/pkg/grpc/client/resilience_future.go
+++ b/pkg/grpc/client/resilience_future.go
@@ -1,262 +1,278 @@
 // file: pkg/grpc/client/resilience_future.go
-// version: 0.1.0
-// guid: 3b588c6e-e01b-44f1-bd48-4e4700c4d2a7
+// version: 1.0.0
+// guid: 8d3b5d4a-2b9c-4b0e-8d9d-8f7c6e5a4b3c
 
+// Package client provides gRPC client utilities. This file implements
+// advanced resilience features that combine multiple fault-tolerance
+// strategies including retries, circuit breaking, rate limiting and
+// request hedging. The goal is to offer a single interceptor that can be
+// configured with the desired policies while remaining modular so that
+// individual strategies can be reused independently.
 package client
 
-// FutureFeatureSkeleton is a placeholder for upcoming resilience features.
-type FutureFeatureSkeleton struct{}
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
 
-// TODO: implement advanced resilience algorithms
-func (FutureFeatureSkeleton) placeholder() {}
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
-// TODO: COMPLETE IMPLEMENTATION
+// RateLimiter decides whether a request is allowed to proceed based on
+// current load. Implementations must be safe for concurrent use.
+type RateLimiter interface {
+	Allow() bool
+}
+
+// TokenBucket implements a simple token bucket rate limiter. The bucket is
+// filled at a steady rate up to a maximum burst capacity. Each call to
+// Allow consumes one token. If no tokens remain the call is rejected.
+type TokenBucket struct {
+	mu       sync.Mutex
+	capacity float64
+	tokens   float64
+	rate     float64
+	last     time.Time
+}
+
+// NewTokenBucket creates a token bucket with the given fill rate (tokens per
+// second) and burst capacity. The bucket starts full.
+func NewTokenBucket(rate, burst int) *TokenBucket {
+	if rate <= 0 {
+		rate = 1
+	}
+	if burst <= 0 {
+		burst = rate
+	}
+	return &TokenBucket{
+		capacity: float64(burst),
+		tokens:   float64(burst),
+		rate:     float64(rate),
+		last:     time.Now(),
+	}
+}
+
+// Allow reports whether a token is available. If so it consumes one token and
+// returns true. Otherwise it returns false.
+func (tb *TokenBucket) Allow() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	now := time.Now()
+	elapsed := now.Sub(tb.last).Seconds()
+	tb.last = now
+	tb.tokens += elapsed * tb.rate
+	if tb.tokens > tb.capacity {
+		tb.tokens = tb.capacity
+	}
+	if tb.tokens < 1 {
+		return false
+	}
+	tb.tokens--
+	return true
+}
+
+// HedgingPolicy controls how additional hedged RPCs are issued. Hedging
+// allows secondary requests to be sent if the initial call is taking too long
+// which can reduce tail latency at the expense of extra load.
+type HedgingPolicy struct {
+	// MaxHedges is the maximum number of parallel hedged requests
+	// including the original. Values less than two disable hedging.
+	MaxHedges int
+	// HedgeDelay is the delay before starting each additional hedge.
+	HedgeDelay time.Duration
+}
+
+// ResilienceOptions configures the behaviour of the ResilientUnaryInterceptor.
+// All fields are optional. Zero values will cause sensible defaults to be
+// selected.
+type ResilienceOptions struct {
+	Retry          RetryOptions
+	CircuitBreaker *CircuitBreaker
+	RateLimiter    RateLimiter
+	Hedge          HedgingPolicy
+	Timeout        time.Duration
+}
+
+// ResilientUnaryInterceptor returns a grpc.UnaryClientInterceptor that
+// composes multiple resilience strategies including retries, circuit breaking,
+// rate limiting and hedging. Each component can be enabled or disabled via the
+// supplied options.
+func ResilientUnaryInterceptor(opts ResilienceOptions) grpc.UnaryClientInterceptor {
+	if opts.RateLimiter == nil {
+		opts.RateLimiter = NewTokenBucket(100, 100)
+	}
+	if opts.CircuitBreaker == nil {
+		opts.CircuitBreaker = NewCircuitBreaker()
+	}
+	if opts.Retry.MaxAttempts == 0 {
+		opts.Retry.MaxAttempts = 3
+	}
+	if opts.Retry.BackoffStrategy == nil {
+		opts.Retry.BackoffStrategy = NewExponentialBackoff()
+	}
+	if opts.Retry.Retryable == nil {
+		opts.Retry.Retryable = defaultRetryable
+	}
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker, callOpts ...grpc.CallOption) error {
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+		if opts.RateLimiter != nil && !opts.RateLimiter.Allow() {
+			return status.Error(codes.ResourceExhausted, "rate limit exceeded")
+		}
+
+		attempt := func(c context.Context) error {
+			if !opts.CircuitBreaker.Allow() {
+				return status.Error(codes.Unavailable, "circuit open")
+			}
+			err := invoker(c, method, req, reply, cc, callOpts...)
+			if err != nil {
+				opts.CircuitBreaker.MarkFailure()
+			} else {
+				opts.CircuitBreaker.MarkSuccess()
+			}
+			return err
+		}
+
+		if opts.Hedge.MaxHedges > 1 {
+			return runWithHedging(ctx, attempt, opts)
+		}
+		return runWithRetry(ctx, attempt, opts)
+	}
+}
+
+// runWithRetry executes the provided function using the retry policy defined in
+// ResilienceOptions. Retries are attempted with the configured backoff
+// strategy. The function stops retrying once it succeeds or the retry policy is
+// exhausted.
+func runWithRetry(ctx context.Context, fn func(context.Context) error, opts ResilienceOptions) error {
+	if opts.Retry.BackoffStrategy == nil {
+		opts.Retry.BackoffStrategy = NewExponentialBackoff()
+	}
+	if opts.Retry.Retryable == nil {
+		opts.Retry.Retryable = defaultRetryable
+	}
+	var lastErr error
+	for attempt := uint(0); attempt < opts.Retry.MaxAttempts; attempt++ {
+		if attempt > 0 {
+			d := opts.Retry.BackoffStrategy.Next(attempt - 1)
+			select {
+			case <-time.After(d):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		lastErr = fn(ctx)
+		if lastErr == nil || !opts.Retry.Retryable(lastErr) {
+			return lastErr
+		}
+		if s, ok := status.FromError(lastErr); ok && s.Code() == codes.Unauthenticated {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+// runWithHedging executes the function with request hedging. The initial
+// attempt is started immediately and additional hedged attempts are launched
+// after the configured delay. The first successful attempt returns and all
+// others are canceled. Retries are still applied within each hedged attempt.
+func runWithHedging(ctx context.Context, fn func(context.Context) error, opts ResilienceOptions) error {
+	var (
+		wg      sync.WaitGroup
+		cancel  context.CancelFunc
+		hedges  = opts.Hedge.MaxHedges
+		results = make(chan error, hedges)
+	)
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+
+	startAttempt := func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := runWithRetry(ctx, fn, opts)
+			if err == nil {
+				select {
+				case results <- nil:
+				default:
+				}
+				cancel()
+			} else {
+				results <- err
+			}
+		}()
+	}
+
+	startAttempt() // initial request
+
+	for i := 1; i < hedges; i++ {
+		select {
+		case <-ctx.Done():
+			break
+		case <-time.After(opts.Hedge.HedgeDelay):
+			startAttempt()
+		}
+	}
+
+	var lastErr error
+	for i := 0; i < hedges; i++ {
+		select {
+		case err := <-results:
+			if err == nil {
+				wg.Wait()
+				return nil
+			}
+			lastErr = err
+		case <-ctx.Done():
+			wg.Wait()
+			return lastErr
+		}
+	}
+
+	wg.Wait()
+	return lastErr
+}
+
+// BulkheadLimiter limits the number of concurrent operations. It implements the
+// RateLimiter interface but enforces a concurrency ceiling rather than a
+// throughput rate. Once the limit is reached additional calls are rejected
+// until running operations complete.
+type BulkheadLimiter struct {
+	capacity int32
+	current  int32
+}
+
+// NewBulkheadLimiter creates a BulkheadLimiter with the specified capacity.
+func NewBulkheadLimiter(capacity int) *BulkheadLimiter {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &BulkheadLimiter{capacity: int32(capacity)}
+}
+
+// Allow attempts to reserve one slot. It returns true if capacity permits the
+// operation and false otherwise.
+func (b *BulkheadLimiter) Allow() bool {
+	for {
+		cur := atomic.LoadInt32(&b.current)
+		if cur >= b.capacity {
+			return false
+		}
+		if atomic.CompareAndSwapInt32(&b.current, cur, cur+1) {
+			return true
+		}
+	}
+}
+
+// Done releases a previously reserved slot. It should be called when the
+// operation completes.
+func (b *BulkheadLimiter) Done() {
+	atomic.AddInt32(&b.current, -1)
+}

--- a/pkg/grpc/client/resilience_future_test.go
+++ b/pkg/grpc/client/resilience_future_test.go
@@ -1,0 +1,67 @@
+// file: pkg/grpc/client/resilience_future_test.go
+// version: 1.0.0
+// guid: 7f4e9c2b-3a1d-4d5e-9c0b-1e2f3a4b5c6d
+
+package client
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTokenBucket verifies the basic rate limiting behaviour of the token bucket.
+func TestTokenBucket(t *testing.T) {
+	tb := NewTokenBucket(1, 1)
+	if !tb.Allow() {
+		t.Fatalf("first call should be allowed")
+	}
+	if tb.Allow() {
+		t.Fatalf("second call should be rate limited")
+	}
+	time.Sleep(time.Second)
+	if !tb.Allow() {
+		t.Fatalf("token bucket should refill after interval")
+	}
+}
+
+// TestBulkheadLimiter ensures the bulkhead limits concurrent operations.
+func TestBulkheadLimiter(t *testing.T) {
+	b := NewBulkheadLimiter(2)
+	if !b.Allow() || !b.Allow() {
+		t.Fatalf("initial acquisitions should succeed")
+	}
+	if b.Allow() {
+		t.Fatalf("third acquisition should be blocked")
+	}
+	b.Done()
+	if !b.Allow() {
+		t.Fatalf("slot should be available after Done")
+	}
+}
+
+// TestRunWithHedging validates that hedged calls are issued when the first
+// attempt is slow and succeed when a subsequent attempt completes successfully.
+func TestRunWithHedging(t *testing.T) {
+	opts := ResilienceOptions{
+		Hedge: HedgingPolicy{MaxHedges: 2, HedgeDelay: 10 * time.Millisecond},
+		Retry: RetryOptions{MaxAttempts: 1},
+	}
+	var calls int32
+	fn := func(ctx context.Context) error {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			time.Sleep(100 * time.Millisecond)
+			return errors.New("slow")
+		}
+		return nil
+	}
+	if err := runWithHedging(context.Background(), fn, opts); err != nil {
+		t.Fatalf("expected success from hedged call, got %v", err)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected hedged attempt to execute")
+	}
+}


### PR DESCRIPTION
## Summary
- add token bucket rate limiter, request hedging, and bulkhead limiter to gRPC client
- exercise new resilience utilities with unit tests
- note progress for gRPC service consolidation task and changelog

## Testing
- `go test ./pkg/grpc/client -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689a0b91131483219a2d9e9722a275b7