### PR TITLE
chore(standards): bump .standards to current and let dependabot keep it there

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
-# Dependabot Configuration
-# version: 1.0.0
+# file: .github/dependabot.yml
+# version: 1.1.0
 # guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+# last-edited: 2026-08-30
+#
+# Dependabot Configuration
 
 version: 2
 
@@ -27,6 +30,19 @@ updates:
     labels:
       - github-actions
       - ci-cd
+
+  # Git submodules — .standards is the org-wide coding standards submodule
+  # (falkcorp/.github). It is a pinned commit, not a live link: without this
+  # entry the pin only moves when someone remembers to bump it by hand, and
+  # nobody did between 2026-06-12 and 2026-08-30. CLAUDE.md points contributors
+  # and agents at .standards/instructions/ as authoritative, so a stale pin
+  # silently serves outdated rules instead of failing loudly.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    patterns: ["*"]
+    multi-ecosystem-group: dependencies
+    labels:
+      - documentation
 
   # Pip
   - package-ecosystem: pip


### PR DESCRIPTION
`CLAUDE.md` names `.standards/instructions/` authoritative and links two files by name — `file-headers.md` and `commit-messages.md`. **A submodule is a pinned commit, not a live link**, and this one had not moved since `664ae68` on **2026-06-12** — the commit that *created* `falkcorp/.github`. Everything merged upstream in the two and a half months since has been read by no consumer here, because the pin is what the repo actually checks out.

## What was not reaching anyone

Both files this repo's CLAUDE.md points at were fixed upstream, and neither fix arrived:

- **`instructions/file-headers.md`** — the file that declares the four-line header *mandatory* **had no header itself** at the pinned commit. Fixed in `falkcorp/.github#3`.
- **`instructions/commit-messages.md`** — the file that tells every repo in the org how to write a commit contained a fenced code block with no language. That repo publishes standards to ~45 others and had **no CI at all**; its first Super Linter run (`falkcorp/.github#2`) found five violations in the instruction documents themselves.
- **`templates/executive-summary.md`** — the org-wide template (`falkcorp/.github#1`), 185 lines, did not exist at this pin.

The Go standards moved furthest: `instructions/go.md` went from **55 unversioned lines** to **v1.3.0 at 384** — the Go version policy and the 1.26 minimum, the `io/ioutil` ban and the deprecated-stdlib table, the `wg.Go(fn)` rule over `Add(1)`/`defer Done()`, the testing-isolation table (`t.Setenv` / `t.Chdir` / `t.TempDir` / `synctest`), and `omitempty` vs `omitzero` under `encoding/json/v2`. This repository has **no Go files today** — it is protobuf definitions and Python tooling — so that is not the headline here, but the submodule is org-wide and the checkout is shared.

## Why it went stale, and why bumping alone is not the fix

There is **no sync automation anywhere in the org**. The pin has only ever moved when someone remembered, and for two and a half months nobody did. So this does both:

- `.standards` `664ae68` → `7bdfd13` (nine commits)
- `.github/dependabot.yml` gains a `gitsubmodule` ecosystem on the existing weekly `multi-ecosystem-group`, alongside `github-actions` and `pip`, so falling behind opens a PR instead of going quietly unnoticed

Fixing only the pin would leave the same drift to reappear in a month.

## Verification — the bump is build-safe

Grepped every workflow, Makefile and script in the repo for `.standards` before making the change. **Nothing in CI reads it.** The only references anywhere are `.gitmodules` and three lines of prose in `CLAUDE.md`. `ci.yml` is `buf lint` / `format` / breaking-change over the protos; there is no markdown lint and no file-header check, so no gate can see the submodule's contents at all. It is documentation consumed by humans and agents, and a nine-commit jump adds rules without touching a single check.

- `.github/dependabot.yml` validated through a YAML parse; ecosystems enumerate as `['github-actions', 'gitsubmodule', 'pip']`. Note this checks YAML syntax, not Dependabot's schema — whether it accepts `gitsubmodule` inside a `multi-ecosystem-group` only shows in this repo's Dependabot logs after merge.
- Header bumped `1.0.0` → `1.1.0`, and given the `# file:` and `# last-edited:` lines it was missing — which is the very rule `file-headers.md` states, and which this PR is what makes readable. The `guid` is left alone: it is an obviously-shared org-template placeholder (byte-identical across repos), and regenerating it is a different problem.
- The `documentation` label used by the new entry exists in this repo. Noted but **not fixed**: `multi-ecosystem-groups.dependencies` already lists a `dependabot` label that does not exist here; Dependabot silently drops labels it cannot apply. That predates this PR.

## Not done here

~44 other repositories carry this submodule and none is pinned at current. `falkcorp/audiobook-organizer#2996` and `falkcorp/transcodarr#92` make the same two-part fix in those repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYLcqMcDNGR5Y93QptSg2g