### PR TITLE
feat: add auth and cache examples

### DIFF
--- a/.github/doc-updates/595611e4-395f-4223-8a83-8beb1e12d78e.json
+++ b/.github/doc-updates/595611e4-395f-4223-8a83-8beb1e12d78e.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add JWT auth and basic cache examples",
+  "guid": "595611e4-395f-4223-8a83-8beb1e12d78e",
+  "created_at": "2025-08-11T15:32:56Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/96e9daa6-352e-4052-a708-92012702efe3.json
+++ b/.github/doc-updates/96e9daa6-352e-4052-a708-92012702efe3.json
@@ -1,0 +1,16 @@
+{
+  "file": "examples/modules/auth/jwt-auth/README.md",
+  "mode": "replace",
+  "content": "<!-- file: examples/modules/auth/jwt-auth/README.md -->\n<!-- version: 1.1.0 -->\n<!-- guid: c33cf049-7ab0-4b5d-a191-05e7829d0866 -->\n\n# JWT Auth Example\n\nDemonstrates generating and validating JSON Web Tokens with gcommon's auth module.\n\n## Run\n\n```bash\ngo run .\n```\n\nExpected output:\n\n```\ntoken: <JWT>\nclaims: map[...]\n```\n\n## Next Steps\n\n- Explore the [RBAC example](../rbac)\n- Read the [auth package documentation](../../../pkg/auth)",
+  "guid": "96e9daa6-352e-4052-a708-92012702efe3",
+  "created_at": "2025-08-11T15:32:47Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f48fab2b-2899-4b4b-99b5-7cef20ea9d9e.json
+++ b/.github/doc-updates/f48fab2b-2899-4b4b-99b5-7cef20ea9d9e.json
@@ -1,0 +1,16 @@
+{
+  "file": "examples/modules/cache/basic-cache/README.md",
+  "mode": "replace",
+  "content": "<!-- file: examples/modules/cache/basic-cache/README.md -->\n<!-- version: 1.1.0 -->\n<!-- guid: c64487d9-7a76-47f4-8f49-a022a1b21f4a -->\n\n# Basic Cache Example\n\nShows storing and retrieving values using the in-memory cache provider.\n\n## Run\n\n```bash\ngo run .\n```\n\nExpected output:\n\n```\nfoo=bar\n```\n\n## Next Steps\n\n- Try the [Redis cache example](../redis-cache)\n- Read the [cache package documentation](../../../pkg/cache)",
+  "guid": "f48fab2b-2899-4b4b-99b5-7cef20ea9d9e",
+  "created_at": "2025-08-11T15:32:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/e084deb8-0131-4662-8af2-f7cdeff38022.json
+++ b/.github/issue-updates/e084deb8-0131-4662-8af2-f7cdeff38022.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "title": "Add auth and cache examples",
+  "body": "Implement working JWT auth and basic cache examples",
+  "labels": ["documentation", "examples"],
+  "guid": "e084deb8-0131-4662-8af2-f7cdeff38022",
+  "legacy_guid": "create-add-auth-and-cache-examples-2025-08-11",
+  "created_at": "2025-08-11T15:31:24.000Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null
+}

--- a/examples/modules/auth/jwt-auth/main.go
+++ b/examples/modules/auth/jwt-auth/main.go
@@ -7,27 +7,39 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jdfalk/gcommon/pkg/auth/tokens"
 )
 
-// TODO: Complete jwt-auth example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for jwt-auth
-	return nil
+// setup returns a shared secret used for signing tokens.
+func setup(ctx context.Context) ([]byte, error) {
+	return []byte("secret"), nil
 }
 
-func run(ctx context.Context) error {
-	// TODO: run jwt-auth logic
-	fmt.Println("TODO: run jwt-auth")
+// run generates and validates a JWT using the provided secret.
+func run(ctx context.Context, secret []byte) error {
+	tok, err := tokens.Generate(secret, jwt.SigningMethodHS256, "demo-user", time.Minute, map[string]any{"role": "user"})
+	if err != nil {
+		return err
+	}
+	claims, err := tokens.Parse(secret, tok)
+	if err != nil {
+		return err
+	}
+	fmt.Println("token:", tok)
+	fmt.Println("claims:", claims)
 	return nil
 }
 
 func main() {
 	ctx := context.Background()
-	if err := setup(ctx); err != nil {
+	secret, err := setup(ctx)
+	if err != nil {
 		panic(err)
 	}
-	if err := run(ctx); err != nil {
+	if err := run(ctx, secret); err != nil {
 		panic(err)
 	}
 }

--- a/examples/modules/cache/basic-cache/main.go
+++ b/examples/modules/cache/basic-cache/main.go
@@ -7,27 +7,42 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/jdfalk/gcommon/pkg/cache/policies"
+	"github.com/jdfalk/gcommon/pkg/cache/providers"
 )
 
-// TODO: Complete basic-cache example
-
-func setup(ctx context.Context) error {
-	// TODO: implement setup for basic-cache
-	return nil
+// cacheApp wraps the cache provider used in this example.
+type cacheApp struct {
+	cache *providers.MemoryCache
 }
 
-func run(ctx context.Context) error {
-	// TODO: run basic-cache logic
-	fmt.Println("TODO: run basic-cache")
+// setup initializes an in-memory cache with LRU eviction.
+func setup(ctx context.Context) (*cacheApp, error) {
+	return &cacheApp{cache: providers.NewMemoryCache(10, policies.NewLRU())}, nil
+}
+
+// run stores and retrieves a value to demonstrate basic cache operations.
+func run(ctx context.Context, app *cacheApp) error {
+	if err := app.cache.Set(ctx, "foo", "bar", time.Minute); err != nil {
+		return err
+	}
+	val, err := app.cache.Get(ctx, "foo")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("foo=%v\n", val)
 	return nil
 }
 
 func main() {
 	ctx := context.Background()
-	if err := setup(ctx); err != nil {
+	app, err := setup(ctx)
+	if err != nil {
 		panic(err)
 	}
-	if err := run(ctx); err != nil {
+	if err := run(ctx, app); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary
- add runnable JWT auth example
- add basic in-memory cache example
- record doc updates and changelog entry

## Issues Addressed
- N/A

## Testing
- `go run examples/modules/auth/jwt-auth/main.go`
- `go run examples/modules/cache/basic-cache/main.go`
- `go test ./pkg/auth/... ./pkg/cache/...`


------
https://chatgpt.com/codex/tasks/task_e_689a0bd54fec8321981465998ac2adfe