### PR TITLE
ci: add submodules: recursive to all checkout steps

### DIFF
--- a/.github/workflows/auto-assign-projects.yml
+++ b/.github/workflows/auto-assign-projects.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        submodules: recursive
     - name: Auto-assign to Protobuf Project
       if: contains(github.event.issue.labels.*.name, 'type:protobuf') || contains(github.event.issue.labels.*.name,
         'epic:protobuf')

--- a/.github/workflows/commit-override-handler.yml
+++ b/.github/workflows/commit-override-handler.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 10
 
       - name: Check commit messages for override keywords

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Analyze issue content
         id: analyze
@@ -125,6 +127,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Triage issues
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Detect project type
         id: detect
@@ -115,6 +117,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Handle stale issues and PRs
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
@@ -181,6 +185,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
         if: matrix.condition == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -429,6 +435,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for security advisories

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -194,6 +195,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Apply file-based labels
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -211,6 +214,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
 
       - name: Set up Python
@@ -353,6 +357,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
 
       - name: Analyze PR size and complexity
@@ -406,6 +411,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
 
       - name: Check for breaking changes
@@ -544,6 +550,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Check for merge conflicts
         id: conflict-check

--- a/.github/workflows/proto-docs.yml
+++ b/.github/workflows/proto-docs.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/protobuf-generation.yml
+++ b/.github/workflows/protobuf-generation.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
 
       - name: Check file changes
@@ -128,6 +129,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
@@ -315,6 +317,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Download protobuf artifacts
         if: inputs.protobuf-artifacts == 'true'
@@ -131,6 +133,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/release-frontend.yml
+++ b/.github/workflows/release-frontend.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Download protobuf artifacts
         if: inputs.protobuf-artifacts == 'true'

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Download protobuf artifacts
         if: inputs.protobuf-artifacts == 'true'

--- a/.github/workflows/release-protobuf.yml
+++ b/.github/workflows/release-protobuf.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Quick change detection
         id: changes

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Download protobuf artifacts
         if: inputs.protobuf-artifacts == 'true'

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Download protobuf artifacts
         if: inputs.protobuf-artifacts == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Detect project languages and generate matrices
         id: detect
@@ -192,6 +194,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Detect project languages
         id: detect
@@ -117,6 +119,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -159,6 +163,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Go vulnerability check
         if: needs.detect-languages.outputs.has_go == 'true'
@@ -199,6 +205,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Build Docker image for scanning
         run: |
@@ -227,6 +235,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
 
       - name: Run Gitleaks
@@ -252,6 +261,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Go license check
         if: needs.detect-languages.outputs.has_go == 'true'
@@ -293,6 +304,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
 
       - name: Check for security policy
         run: |

--- a/.github/workflows/sync-receiver.yml
+++ b/.github/workflows/sync-receiver.yml
@@ -51,12 +51,14 @@ jobs:
       - name: Checkout current repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout ghcommon
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           repository: jdfalk/ghcommon
           path: ghcommon-source
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unified-automation.yml
+++ b/.github/workflows/unified-automation.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Ensures the `.standards/` submodule (falkcorp/.github) is populated in every CI run so agents and linters have org-wide coding standards available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)