### PR TITLE
fix(queuepb): remove unused validate import (unbreaks CI)

### DIFF
--- a/queuepb/v2/start_workflow_request.proto
+++ b/queuepb/v2/start_workflow_request.proto
@@ -1,12 +1,11 @@
 // file: queuepb/v2/start_workflow_request.proto
-// version: 1.1.0
+// version: 1.1.1
 // guid: 2f3e4d5c-6b7a-8190-2e3f-4a5b6c7d8e9f
 
 edition = "2023";
 
 package queue.v2;
 
-import "buf/validate/validate.proto";
 import "google/protobuf/go_features.proto";
 import "queuepb/v2/workflow.proto";
 


### PR DESCRIPTION
Follow-up to #1138. That PR was merged with only its first commit; the fix commit that removed a now-unused import never landed, so `main`'s `queuepb/v2/start_workflow_request.proto` imports `buf/validate/validate.proto` but no longer uses it (the typed-workflow change removed all validate constraints from that file).

CI's buf (1.50 via buf-setup-action) flags this via IMPORT_USED and fails the lint step; local buf 1.71 doesn't report it, which is why it slipped through. Removing the dead import.

`buf lint` / `format` / `breaking` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)