### PR TITLE
feat(queuepb): typed workflow step DAG

### DIFF
--- a/queuepb/v2/start_workflow_request.proto
+++ b/queuepb/v2/start_workflow_request.proto
@@ -1,5 +1,5 @@
 // file: queuepb/v2/start_workflow_request.proto
-// version: 1.0.2
+// version: 1.1.0
 // guid: 2f3e4d5c-6b7a-8190-2e3f-4a5b6c7d8e9f
 
 edition = "2023";
@@ -8,20 +8,30 @@ package queue.v2;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/go_features.proto";
+import "queuepb/v2/workflow.proto";
 
 option features.(pb.go).api_level = API_OPAQUE;
 option go_package = "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2";
 
 /**
  * StartWorkflowRequest defines the request for starting a workflow.
+ *
+ * Provide the workflow to run as a typed `definition` (preferred). Alternatively
+ * reference a previously registered workflow by `workflow_id`.
  */
 message StartWorkflowRequest {
-  // Workflow identifier
-  string workflow_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Identifier of a registered workflow to start. Optional when `definition` is
+  // supplied inline.
+  string workflow_id = 1;
 
-  // Workflow definition or template
-  string workflow_definition = 2 [(buf.validate.field).string.min_len = 1];
+  // DEPRECATED: use `definition` for a typed workflow. Previously an opaque
+  // template/definition string with no schema.
+  string workflow_definition = 2 [deprecated = true];
 
-  // Input parameters for the workflow
+  // Input parameters passed to the workflow execution.
   map<string, string> parameters = 3;
+
+  // Typed workflow definition to run, including its step DAG. Preferred over the
+  // deprecated `workflow_definition` string.
+  QueueWorkflow definition = 4;
 }

--- a/queuepb/v2/workflow.proto
+++ b/queuepb/v2/workflow.proto
@@ -1,5 +1,5 @@
 // file: queuepb/v2/workflow.proto
-// version: 1.0.2
+// version: 1.1.0
 // guid: 6f7e8d9c-0b1a-2534-6e7f-8a9b0c1d2e3f
 
 edition = "2023";
@@ -8,6 +8,7 @@ package queue.v2;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/go_features.proto";
+import "queuepb/v2/workflow_step.proto";
 
 option features.(pb.go).api_level = API_OPAQUE;
 option go_package = "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2";
@@ -34,4 +35,9 @@ message QueueWorkflow {
 
   // Whether the workflow is active
   bool enabled = 5;
+
+  // The workflow's execution graph. Each step declares its dependencies via
+  // WorkflowStep.depends_on, forming a DAG. Empty means the workflow has no
+  // steps defined yet.
+  repeated WorkflowStep steps = 6;
 }

--- a/queuepb/v2/workflow_step.proto
+++ b/queuepb/v2/workflow_step.proto
@@ -1,0 +1,40 @@
+// file: queuepb/v2/workflow_step.proto
+// version: 1.0.0
+// guid: f8b9d644-2aa5-43d4-a355-93b47dde33d6
+
+edition = "2023";
+
+package queue.v2;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/go_features.proto";
+
+option features.(pb.go).api_level = API_OPAQUE;
+option go_package = "github.com/falkcorp/gcommon/v2/pkg/queuepb/v2";
+
+/**
+ * WorkflowStep is a single node in a workflow's execution DAG.
+ *
+ * Steps form a directed acyclic graph via `depends_on`: a step becomes eligible
+ * to run once every step it depends on has completed. Steps with no dependencies
+ * are the entry points. The concrete work a step performs is carried in `config`
+ * as a task-specific message, so the workflow definition stays generic.
+ */
+message WorkflowStep {
+  // Unique identifier for this step within its workflow.
+  string step_id = 1 [(buf.validate.field).string.min_len = 1];
+
+  // Human-readable step name.
+  string name = 2 [(buf.validate.field).string.max_len = 100];
+
+  // step_ids of the steps that must complete before this step runs.
+  // Empty means this step is an entry point. Must reference steps in the same
+  // workflow; a cycle makes the workflow invalid.
+  repeated string depends_on = 3;
+
+  // Task-specific payload describing the work this step performs (e.g. a publish,
+  // an HTTP call, a sub-workflow). Left as Any so the workflow model does not need
+  // to know every task type.
+  google.protobuf.Any config = 4;
+}


### PR DESCRIPTION
Fills the documented **queuepb workflow** gap from the consumer proto audit: the workflow definition was an opaque `string workflow_definition` and `QueueWorkflow` carried only metadata (no steps).

## Changes
- **New `WorkflowStep`** — `step_id`, `name`, `depends_on` (DAG edges: a step runs once its dependencies complete), and a task-specific `google.protobuf.Any config` so the workflow model doesn't need to know every task type.
- **`QueueWorkflow`** gains `repeated WorkflowStep steps` — the execution DAG.
- **`StartWorkflowRequest`** gains a typed `QueueWorkflow definition`; the opaque `workflow_definition` string is **deprecated** (kept for wire-compat). `workflow_id` is now optional — reference a registered workflow *or* pass a definition inline.

## Scope discipline
Deliberately minimal — no workflow engine (no retries/conditionals/timeouts), just enough to carry a typed graph, matching what `StartWorkflow` actually needs. The change is **additive**, so it's non-breaking (`buf breaking` passes).

## Verification
- `buf lint` ✅ · `buf format --exit-code` ✅ · `buf breaking --against main` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)